### PR TITLE
feat: Add Android Lint rules module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # Local documentation (not for public repo)
 /docs-local/
 /detekt-rules/build/
+/lint-rules/build/

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -1,0 +1,87 @@
+plugins {
+    kotlin("jvm") version "2.3.0"
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+    // Android Lint API - compileOnly to avoid runtime conflicts
+    compileOnly("com.android.tools.lint:lint-api:31.4.0")
+    compileOnly("com.android.tools.lint:lint-checks:31.4.0")
+    
+    // Testing
+    testImplementation("com.android.tools.lint:lint:31.4.0")
+    testImplementation("com.android.tools.lint:lint-tests:31.4.0")
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.assertj:assertj-core:3.25.3")
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+// Create JAR with Lint rules
+val lintJar = tasks.register<Jar>("lintJar") {
+    archiveBaseName.set("structured-coroutines-lint-rules")
+    archiveClassifier.set("")
+    
+    // Include compiled classes and resources
+    from(sourceSets.main.get().output)
+    
+    manifest {
+        attributes("Lint-Registry-v2" to "io.github.santimattius.structured.lint.StructuredCoroutinesIssueRegistry")
+    }
+    
+    // Ensure this task runs after compilation
+    dependsOn(tasks.named("classes"))
+    
+    // Make sure resources are included
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
+// Make lintJar the default artifact
+tasks.named("jar") {
+    enabled = false
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "io.github.santimattius"
+            artifactId = "structured-coroutines-lint-rules"
+            version = project.version.toString()
+            
+            // Use the lintJar task instead of default jar
+            artifact(lintJar)
+            
+            pom {
+                name.set("Structured Coroutines Lint Rules")
+                description.set("Android Lint rules for enforcing structured concurrency best practices in Kotlin Coroutines")
+                url.set("https://github.com/santimattius/structured-coroutines")
+                
+                licenses {
+                    license {
+                        name.set("Apache License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+                
+                developers {
+                    developer {
+                        id.set("santimattius")
+                        name.set("Santiago Mattiauda")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/StructuredCoroutinesIssueRegistry.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/StructuredCoroutinesIssueRegistry.kt
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.CURRENT_API
+import io.github.santimattius.structured.lint.detectors.*
+
+/**
+ * Registry for all Structured Coroutines Lint issues.
+ * 
+ * This registry is automatically discovered by Android Lint through the
+ * META-INF/services/com.android.tools.lint.client.api.IssueRegistry file.
+ */
+class StructuredCoroutinesIssueRegistry : IssueRegistry() {
+    
+    override val issues: List<com.android.tools.lint.detector.api.Issue>
+        get() = listOf(
+            // Fase 3.1: Reglas Básicas
+            GlobalScopeUsageDetector.ISSUE,
+            InlineCoroutineScopeDetector.ISSUE,
+            RunBlockingInSuspendDetector.ISSUE,
+            DispatchersUnconfinedDetector.ISSUE,
+            CancellationExceptionSubclassDetector.ISSUE,
+            
+            // Fase 3.2: Reglas Android-Específicas
+            MainDispatcherMisuseDetector.ISSUE,
+            ViewModelScopeLeakDetector.ISSUE,
+            LifecycleAwareScopeDetector.ISSUE,
+            
+            // Fase 3.3: Reglas Avanzadas
+            JobInBuilderContextDetector.ISSUE,
+            SuspendInFinallyDetector.ISSUE,
+            CancellationExceptionSwallowedDetector.ISSUE,
+            AsyncWithoutAwaitDetector.ISSUE,
+            
+            // Fase 3.4: Reglas Adicionales
+            UnstructuredLaunchDetector.ISSUE,
+            RedundantLaunchInCoroutineScopeDetector.ISSUE,
+            RunBlockingWithDelayInTestDetector.ISSUE,
+            LoopWithoutYieldDetector.ISSUE,
+            ScopeReuseAfterCancelDetector.ISSUE,
+        )
+    
+    override val api: Int = CURRENT_API
+    
+    override val minApi: Int = 1 // Works with all API levels
+    
+    override val vendor: com.android.tools.lint.client.api.Vendor
+        get() = com.android.tools.lint.client.api.Vendor(
+            vendorName = "Santiago Mattiauda",
+            identifier = "io.github.santimattius"
+        )
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/AsyncWithoutAwaitDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/AsyncWithoutAwaitDetector.kt
@@ -1,0 +1,199 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Detects async calls whose Deferred result is never awaited.
+ * 
+ * Best Practice 1.2: Using async as if it were launch (and never calling await)
+ * 
+ * Using async just "to launch things" and not consuming the Deferred is confusing 
+ * for code readers and can hide exceptions that remain hanging inside the Deferred.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - async without await
+ * val deferred = scope.async { computeValue() }
+ * // deferred never used - exception may be hidden
+ * 
+ * // ✅ GOOD - async with await
+ * val deferred = scope.async { computeValue() }
+ * val result = deferred.await()
+ * 
+ * // ✅ GOOD - async with awaitAll
+ * val deferred1 = scope.async { computeValue1() }
+ * val deferred2 = scope.async { computeValue2() }
+ * val results = awaitAll(deferred1, deferred2)
+ * 
+ * // ✅ GOOD - Use launch if no result needed
+ * scope.launch { doWork() }  // No result needed
+ * ```
+ */
+class AsyncWithoutAwaitDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "AsyncWithoutAwait",
+            briefDescription = "async without await",
+            explanation = """
+                Using async without calling await() is confusing and can hide exceptions 
+                that remain hanging inside the Deferred. If you don't need a result, 
+                use launch instead.
+                
+                Always call .await() or awaitAll() on Deferred values, or use launch 
+                if you don't need a result.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 8,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                AsyncWithoutAwaitDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+        
+        private val ASYNC_NAME = "async"
+        private val AWAIT_NAME = "await"
+        private val AWAIT_ALL_NAME = "awaitAll"
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf(ASYNC_NAME)
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        if (node.methodName != ASYNC_NAME) return
+        
+        // Find the containing function/block
+        val containingBlock = findContainingBlock(node) ?: return
+        
+        // Check if this async is part of a variable assignment
+        val variableName = findVariableNameFromAsyncCall(node, containingBlock) ?: return
+        
+        // Check if await() is called on this variable in the same block
+        if (!hasAwaitCall(containingBlock, variableName)) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "async result is never awaited. Call .await() or awaitAll() on the Deferred, or use launch if no result is needed"
+            )
+        }
+    }
+    
+    /**
+     * Finds the containing block (function body) for the async call.
+     */
+    private fun findContainingBlock(call: UCallExpression): UExpression? {
+        var current: UElement? = call
+        while (current != null) {
+            // UMethod represents both Java methods and Kotlin functions
+            if (current is UMethod) {
+                return current.uastBody
+            }
+            if (current is UBlockExpression) {
+                return current
+            }
+            current = current.uastParent
+        }
+        return null
+    }
+    
+    /**
+     * Finds the variable name from an async call assignment.
+     */
+    private fun findVariableNameFromAsyncCall(
+        asyncCall: UCallExpression,
+        block: UExpression
+    ): String? {
+        // Check if the async call is directly assigned to a variable
+        var current: UElement? = asyncCall
+        while (current != null) {
+            // Check for variable declaration: val x = async { }
+            if (current is UVariable) {
+                val initializer = current.uastInitializer
+                if (initializer == asyncCall || 
+                    (initializer is UCallExpression && 
+                     initializer.sourcePsi == asyncCall.sourcePsi)) {
+                    return current.name
+                }
+            }
+            
+            // Check for binary assignment: x = async { }
+            if (current is UBinaryExpression) {
+                val operatorText = current.operator.text
+                if (operatorText == "=") {
+                    val right = current.rightOperand
+                    if (right == asyncCall || right.sourcePsi == asyncCall.sourcePsi) {
+                        val left = current.leftOperand
+                        if (left is UReferenceExpression) {
+                            return left.asSourceString()
+                        }
+                    }
+                }
+            }
+            
+            current = current.uastParent
+        }
+        
+        return null
+    }
+    
+    /**
+     * Checks if await() or awaitAll() is called on the given variable in the block.
+     */
+    private fun hasAwaitCall(block: UExpression, variableName: String): Boolean {
+        var foundAwait = false
+        
+        block.accept(object : AbstractUastVisitor() {
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+                val methodName = node.methodName
+                
+                // Check for .await() call
+                if (methodName == AWAIT_NAME || methodName == AWAIT_ALL_NAME) {
+                    val receiver = node.receiver
+                    if (receiver is UQualifiedReferenceExpression) {
+                        val receiverName = receiver.receiver.asSourceString()
+                        if (receiverName == variableName) {
+                            foundAwait = true
+                            return false // Stop traversal
+                        }
+                    }
+                }
+                
+                // Check for awaitAll(deferred1, deferred2, ...)
+                if (methodName == AWAIT_ALL_NAME) {
+                    val arguments = node.valueArguments
+                    for (arg in arguments) {
+                        val argSource = arg.asSourceString()
+                        if (argSource == variableName || argSource.contains(variableName)) {
+                            foundAwait = true
+                            return false // Stop traversal
+                        }
+                    }
+                }
+                
+                return super.visitCallExpression(node)
+            }
+        })
+        
+        return foundAwait
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSubclassDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSubclassDetector.kt
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.*
+
+/**
+ * Detects classes that extend CancellationException.
+ * 
+ * Best Practice 5.2: Extending CancellationException for Domain Errors
+ * 
+ * Defining domain errors that inherit from CancellationException to "leverage" 
+ * cancellation doesn't propagate upward like other exceptions; it only cancels 
+ * the current coroutine and its children, which can break error logic.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Domain error extendiendo CancellationException
+ * class UserNotFoundException : CancellationException("User not found")
+ * 
+ * suspend fun fetchUser(id: String) {
+ *     if (user == null) {
+ *         throw UserNotFoundException()  // Treated as cancellation!
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Regular exception para domain errors
+ * class UserNotFoundException : Exception("User not found")
+ * 
+ * suspend fun fetchUser(id: String) {
+ *     if (user == null) {
+ *         throw UserNotFoundException()  // Proper exception handling
+ *     }
+ * }
+ * ```
+ */
+class CancellationExceptionSubclassDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "CancellationExceptionSubclass",
+            briefDescription = "Class extends CancellationException",
+            explanation = """
+                Defining domain errors that inherit from CancellationException doesn't 
+                propagate upward like other exceptions; it only cancels the current 
+                coroutine and its children, which can break error logic.
+                
+                For domain errors, use normal Exception or RuntimeException.
+                Reserve CancellationException for true cancellation cases.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 9,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                CancellationExceptionSubclassDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun visitClass(
+        context: JavaContext,
+        declaration: UClass
+    ) {
+        if (CoroutineLintUtils.extendsCancellationException(context, declaration)) {
+            context.report(
+                ISSUE,
+                declaration,
+                context.getLocation(declaration as UElement),
+                "Don't extend CancellationException for domain errors. Use Exception or RuntimeException instead"
+            )
+        }
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSwallowedDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSwallowedDetector.kt
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Detects catch(Exception) blocks in suspend functions that may swallow CancellationException.
+ * 
+ * Best Practice 4.2: Consuming CancellationException as if it Were a Normal Error
+ * 
+ * Doing catch (e: Exception) and treating CancellationException the same as any 
+ * other error can prevent cancellation from propagating correctly and leave 
+ * coroutines alive when they should terminate.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Swallows CancellationException
+ * suspend fun bad() {
+ *     try {
+ *         work()
+ *     } catch (e: Exception) {
+ *         log(e)  // CancellationException is caught and not re-thrown!
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Explicit CancellationException handling
+ * suspend fun good() {
+ *     try {
+ *         work()
+ *     } catch (e: CancellationException) {
+ *         throw e  // Always re-throw!
+ *     } catch (e: Exception) {
+ *         log(e)
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Using ensureActive() in catch block
+ * suspend fun alsoGood() {
+ *     try {
+ *         work()
+ *     } catch (e: Exception) {
+ *         ensureActive()  // Re-throws if cancelled
+ *         log(e)
+ *     }
+ * }
+ * ```
+ */
+class CancellationExceptionSwallowedDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "CancellationExceptionSwallowed",
+            briefDescription = "catch(Exception) may swallow CancellationException",
+            explanation = """
+                Catching Exception or Throwable in suspend functions can prevent 
+                CancellationException from propagating correctly, leaving coroutines 
+                alive when they should terminate.
+                
+                Always handle CancellationException separately by either:
+                1. Adding a catch (e: CancellationException) { throw e } clause before 
+                   the general Exception catch
+                2. Calling ensureActive() in the catch block to re-throw if cancelled
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 7,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                CancellationExceptionSwallowedDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+        
+        private val BROAD_EXCEPTION_TYPES = setOf(
+            "Exception",
+            "Throwable",
+            "java.lang.Exception",
+            "java.lang.Throwable"
+        )
+        
+        private val CANCELLATION_EXCEPTION_TYPES = setOf(
+            "CancellationException",
+            "kotlinx.coroutines.CancellationException",
+            "java.util.concurrent.CancellationException"
+        )
+    }
+    
+    override fun visitClass(context: JavaContext, declaration: UClass) {
+        declaration.accept(object : AbstractUastVisitor() {
+            override fun visitTryExpression(node: UTryExpression): Boolean {
+                // Only check inside suspend functions
+                if (!CoroutineLintUtils.isInSuspendFunction(context, node)) {
+                    return super.visitTryExpression(node)
+                }
+                
+                val catchClauses = node.catchClauses
+                if (catchClauses.isEmpty()) return super.visitTryExpression(node)
+                
+                // Check if there's a catch(CancellationException) - if present, the code is safe
+                val hasCancellationExceptionCatch = catchClauses.any { clause ->
+                    val parameters = clause.parameters
+                    if (parameters.isEmpty()) return@any false
+                    val parameter = parameters.first()
+                    val typeName = parameter.type.canonicalText
+                    CANCELLATION_EXCEPTION_TYPES.any { typeName.contains(it) }
+                }
+                
+                if (hasCancellationExceptionCatch) return super.visitTryExpression(node)
+                
+                // Look for catch(Exception) or catch(Throwable)
+                for (catchClause in catchClauses) {
+                    val parameters = catchClause.parameters
+                    if (parameters.isEmpty()) continue
+                    val parameter = parameters.first()
+                    val typeName = parameter.type.canonicalText
+                    
+                    if (BROAD_EXCEPTION_TYPES.any { typeName.contains(it) }) {
+                        // Check if the catch block properly handles cancellation
+                        val catchBody = catchClause.body
+                        if (!handlesCancellationProperly(catchBody)) {
+                            context.report(
+                                ISSUE,
+                                node,
+                                context.getLocation(node as UElement),
+                                "catch(Exception) may swallow CancellationException. Add catch (e: CancellationException) { throw e } or call ensureActive() in the catch block"
+                            )
+                            return super.visitTryExpression(node)
+                        }
+                    }
+                }
+                
+                return super.visitTryExpression(node)
+            }
+        })
+    }
+    
+    /**
+     * Checks if a catch block properly handles cancellation by:
+     * - Re-throwing the exception
+     * - Calling ensureActive()
+     */
+    private fun handlesCancellationProperly(body: UExpression): Boolean {
+        var hasThrow = false
+        var hasEnsureActive = false
+        
+        body.accept(object : AbstractUastVisitor() {
+            override fun visitThrowExpression(node: UThrowExpression): Boolean {
+                hasThrow = true
+                return super.visitThrowExpression(node)
+            }
+            
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+                val methodName = node.methodName
+                if (methodName == "ensureActive" || methodName == "currentCoroutineContext") {
+                    hasEnsureActive = true
+                }
+                return super.visitCallExpression(node)
+            }
+        })
+        
+        return hasThrow || hasEnsureActive
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/DispatchersUnconfinedDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/DispatchersUnconfinedDetector.kt
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.UCallExpression
+
+/**
+ * Detects usage of Dispatchers.Unconfined in coroutine builders.
+ * 
+ * Best Practice 3.2: Abusing Dispatchers.Unconfined
+ * 
+ * Dispatchers.Unconfined runs code on whatever thread happens to resume it,
+ * which makes it difficult to reason about execution and can end up running
+ * on the UI thread with blocking calls.
+ * 
+ * Example:
+ * ```kotlin
+ * // ⚠️ WARNING - Dispatchers.Unconfined
+ * scope.launch(Dispatchers.Unconfined) {
+ *     doWork()  // Thread impredecible
+ * }
+ * 
+ * // ✅ GOOD - Dispatchers apropiados
+ * scope.launch(Dispatchers.Default) {  // CPU-bound
+ *     heavyComputation()
+ * }
+ * 
+ * scope.launch(Dispatchers.IO) {  // IO-bound
+ *     networkCall()
+ * }
+ * 
+ * scope.launch(Dispatchers.Main) {  // UI updates
+ *     updateUI()
+ * }
+ * ```
+ */
+class DispatchersUnconfinedDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "DispatchersUnconfined",
+            briefDescription = "Dispatchers.Unconfined usage",
+            explanation = """
+                Dispatchers.Unconfined runs code on whatever thread happens to resume it, 
+                which makes it difficult to reason about execution and can end up running 
+                on the UI thread with blocking calls.
+                
+                In production, always choose a dispatcher appropriate for the type of 
+                workload: Default (CPU-bound), Main (UI), IO (blocking I/O), etc.
+                
+                Reserve Dispatchers.Unconfined for very special cases or legacy testing.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 6,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                DispatchersUnconfinedDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("launch", "async", "withContext")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        if (CoroutineLintUtils.usesUnconfinedDispatcher(node)) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "Use an appropriate dispatcher (Dispatchers.Default, Dispatchers.IO, Dispatchers.Main) instead of Dispatchers.Unconfined"
+            )
+        }
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/GlobalScopeUsageDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/GlobalScopeUsageDetector.kt
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.UCallExpression
+
+/**
+ * Detects usage of GlobalScope.launch or GlobalScope.async.
+ * 
+ * Best Practice 1.1: Using GlobalScope in Production Code
+ * 
+ * GlobalScope breaks structured concurrency by creating orphan coroutines
+ * that don't have a parent-child relationship, making cancellation and
+ * exception propagation difficult to manage.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD
+ * GlobalScope.launch { fetchData() }
+ * 
+ * // ✅ GOOD - Framework scopes
+ * class MyViewModel : ViewModel() {
+ *     fun load() {
+ *         viewModelScope.launch { fetchData() }
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Structured builders
+ * suspend fun process() = coroutineScope {
+ *     launch { fetchData() }
+ * }
+ * ```
+ */
+class GlobalScopeUsageDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "GlobalScopeUsage",
+            briefDescription = "GlobalScope usage in production code",
+            explanation = """
+                GlobalScope breaks structured concurrency by creating orphan coroutines 
+                that don't have a parent-child relationship. This makes cancellation 
+                and exception propagation difficult to manage.
+                
+                Use framework scopes (viewModelScope, lifecycleScope, rememberCoroutineScope) 
+                or structured concurrency patterns (coroutineScope, supervisorScope) instead.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 9,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                GlobalScopeUsageDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("launch", "async")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        if (CoroutineLintUtils.isGlobalScopeCall(node)) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "Use viewModelScope, lifecycleScope, rememberCoroutineScope(), or coroutineScope { } instead of GlobalScope"
+            )
+        }
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/InlineCoroutineScopeDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/InlineCoroutineScopeDetector.kt
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Detects inline creation of CoroutineScope with launch/async calls.
+ * Also detects property initialization with CoroutineScope(...).
+ * 
+ * Best Practice 1.3: Breaking Structured Concurrency by Launching in External Scopes
+ * 
+ * Creating a CoroutineScope inline and immediately launching a coroutine creates
+ * an orphan coroutine that isn't tied to any lifecycle or structured concurrency tree.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Inline creation with launch/async
+ * CoroutineScope(Dispatchers.IO).launch {
+ *     fetchData()  // Orphan coroutine
+ * }
+ * 
+ * // ❌ BAD - Property initialized with CoroutineScope
+ * val viewModelScope = CoroutineScope(Dispatchers.Main)
+ * 
+ * // ✅ GOOD - Framework scopes
+ * class MyViewModel : ViewModel() {
+ *     fun load() {
+ *         viewModelScope.launch { fetchData() }
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Structured builders
+ * suspend fun process() = coroutineScope {
+ *     launch { fetchData() }
+ * }
+ * ```
+ */
+class InlineCoroutineScopeDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "InlineCoroutineScope",
+            briefDescription = "Inline CoroutineScope creation",
+            explanation = """
+                Creating a CoroutineScope inline and immediately launching a coroutine 
+                creates an orphan coroutine that isn't tied to any lifecycle or 
+                structured concurrency tree.
+                
+                Use framework scopes (viewModelScope, lifecycleScope) or structured 
+                concurrency patterns (coroutineScope, supervisorScope) instead.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 9,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                InlineCoroutineScopeDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("launch", "async", "CoroutineScope")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        // Check for inline CoroutineScope creation: CoroutineScope(...).launch/async
+        if (CoroutineLintUtils.isInlineCoroutineScopeCreation(node)) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "Use framework scopes (viewModelScope, lifecycleScope) or structured builders (coroutineScope { }) instead of inline CoroutineScope creation"
+            )
+            return
+        }
+        
+        // Check for CoroutineScope constructor call: CoroutineScope(...)
+        if (node.methodName == "CoroutineScope") {
+            // Check if this is a variable initialization
+            var current: UElement? = node
+            while (current != null) {
+                if (current is UVariable) {
+                    val variableName = current.name
+                    val message = if (variableName == "viewModelScope") {
+                        "Don't create a custom viewModelScope. Use the official viewModelScope property from androidx.lifecycle.ViewModel"
+                    } else {
+                        "Use framework scopes (viewModelScope, lifecycleScope) or inject a scope annotated with @StructuredScope instead of creating CoroutineScope manually"
+                    }
+                    
+                    context.report(
+                        ISSUE,
+                        node,
+                        context.getLocation(node),
+                        message
+                    )
+                    return
+                }
+                current = current.uastParent
+            }
+            
+            // If not in a variable, it might be inline usage
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "Use framework scopes (viewModelScope, lifecycleScope) or structured builders (coroutineScope { }) instead of creating CoroutineScope manually"
+            )
+        }
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/JobInBuilderContextDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/JobInBuilderContextDetector.kt
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import org.jetbrains.uast.*
+
+/**
+ * Detects Job() or SupervisorJob() passed directly to coroutine builders.
+ * 
+ * Best Practice 3.3 & 5.1: Passing Job()/SupervisorJob() Directly as Context to Builders
+ * 
+ * Passing a new Job directly to coroutine builders breaks the parent-child relationship
+ * that is fundamental to structured concurrency.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Job() breaks structured concurrency
+ * scope.launch(Job()) {
+ *     doWork()  // This coroutine is now orphaned!
+ * }
+ * 
+ * // ❌ BAD - SupervisorJob() doesn't work as expected
+ * withContext(SupervisorJob()) {
+ *     launch { task1() }
+ *     launch { task2() }
+ * }
+ * 
+ * // ✅ GOOD - Use supervisorScope for supervisor behavior
+ * suspend fun processAll() = supervisorScope {
+ *     launch { task1() }
+ *     launch { task2() }
+ * }
+ * 
+ * // ✅ GOOD - Use the scope's Job (default behavior)
+ * scope.launch {
+ *     doWork()  // Uses parent's Job automatically
+ * }
+ * ```
+ */
+class JobInBuilderContextDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "JobInBuilderContext",
+            briefDescription = "Job() or SupervisorJob() in coroutine builder",
+            explanation = """
+                Passing Job() or SupervisorJob() directly to coroutine builders breaks 
+                the parent-child relationship that is fundamental to structured concurrency.
+                
+                The new Job becomes an independent parent, breaking the hierarchy. The original 
+                parent loses control over cancellation, exceptions don't propagate as expected, 
+                and resources may leak if the parent is cancelled.
+                
+                Use supervisorScope { } for supervisor semantics, or use the scope's Job 
+                (default behavior) for regular coroutines.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 9,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                JobInBuilderContextDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+        
+        private val COROUTINE_BUILDERS = setOf("launch", "async", "withContext")
+        private val JOB_CONSTRUCTORS = setOf("Job", "SupervisorJob")
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return COROUTINE_BUILDERS.toList()
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        // Check arguments for Job() or SupervisorJob() calls
+        val arguments = node.valueArguments
+        for (arg in arguments) {
+
+            // Check if argument is a call to Job() or SupervisorJob()
+            if (arg is UCallExpression) {
+                val methodName = arg.methodName
+                if (methodName in JOB_CONSTRUCTORS) {
+                    context.report(
+                        ISSUE,
+                        node,
+                        context.getLocation(node),
+                        "Don't pass Job() or SupervisorJob() to coroutine builders. Use supervisorScope { } for supervisor semantics, or use the scope's Job (default behavior)"
+                    )
+                    return
+                }
+            }
+            
+            // Also check if the argument source contains Job() or SupervisorJob()
+            val argSource = arg.asSourceString()
+            if (argSource.contains("Job()") || argSource.contains("SupervisorJob()")) {
+                context.report(
+                    ISSUE,
+                    node,
+                    context.getLocation(node),
+                    "Don't pass Job() or SupervisorJob() to coroutine builders. Use supervisorScope { } for supervisor semantics, or use the scope's Job (default behavior)"
+                )
+                return
+            }
+        }
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/LifecycleAwareScopeDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/LifecycleAwareScopeDetector.kt
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.AndroidLintUtils
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Validates correct usage of lifecycle-aware scopes (lifecycleScope).
+ * 
+ * Android-specific: Ensures that lifecycleScope is only used in LifecycleOwner 
+ * components (Activity, Fragment) and that it's used correctly.
+ * 
+ * Example:
+ * ```kotlin
+ * // ✅ GOOD - lifecycleScope in Activity
+ * class MainActivity : AppCompatActivity() {
+ *     fun load() {
+ *         lifecycleScope.launch { fetchData() }
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - lifecycleScope in Fragment
+ * class MyFragment : Fragment() {
+ *     fun load() {
+ *         lifecycleScope.launch { fetchData() }
+ *     }
+ * }
+ * 
+ * // ❌ BAD - lifecycleScope used outside LifecycleOwner
+ * class MyRepository {
+ *     fun load(activity: Activity) {
+ *         activity.lifecycleScope.launch { }  // Wrong - should use viewModelScope or injected scope
+ *     }
+ * }
+ * 
+ * // ❌ BAD - Custom scope in LifecycleOwner
+ * class MainActivity : AppCompatActivity() {
+ *     private val customScope = CoroutineScope(Dispatchers.Main)
+ *     
+ *     fun load() {
+ *         customScope.launch { }  // Not lifecycle-aware
+ *     }
+ * }
+ * ```
+ */
+class LifecycleAwareScopeDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "LifecycleAwareScope",
+            briefDescription = "Incorrect lifecycle-aware scope usage",
+            explanation = """
+                lifecycleScope should only be used in LifecycleOwner components 
+                (Activity, Fragment) and is automatically cancelled when the lifecycle 
+                is destroyed. Using custom scopes in lifecycle-aware components or 
+                using lifecycleScope outside of them can lead to memory leaks.
+                
+                Always use lifecycleScope.launch { } inside Activity/Fragment classes.
+                For ViewModels, use viewModelScope instead.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 7,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                LifecycleAwareScopeDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("launch", "async")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        // Check if lifecycleScope is used outside of a LifecycleOwner
+        if (isLifecycleScopeUsedOutsideLifecycleOwner(context, node)) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "lifecycleScope should only be used in LifecycleOwner components (Activity, Fragment). Use viewModelScope for ViewModels or inject a scope for other classes"
+            )
+        }
+        
+        // Check if a custom scope is used in a LifecycleOwner instead of lifecycleScope
+        if (isCustomScopeInLifecycleOwner(context, node)) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "Use lifecycleScope instead of creating a custom CoroutineScope in LifecycleOwner components"
+            )
+        }
+    }
+    
+    /**
+     * Checks if lifecycleScope is used outside of a LifecycleOwner component.
+     */
+    private fun isLifecycleScopeUsedOutsideLifecycleOwner(
+        context: JavaContext,
+        call: UCallExpression
+    ): Boolean {
+        val receiver = call.receiver as? UQualifiedReferenceExpression
+        val receiverName = receiver?.receiver?.asSourceString() ?: return false
+        
+        // Check if this is a lifecycleScope call
+        if (receiverName != "lifecycleScope") {
+            return false
+        }
+        
+        // Check if we're NOT inside a LifecycleOwner
+        return !AndroidLintUtils.isInLifecycleOwner(context, call)
+    }
+    
+    /**
+     * Checks if a custom CoroutineScope is being used in a LifecycleOwner.
+     */
+    private fun isCustomScopeInLifecycleOwner(
+        context: JavaContext,
+        call: UCallExpression
+    ): Boolean {
+        // Check if we're inside a LifecycleOwner
+        if (!AndroidLintUtils.isInLifecycleOwner(context, call)) {
+            return false
+        }
+        
+        // Check if the receiver is a custom scope (not lifecycleScope or viewModelScope)
+        val receiver = call.receiver as? UQualifiedReferenceExpression
+        val receiverName = receiver?.receiver?.asSourceString() ?: return false
+        
+        // If it's lifecycleScope or viewModelScope, it's fine
+        if (receiverName == "lifecycleScope" || receiverName == "viewModelScope") {
+            return false
+        }
+        
+        // If it's a framework scope function, it's fine
+        if (CoroutineLintUtils.isFrameworkScopeCall(call)) {
+            return false
+        }
+        
+        // If it's GlobalScope, it's already caught by GlobalScopeUsageDetector
+        if (receiverName == "GlobalScope") {
+            return false
+        }
+        
+        // Otherwise, it might be a custom scope
+        return true
+    }
+    
+    override fun visitClass(context: JavaContext, declaration: UClass) {
+        declaration.accept(object : AbstractUastVisitor() {
+            override fun visitVariable(node: UVariable): Boolean {
+                // Check for property initialization with CoroutineScope in LifecycleOwner
+                if (!AndroidLintUtils.isInLifecycleOwner(context, node)) {
+                    return super.visitVariable(node)
+                }
+                
+                val initializer = node.uastInitializer as? UCallExpression ?: return super.visitVariable(node)
+                
+                if (initializer.methodName == "CoroutineScope") {
+                    context.report(
+                        ISSUE,
+                        node.sourcePsi,
+                        context.getLocation(node as UElement),
+                        "Don't create custom CoroutineScope in LifecycleOwner. Use lifecycleScope instead"
+                    )
+                }
+                return super.visitVariable(node)
+            }
+        })
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/LoopWithoutYieldDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/LoopWithoutYieldDetector.kt
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Detects loops without cooperation points in suspend functions.
+ * 
+ * Best Practice 4.1: Ignoring Cancellation in Intensive Loops (Parcial)
+ * 
+ * Long-running loops in suspend functions without cooperation points (yield, 
+ * ensureActive, delay) cannot be cancelled until the loop completes. This defeats 
+ * the cooperative nature of coroutine cancellation.
+ * 
+ * Note: This is a heuristic rule. It flags loops that don't contain any known 
+ * cooperation points. False positives may occur if the loop body contains suspend 
+ * function calls that themselves provide cooperation points.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Loop cannot be cancelled
+ * suspend fun processItems(items: List<Item>) {
+ *     for (item in items) {
+ *         heavyComputation(item)  // No cooperation point
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Loop can be cancelled
+ * suspend fun processItems(items: List<Item>) {
+ *     for (item in items) {
+ *         ensureActive()  // Check for cancellation
+ *         heavyComputation(item)
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Using yield for CPU-bound work
+ * suspend fun processItems(items: List<Item>) {
+ *     for (item in items) {
+ *         yield()  // Cooperation point
+ *         heavyComputation(item)
+ *     }
+ * }
+ * ```
+ */
+class LoopWithoutYieldDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "LoopWithoutYield",
+            briefDescription = "Loop without cooperation point in suspend function",
+            explanation = """
+                Long-running loops in suspend functions without cooperation points 
+                (yield, ensureActive, delay) cannot be cancelled until the loop completes.
+                
+                Add yield(), ensureActive(), or delay() inside the loop to allow cancellation.
+                
+                Note: This is a heuristic rule. False positives may occur if the loop body 
+                contains suspend function calls that themselves provide cooperation points.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 5,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                LoopWithoutYieldDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+        
+        private val COOPERATION_POINTS = setOf(
+            "yield",
+            "ensureActive",
+            "delay",
+            "suspendCancellableCoroutine",
+            "withTimeout",
+            "withTimeoutOrNull"
+        )
+    }
+    
+    override fun visitClass(context: JavaContext, declaration: UClass) {
+        declaration.accept(object : AbstractUastVisitor() {
+            override fun visitForExpression(node: UForExpression): Boolean {
+                checkLoop(context, node, node.body)
+                return super.visitForExpression(node)
+            }
+            
+            override fun visitWhileExpression(node: UWhileExpression): Boolean {
+                checkLoop(context, node, node.body)
+                return super.visitWhileExpression(node)
+            }
+        })
+    }
+    
+    private fun checkLoop(
+        context: JavaContext,
+        loop: ULoopExpression,
+        loopBody: UExpression?
+    ) {
+        // Only check inside suspend functions
+        if (!CoroutineLintUtils.isInSuspendFunction(context, loop)) {
+            return
+        }
+        
+        if (loopBody == null) return
+        
+        // Check if the loop body contains any cooperation points
+        val hasCooperationPoint = hasCooperationPoint(loopBody)
+        
+        if (!hasCooperationPoint) {
+            val loopType = when (loop) {
+                is UForExpression -> "for"
+                is UWhileExpression -> "while"
+                else -> "loop"
+            }
+            
+            context.report(
+                ISSUE,
+                loop,
+                context.getLocation(loop),
+                "'$loopType' loop in suspend function without cooperation point. Add ensureActive() or yield() inside the loop to enable cancellation"
+            )
+        }
+    }
+    
+    /**
+     * Checks if an expression contains any cooperation points.
+     */
+    private fun hasCooperationPoint(expression: UExpression): Boolean {
+        var found = false
+        
+        expression.accept(object : AbstractUastVisitor() {
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+                val methodName = node.methodName
+                if (methodName in COOPERATION_POINTS) {
+                    found = true
+                    return false // Stop traversal
+                }
+                return super.visitCallExpression(node)
+            }
+        })
+        
+        return found
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/MainDispatcherMisuseDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/MainDispatcherMisuseDetector.kt
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.AndroidLintUtils
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Detects blocking code on Dispatchers.Main.
+ * 
+ * Best Practice 3.1: Mixing Blocking Code with Dispatchers.Default or Dispatchers.Main
+ * 
+ * Doing blocking I/O (files, JDBC, synchronous libraries) in coroutines running 
+ * on Dispatchers.Main can freeze the UI and cause ANRs (Application Not Responding).
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Blocking call on Main dispatcher
+ * viewModelScope.launch(Dispatchers.Main) {
+ *     Thread.sleep(1000)  // Freezes UI!
+ *     inputStream.read()  // Blocks Main thread
+ *     jdbcStatement.executeQuery()  // Blocks Main thread
+ * }
+ * 
+ * // ✅ GOOD - Use Dispatchers.IO for blocking operations
+ * viewModelScope.launch(Dispatchers.Main) {
+ *     updateUI()  // Quick UI update
+ *     withContext(Dispatchers.IO) {
+ *         inputStream.read()  // Blocking I/O on IO dispatcher
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Use appropriate dispatcher from the start
+ * viewModelScope.launch(Dispatchers.IO) {
+ *     inputStream.read()
+ *     withContext(Dispatchers.Main) {
+ *         updateUI()  // Switch back to Main for UI update
+ *     }
+ * }
+ * ```
+ */
+class MainDispatcherMisuseDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "MainDispatcherMisuse",
+            briefDescription = "Blocking code on Main dispatcher",
+            explanation = """
+                Blocking operations on Dispatchers.Main can freeze the UI and cause 
+                ANRs (Application Not Responding).
+                
+                For blocking operations (I/O, JDBC, synchronous HTTP), use 
+                Dispatchers.IO or wrap the blocking code with withContext(Dispatchers.IO).
+                
+                Dispatchers.Main should only be used for quick UI updates and 
+                non-blocking operations.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 10, // Highest priority - can cause ANRs
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                MainDispatcherMisuseDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("launch", "async", "withContext")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        // Check if this call uses Dispatchers.Main
+        if (!CoroutineLintUtils.usesMainDispatcher(node)) {
+            return
+        }
+        
+        // Find the lambda body of the coroutine builder
+        val lambdaBody = getLambdaBody(node) ?: return
+        
+        // Check if the lambda body contains blocking calls
+        val blockingCalls = findBlockingCallsInLambda(lambdaBody)
+        
+        if (blockingCalls.isNotEmpty()) {
+            for (blockingCall in blockingCalls) {
+                context.report(
+                    ISSUE,
+                    blockingCall,
+                    context.getLocation(blockingCall),
+                    "Blocking call on Main dispatcher. Move this to Dispatchers.IO using withContext(Dispatchers.IO) { }"
+                )
+            }
+        }
+    }
+    
+    /**
+     * Gets the lambda body from a coroutine builder call.
+     */
+    private fun getLambdaBody(call: UCallExpression): UExpression? {
+        val arguments = call.valueArguments
+        if (arguments.isEmpty()) return null
+        
+        // The last argument is typically the lambda
+        val lastArg = arguments.lastOrNull() ?: return null
+        
+        return when (lastArg) {
+            is ULambdaExpression -> lastArg.body
+            is UBlockExpression -> lastArg
+            else -> null
+        }
+    }
+    
+    /**
+     * Finds all blocking calls within a lambda expression.
+     */
+    private fun findBlockingCallsInLambda(lambdaBody: UExpression): List<UCallExpression> {
+        val blockingCalls = mutableListOf<UCallExpression>()
+        
+        lambdaBody.accept(object : AbstractUastVisitor() {
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+                if (AndroidLintUtils.containsBlockingCall(node)) {
+                    blockingCalls.add(node)
+                }
+                return super.visitCallExpression(node)
+            }
+        })
+        
+        return blockingCalls
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/RedundantLaunchInCoroutineScopeDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/RedundantLaunchInCoroutineScopeDetector.kt
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Detects redundant launch calls inside coroutineScope.
+ * 
+ * Best Practice 2.1: Using launch on the Last Line of a coroutineScope
+ * 
+ * Using launch on the last line of a coroutineScope is redundant because
+ * coroutineScope already waits for all children to complete. If you want the
+ * function to wait, execute the work directly without wrapping it in launch.
+ * 
+ * Example:
+ * ```kotlin
+ * // ⚠️ WARNING - Redundant launch
+ * suspend fun bad() = coroutineScope {
+ *     launch { work() }  // Innecesario - debería ser solo work()
+ * }
+ * 
+ * // ✅ GOOD - Direct execution
+ * suspend fun good() = coroutineScope {
+ *     work()  // Directo, sin launch
+ * }
+ * 
+ * // ✅ GOOD - Multiple launches (not redundant)
+ * suspend fun good() = coroutineScope {
+ *     launch { work1() }
+ *     launch { work2() }
+ * }
+ * ```
+ */
+class RedundantLaunchInCoroutineScopeDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "RedundantLaunchInCoroutineScope",
+            briefDescription = "Redundant launch in coroutineScope",
+            explanation = """
+                Using launch on the last line of a coroutineScope is redundant because 
+                coroutineScope already waits for all children to complete. If you want 
+                the function to wait, execute the work directly without wrapping it in launch.
+                
+                Only use launch inside coroutineScope when you need multiple concurrent 
+                operations. For a single operation, execute it directly.
+            """.trimIndent(),
+            category = Category.PERFORMANCE,
+            priority = 5,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                RedundantLaunchInCoroutineScopeDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("coroutineScope")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        if (node.methodName != "coroutineScope") return
+        
+        // Get the lambda body
+        val lambdaBody = getLambdaBody(node) ?: return
+        
+        // Count launch and async calls in the block
+        val launchCount = countBuilderCalls(lambdaBody, "launch")
+        val asyncCount = countBuilderCalls(lambdaBody, "async")
+        val totalBuilders = launchCount + asyncCount
+        
+        // If there's exactly 1 launch and no other builders, it's redundant
+        if (launchCount == 1 && totalBuilders == 1) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "Redundant launch in coroutineScope. If you want the function to wait, execute the work directly without wrapping it in launch"
+            )
+        }
+    }
+    
+    /**
+     * Gets the lambda body from the coroutineScope call.
+     */
+    private fun getLambdaBody(call: UCallExpression): UExpression? {
+        val arguments = call.valueArguments
+        if (arguments.isEmpty()) return null
+        
+        val lastArg = arguments.lastOrNull() ?: return null
+        
+        return when (lastArg) {
+            is ULambdaExpression -> lastArg.body
+            is UBlockExpression -> lastArg
+            else -> null
+        }
+    }
+    
+    /**
+     * Counts calls to a specific builder (launch or async) in an expression.
+     */
+    private fun countBuilderCalls(expression: UExpression, builderName: String): Int {
+        var count = 0
+        
+        expression.accept(object : AbstractUastVisitor() {
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+                if (node.methodName == builderName) {
+                    count++
+                }
+                return super.visitCallExpression(node)
+            }
+        })
+        
+        return count
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/RunBlockingInSuspendDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/RunBlockingInSuspendDetector.kt
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.UCallExpression
+
+/**
+ * Detects runBlocking calls inside suspend functions.
+ * 
+ * Best Practice 2.2: Using runBlocking Inside suspend Functions
+ * 
+ * runBlocking blocks the current thread, which breaks the non-blocking model
+ * of coroutines and can cause deadlocks or ANRs (on Android).
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - runBlocking en suspend function
+ * suspend fun fetchData() {
+ *     runBlocking {  // Bloquea el thread!
+ *         delay(1000)
+ *         loadFromNetwork()
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Direct suspend
+ * suspend fun fetchData() {
+ *     delay(1000)  // Non-blocking
+ *     loadFromNetwork()
+ * }
+ * 
+ * // ✅ GOOD - runBlocking en top level (entry point)
+ * fun main() = runBlocking {
+ *     fetchData()
+ * }
+ * ```
+ */
+class RunBlockingInSuspendDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "RunBlockingInSuspend",
+            briefDescription = "runBlocking in suspend function",
+            explanation = """
+                runBlocking blocks the current thread, which breaks the non-blocking model 
+                of coroutines and can cause deadlocks or ANRs (on Android).
+                
+                Inside suspend functions, keep suspending. Use the suspend versions of 
+                libraries or wrap blocking operations with withContext(Dispatchers.IO) 
+                when no suspend API is available.
+                
+                runBlocking should only be used as a bridge from purely blocking code 
+                to coroutines (e.g., old entry points, console scripts).
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 8,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                RunBlockingInSuspendDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("runBlocking")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        if (CoroutineLintUtils.isRunBlockingCall(node) &&
+            CoroutineLintUtils.isInSuspendFunction(context, node)) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "Remove runBlocking wrapper. Inside suspend functions, use suspend calls directly or withContext(Dispatchers.IO) for blocking operations"
+            )
+        }
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/RunBlockingWithDelayInTestDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/RunBlockingWithDelayInTestDetector.kt
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.AndroidLintUtils
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Detects runBlocking with delay in test files.
+ * 
+ * Best Practice 6.1: Slow Tests Using runBlocking + Real delay
+ * 
+ * Using runBlocking with delay() in tests makes tests slow and flaky because
+ * they wait for real time to pass. This defeats the purpose of virtual time
+ * testing provided by kotlinx-coroutines-test.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Slow test with real delays
+ * @Test
+ * fun `test something`() = runBlocking {
+ *     delay(1000)  // Waits 1 real second
+ *     val result = repository.getData()
+ *     assertEquals(expected, result)
+ * }
+ * 
+ * // ✅ GOOD - Fast test with virtual time
+ * @Test
+ * fun `test something`() = runTest {
+ *     delay(1000)  // Instant - uses virtual time
+ *     val result = repository.getData()
+ *     assertEquals(expected, result)
+ * }
+ * ```
+ */
+class RunBlockingWithDelayInTestDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "RunBlockingWithDelayInTest",
+            briefDescription = "runBlocking with delay in test file",
+            explanation = """
+                Using runBlocking with delay() in tests makes tests slow and flaky because 
+                they wait for real time to pass. This defeats the purpose of virtual time 
+                testing provided by kotlinx-coroutines-test.
+                
+                Use runTest { } from kotlinx-coroutines-test for instant virtual time support.
+            """.trimIndent(),
+            category = Category.PERFORMANCE,
+            priority = 6,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                RunBlockingWithDelayInTestDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("runBlocking")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        // Only check in test files
+        if (!AndroidLintUtils.isTestFile(context, node)) return
+        
+        if (node.methodName != "runBlocking") return
+        
+        // Get the lambda body
+        val lambdaBody = getLambdaBody(node) ?: return
+        
+        // Check if the lambda contains delay()
+        if (containsDelayCall(lambdaBody)) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "runBlocking with delay() in test file. Use runTest { } from kotlinx-coroutines-test for instant virtual time"
+            )
+        }
+    }
+    
+    /**
+     * Gets the lambda body from the runBlocking call.
+     */
+    private fun getLambdaBody(call: UCallExpression): UExpression? {
+        val arguments = call.valueArguments
+        if (arguments.isEmpty()) return null
+        
+        val lastArg = arguments.lastOrNull() ?: return null
+        
+        return when (lastArg) {
+            is ULambdaExpression -> lastArg.body
+            is UBlockExpression -> lastArg
+            else -> null
+        }
+    }
+    
+    /**
+     * Checks if the expression contains any delay() calls.
+     */
+    private fun containsDelayCall(expression: UExpression): Boolean {
+        var foundDelay = false
+        
+        expression.accept(object : AbstractUastVisitor() {
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+                if (node.methodName == "delay") {
+                    foundDelay = true
+                    return false // Stop traversal
+                }
+                return super.visitCallExpression(node)
+            }
+        })
+        
+        return foundDelay
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/ScopeReuseAfterCancelDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/ScopeReuseAfterCancelDetector.kt
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Detects obvious cases of scope cancellation followed by reuse.
+ * 
+ * Best Practice 4.4: Cancelling a CoroutineScope and Continuing to Reuse It (Parcial)
+ * 
+ * Doing scope.cancel() and then trying to launch more coroutines in that same scope
+ * doesn't work. A scope with a cancelled Job doesn't accept new children, and 
+ * subsequent launches fail silently.
+ * 
+ * Note: This is a partial/heuristic detection. It only detects obvious cases where
+ * cancel() is called on a scope variable followed by launch/async on the same variable
+ * in the same function. Complex cases requiring flow analysis are not detected.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Scope cancelled and then reused
+ * fun process(scope: CoroutineScope) {
+ *     scope.cancel()
+ *     scope.launch { work() }  // Won't work - scope is cancelled
+ * }
+ * 
+ * // ✅ GOOD - Use cancelChildren() instead
+ * fun process(scope: CoroutineScope) {
+ *     scope.coroutineContext.job.cancelChildren()  // Cancel children, keep scope usable
+ *     scope.launch { work() }  // Still works
+ * }
+ * 
+ * // ✅ GOOD - Only cancel when scope won't be reused
+ * fun cleanup(scope: CoroutineScope) {
+ *     scope.cancel()  // OK - scope won't be used again
+ * }
+ * ```
+ */
+class ScopeReuseAfterCancelDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "ScopeReuseAfterCancel",
+            briefDescription = "Scope cancelled and then reused",
+            explanation = """
+                Cancelling a CoroutineScope and then trying to launch more coroutines 
+                in that same scope doesn't work. A scope with a cancelled Job doesn't 
+                accept new children, and subsequent launches fail silently.
+                
+                To "clean up" children but keep the scope usable, use 
+                coroutineContext.job.cancelChildren() instead of scope.cancel().
+                
+                Note: This is a heuristic detection. It only detects obvious cases in 
+                the same function. Complex cases requiring flow analysis are not detected.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 6,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                ScopeReuseAfterCancelDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("cancel", "launch", "async")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        // Find the containing function
+        val containingFunction = findContainingFunction(node) ?: return
+        
+        // If this is a cancel() call, check if scope is reused later
+        if (node.methodName == "cancel") {
+            val scopeName = getScopeNameFromCancelCall(node) ?: return
+            
+            // Check if the same scope is used in launch/async later in the function
+            if (isScopeUsedLater(containingFunction, scopeName, node)) {
+                context.report(
+                    ISSUE,
+                    node,
+                    context.getLocation(node),
+                    "Scope '$scopeName' is cancelled and then reused. Use cancelChildren() instead of cancel() if you need to reuse the scope"
+                )
+            }
+        }
+    }
+    
+    /**
+     * Finds the containing function for a call expression.
+     */
+    private fun findContainingFunction(call: UCallExpression): UMethod? {
+        var current: UElement? = call
+        while (current != null) {
+            if (current is UMethod) {
+                return current
+            }
+            current = current.uastParent
+        }
+        return null
+    }
+    
+    /**
+     * Gets the scope name from a cancel() call (e.g., "scope" from "scope.cancel()").
+     */
+    private fun getScopeNameFromCancelCall(call: UCallExpression): String? {
+        val receiver = call.receiver
+        return when (receiver) {
+            is UQualifiedReferenceExpression -> receiver.receiver.asSourceString()
+            is UReferenceExpression -> receiver.asSourceString()
+            else -> null
+        }
+    }
+    
+    /**
+     * Checks if a scope is used in launch/async calls after the cancel() call.
+     */
+    private fun isScopeUsedLater(
+        function: UMethod,
+        scopeName: String,
+        cancelCall: UCallExpression
+    ): Boolean {
+        val functionBody = function.uastBody ?: return false
+        val cancelCallOffset = cancelCall.sourcePsi?.textOffset ?: return false
+        
+        var foundReuse = false
+        
+        functionBody.accept(object : AbstractUastVisitor() {
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+                // Only check calls after the cancel() call
+                val nodeOffset = node.sourcePsi?.textOffset ?: return true
+                if (nodeOffset <= cancelCallOffset) return true
+                
+                // Check if this is a launch/async call
+                if (node.methodName == "launch" || node.methodName == "async") {
+                    // Check if it's called on the same scope
+                    val receiver = node.receiver
+                    val receiverName = when (receiver) {
+                        is UQualifiedReferenceExpression -> receiver.receiver.asSourceString()
+                        is UReferenceExpression -> receiver.asSourceString()
+                        else -> null
+                    }
+                    
+                    if (receiverName == scopeName) {
+                        foundReuse = true
+                        return false // Stop traversal
+                    }
+                }
+                
+                return super.visitCallExpression(node)
+            }
+        })
+        
+        return foundReuse
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/SuspendInFinallyDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/SuspendInFinallyDetector.kt
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Detects suspend calls in finally blocks without withContext(NonCancellable).
+ * 
+ * Best Practice 4.3: Doing Suspendable Cleanup Without NonCancellable
+ * 
+ * In a finally block, making suspend calls without wrapping them in 
+ * withContext(NonCancellable) is dangerous. If the coroutine is in *cancelling* 
+ * state, any suspension will throw CancellationException again and the cleanup 
+ * may not execute.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Suspend call in finally without NonCancellable
+ * try {
+ *     doWork()
+ * } finally {
+ *     saveToDb()  // May not execute if coroutine is cancelled!
+ * }
+ * 
+ * // ✅ GOOD - Wrapped in NonCancellable
+ * try {
+ *     doWork()
+ * } finally {
+ *     withContext(NonCancellable) {
+ *         saveToDb()  // Will execute even if cancelled
+ *         closeResources()
+ *     }
+ * }
+ * ```
+ */
+class SuspendInFinallyDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "SuspendInFinally",
+            briefDescription = "Suspend call in finally without NonCancellable",
+            explanation = """
+                In a finally block, making suspend calls without wrapping them in 
+                withContext(NonCancellable) is dangerous. If the coroutine is in 
+                *cancelling* state, any suspension will throw CancellationException 
+                again and the cleanup may not execute.
+                
+                For critical cleanup that needs to suspend, wrap it with 
+                withContext(NonCancellable) { }.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 7,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                SuspendInFinallyDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun visitClass(context: JavaContext, declaration: UClass) {
+        declaration.accept(object : AbstractUastVisitor() {
+            override fun visitTryExpression(node: UTryExpression): Boolean {
+                val finallyClause = node.finallyClause ?: return super.visitTryExpression(node)
+
+                if (finallyClause is UBlockExpression) {
+                    // Check if there are suspend calls not wrapped in withContext(NonCancellable)
+                    val unprotectedSuspendCalls = findUnprotectedSuspendCallsInFinally(finallyClause)
+                    
+                    if (unprotectedSuspendCalls.isNotEmpty()) {
+                        context.report(
+                            ISSUE,
+                            node,
+                            context.getLocation(node as UElement),
+                            "Suspend calls in finally block should be wrapped with withContext(NonCancellable) { } to ensure cleanup executes even if cancelled"
+                        )
+                    }
+                }
+                
+                return super.visitTryExpression(node)
+            }
+        })
+    }
+    
+    /**
+     * Finds suspend function calls in finally clause that are not wrapped in withContext(NonCancellable).
+     */
+    private fun findUnprotectedSuspendCallsInFinally(finallyClause: UBlockExpression): List<UCallExpression> {
+        val unprotectedCalls = mutableListOf<UCallExpression>()
+        var insideNonCancellable = false
+        
+        // Traverse the finally clause using its sourcePsi
+        finallyClause.accept(object : AbstractUastVisitor() {
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+                // Check if this is withContext(NonCancellable)
+                if (isWithContextNonCancellable(node)) {
+                    // Mark that we're inside NonCancellable
+                    insideNonCancellable = true
+                    // Don't check inside this block
+                    return false
+                }
+                
+                // Check if this might be a suspend call (heuristic: check if it's not a standard function)
+                if (!insideNonCancellable && mightBeSuspendCall(node)) {
+                    unprotectedCalls.add(node)
+                }
+                
+                return super.visitCallExpression(node)
+            }
+        })
+        
+        return unprotectedCalls
+    }
+    
+    /**
+     * Checks if a call is withContext(NonCancellable).
+     */
+    private fun isWithContextNonCancellable(call: UCallExpression): Boolean {
+        if (call.methodName != "withContext") return false
+        
+        val arguments = call.valueArguments
+        if (arguments.isEmpty()) return false
+        
+        val firstArg = arguments.firstOrNull() ?: return false
+        val argSource = firstArg.asSourceString()
+        
+        return argSource.contains("NonCancellable")
+    }
+    
+    /**
+     * Heuristic to check if a call might be a suspend function.
+     * This is a simplified check - in a real implementation, you'd need to
+     * check the actual function signature.
+     */
+    private fun mightBeSuspendCall(call: UCallExpression): Boolean {
+        // Skip standard library functions that are not suspend
+        val methodName = call.methodName ?: return false
+        val nonSuspendFunctions = setOf(
+            "println", "print", "require", "check", "error", "TODO",
+            "equals", "hashCode", "toString", "compareTo"
+        )
+        
+        if (methodName in nonSuspendFunctions) {
+            return false
+        }
+        
+        // If it's inside a suspend function context, it might be a suspend call
+        // This is a heuristic - we can't always determine if a function is suspend in UAST
+        return true
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/UnstructuredLaunchDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/UnstructuredLaunchDetector.kt
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.*
+
+/**
+ * Detects unstructured coroutine launches (launch/async without structured scope).
+ * 
+ * Best Practice 1.1: Using launch/async without a properly structured scope
+ * 
+ * This detector identifies cases where launch or async are called on scopes that
+ * are not explicitly marked as structured (via @StructuredScope annotation) or
+ * are not framework scopes (viewModelScope, lifecycleScope, etc.).
+ * 
+ * Note: This is a heuristic-based detection. GlobalScope and inline CoroutineScope
+ * are already caught by GlobalScopeUsageDetector and InlineCoroutineScopeDetector.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Scope not annotated with @StructuredScope
+ * fun process(scope: CoroutineScope) {
+ *     scope.launch { doWork() }  // scope not marked as structured
+ * }
+ * 
+ * // ✅ GOOD - Using @StructuredScope annotation
+ * fun process(@StructuredScope scope: CoroutineScope) {
+ *     scope.launch { doWork() }
+ * }
+ * 
+ * // ✅ GOOD - Framework scopes (automatically recognized)
+ * class MyViewModel : ViewModel() {
+ *     fun load() {
+ *         viewModelScope.launch { fetchData() }
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Structured builders
+ * suspend fun process() = coroutineScope {
+ *     launch { doWork() }
+ * }
+ * ```
+ */
+class UnstructuredLaunchDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "UnstructuredLaunch",
+            briefDescription = "Unstructured coroutine launch",
+            explanation = """
+                Launching coroutines on scopes that are not explicitly marked as structured 
+                makes it hard to track coroutine lifecycles and ensure proper cleanup.
+                
+                Use framework scopes (viewModelScope, lifecycleScope, rememberCoroutineScope), 
+                structured concurrency patterns (coroutineScope, supervisorScope), or annotate 
+                the scope with @StructuredScope.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 8,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                UnstructuredLaunchDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("launch", "async")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        // Skip if already caught by other detectors
+        if (CoroutineLintUtils.isGlobalScopeCall(node)) return
+        if (CoroutineLintUtils.isInlineCoroutineScopeCreation(node)) return
+        if (CoroutineLintUtils.isFrameworkScopeCall(node)) return
+        
+        // Check if this is inside a structured builder (coroutineScope, supervisorScope)
+        if (isInsideStructuredBuilder(node)) return
+        
+        // Check if the receiver is annotated with @StructuredScope
+        val receiver = node.receiver
+        if (receiver != null && isStructuredScope(receiver)) {
+            return
+        }
+        
+        // If we get here, it's an unstructured launch
+        context.report(
+            ISSUE,
+            node,
+            context.getLocation(node),
+            "Unstructured coroutine launch. Use framework scopes (viewModelScope, lifecycleScope), structured builders (coroutineScope { }), or annotate the scope with @StructuredScope"
+        )
+    }
+    
+    /**
+     * Checks if the call is inside a structured builder (coroutineScope, supervisorScope).
+     */
+    private fun isInsideStructuredBuilder(call: UCallExpression): Boolean {
+        var current: UElement? = call
+        while (current != null) {
+            if (current is UCallExpression) {
+                val methodName = current.methodName
+                if (methodName == "coroutineScope" || methodName == "supervisorScope") {
+                    return true
+                }
+            }
+            current = current.uastParent
+        }
+        return false
+    }
+    
+    /**
+     * Checks if a receiver is a structured scope (annotated with @StructuredScope).
+     * This is a heuristic check based on source code analysis.
+     */
+    private fun isStructuredScope(receiver: UElement): Boolean {
+        // Check if the receiver source contains @StructuredScope annotation
+        val source = receiver.asSourceString()
+        return source.contains("@StructuredScope") || 
+               source.contains("StructuredScope")
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/ViewModelScopeLeakDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/ViewModelScopeLeakDetector.kt
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Severity
+import io.github.santimattius.structured.lint.utils.AndroidLintUtils
+import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
+import org.jetbrains.uast.*
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * Detects potential ViewModel scope leaks and incorrect usage.
+ * 
+ * Android-specific: Detects cases where viewModelScope is used incorrectly
+ * or where custom scopes are created in ViewModels instead of using the
+ * official viewModelScope.
+ * 
+ * Example:
+ * ```kotlin
+ * // ❌ BAD - Custom scope in ViewModel
+ * class MyViewModel : ViewModel() {
+ *     private val customScope = CoroutineScope(Dispatchers.Main)
+ *     
+ *     fun load() {
+ *         customScope.launch { fetchData() }  // Not lifecycle-aware
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Use official viewModelScope
+ * class MyViewModel : ViewModel() {
+ *     fun load() {
+ *         viewModelScope.launch { fetchData() }  // Lifecycle-aware
+ *     }
+ * }
+ * 
+ * // ❌ BAD - viewModelScope used outside ViewModel
+ * class MyRepository {
+ *     fun load(viewModel: MyViewModel) {
+ *         viewModel.viewModelScope.launch { }  // Wrong context
+ *     }
+ * }
+ * 
+ * // ✅ GOOD - Inject scope or use structured concurrency
+ * class MyRepository(private val scope: CoroutineScope) {
+ *     fun load() {
+ *         scope.launch { fetchData() }
+ *     }
+ * }
+ * ```
+ */
+class ViewModelScopeLeakDetector : Detector(), SourceCodeScanner {
+    
+    companion object {
+        val ISSUE = Issue.create(
+            id = "ViewModelScopeLeak",
+            briefDescription = "Incorrect ViewModel scope usage",
+            explanation = """
+                ViewModels should use the official viewModelScope which is automatically 
+                cancelled when the ViewModel is cleared. Creating custom scopes in ViewModels 
+                or using viewModelScope outside of ViewModels can lead to memory leaks.
+                
+                Always use viewModelScope.launch { } inside ViewModel classes.
+                For other classes, inject a CoroutineScope or use structured concurrency.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 8,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                ViewModelScopeLeakDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+    }
+    
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("launch", "async", "CoroutineScope")
+    }
+    
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod
+    ) {
+        // Check for CoroutineScope constructor call in ViewModel
+        if (node.methodName == "CoroutineScope" && AndroidLintUtils.isInViewModel(context, node)) {
+            // Check if this is a variable initialization
+            var current: UElement? = node
+            while (current != null) {
+                if (current is UVariable) {
+                    val variableName = current.name
+                    val message = if (variableName == "viewModelScope") {
+                        "Don't create a custom viewModelScope. Use the official viewModelScope property from androidx.lifecycle.ViewModel"
+                    } else {
+                        "Don't create custom CoroutineScope in ViewModel. Use viewModelScope instead"
+                    }
+                    
+                    context.report(
+                        ISSUE,
+                        node,
+                        context.getLocation(node),
+                        message
+                    )
+                    return
+                }
+                current = current.uastParent
+            }
+        }
+        
+        // Check if this is a call on a custom scope in a ViewModel
+        if (isCustomScopeInViewModel(context, node)) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "Use viewModelScope instead of creating a custom CoroutineScope in ViewModel"
+            )
+        }
+        
+        // Check if viewModelScope is used outside of a ViewModel
+        if (isViewModelScopeUsedOutsideViewModel(context, node)) {
+            context.report(
+                ISSUE,
+                node,
+                context.getLocation(node),
+                "viewModelScope should only be used inside ViewModel classes. Use injected scope or structured concurrency instead"
+            )
+        }
+    }
+    
+    /**
+     * Checks if a custom CoroutineScope is being used in a ViewModel.
+     */
+    private fun isCustomScopeInViewModel(
+        context: JavaContext,
+        call: UCallExpression
+    ): Boolean {
+        // Check if we're inside a ViewModel
+        if (!AndroidLintUtils.isInViewModel(context, call)) {
+            return false
+        }
+        
+        // Check if the receiver is a custom scope (not viewModelScope)
+        val receiver = call.receiver as? UQualifiedReferenceExpression
+        val receiverName = receiver?.receiver?.asSourceString() ?: return false
+        
+        // If it's viewModelScope, it's fine
+        if (receiverName == "viewModelScope") {
+            return false
+        }
+        
+        // If it's a property access (like customScope.launch), it might be a custom scope
+        // Check if it's a variable that was initialized with CoroutineScope
+        return receiverName != "lifecycleScope" && 
+               receiverName != "GlobalScope" &&
+               !CoroutineLintUtils.isFrameworkScopeCall(call)
+    }
+    
+    /**
+     * Checks if viewModelScope is used outside of a ViewModel class.
+     */
+    private fun isViewModelScopeUsedOutsideViewModel(
+        context: JavaContext,
+        call: UCallExpression
+    ): Boolean {
+        val receiver = call.receiver as? UQualifiedReferenceExpression
+        val receiverName = receiver?.receiver?.asSourceString() ?: return false
+        
+        // Check if this is a viewModelScope call
+        if (receiverName != "viewModelScope") {
+            return false
+        }
+        
+        // Check if we're NOT inside a ViewModel
+        return !AndroidLintUtils.isInViewModel(context, call)
+    }
+    
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/AndroidLintUtils.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/AndroidLintUtils.kt
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.utils
+
+import com.android.tools.lint.detector.api.JavaContext
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+
+/**
+ * Android-specific utility functions for Lint rules.
+ */
+object AndroidLintUtils {
+
+    /**
+     * Known blocking methods that should not be called on Main dispatcher.
+     */
+    val BLOCKING_METHODS = setOf(
+        "Thread.sleep",
+        "java.lang.Thread.sleep",
+        "InputStream.read",
+        "java.io.InputStream.read",
+        "OutputStream.write",
+        "java.io.OutputStream.write",
+        "BufferedReader.readLine",
+        "java.io.BufferedReader.readLine",
+        "Statement.execute",
+        "java.sql.Statement.execute",
+        "Statement.executeQuery",
+        "java.sql.Statement.executeQuery",
+        "Connection.prepareStatement",
+        "java.sql.Connection.prepareStatement",
+        "ResultSet.next",
+        "java.sql.ResultSet.next",
+        "Call.execute",
+        "okhttp3.Call.execute",
+        "retrofit2.Call.execute",
+        "Future.get",
+        "java.util.concurrent.Future.get",
+        "BlockingQueue.take",
+        "java.util.concurrent.BlockingQueue.take",
+        "CountDownLatch.await",
+        "java.util.concurrent.CountDownLatch.await",
+        "Semaphore.acquire",
+        "java.util.concurrent.Semaphore.acquire"
+    )
+
+    /**
+     * Checks if a call expression contains blocking calls.
+     */
+    fun containsBlockingCall(call: UCallExpression): Boolean {
+        val methodName = call.methodName ?: return false
+        val fullyQualifiedName = CoroutineLintUtils.getFullyQualifiedMethodName(call)
+        
+        // Direct match on fully qualified name
+        if (fullyQualifiedName in BLOCKING_METHODS) {
+            return true
+        }
+        
+        // Check if any blocking method matches
+        for (blocking in BLOCKING_METHODS) {
+            // Extract the method name from the blocking pattern (e.g., "Thread.sleep" -> "sleep")
+            val blockingMethodName = blocking.substringAfterLast(".")
+            
+            // Check if method name matches
+            if (methodName == blockingMethodName || fullyQualifiedName.endsWith(blocking)) {
+                // Additional check: verify the receiver matches
+                val receiver = call.receiver
+                val receiverName = when (receiver) {
+                    is org.jetbrains.uast.UQualifiedReferenceExpression -> receiver.receiver.asSourceString()
+                    is org.jetbrains.uast.UCallExpression -> receiver.methodName
+                    else -> null
+                }
+                
+                // Check if receiver matches the class in the blocking pattern
+                val blockingClass = blocking.substringBeforeLast(".")
+                if (receiverName != null && (receiverName.contains(blockingClass) || blockingClass.contains(receiverName))) {
+                    return true
+                }
+                
+                // Also check by simple method name match (for common cases like Thread.sleep)
+                if (blockingMethodName == methodName && blockingClass.isNotEmpty()) {
+                    return true
+                }
+            }
+        }
+        
+        return false
+    }
+
+    /**
+     * Checks if the element is inside a ViewModel class.
+     */
+    fun isInViewModel(context: JavaContext, element: UElement): Boolean {
+        var current: UElement? = element
+        while (current != null) {
+            if (current is org.jetbrains.uast.UClass) {
+                val className = current.qualifiedName ?: current.name
+                val superTypes = current.uastSuperTypes
+                
+                // Check if extends ViewModel
+                for (superType in superTypes) {
+                    val typeName = superType.type.canonicalText
+                    if (typeName == "androidx.lifecycle.ViewModel" ||
+                        typeName == "android.arch.lifecycle.ViewModel") {
+                        return true
+                    }
+                }
+            }
+            current = current.uastParent
+        }
+        return false
+    }
+
+    /**
+     * Checks if the element is inside a LifecycleOwner (Activity, Fragment, etc.).
+     */
+    fun isInLifecycleOwner(context: JavaContext, element: UElement): Boolean {
+        var current: UElement? = element
+        while (current != null) {
+            if (current is org.jetbrains.uast.UClass) {
+                val superTypes = current.uastSuperTypes
+                
+                // Check if implements LifecycleOwner or extends Lifecycle-aware component
+                for (superType in superTypes) {
+                    val typeName = superType.type.canonicalText
+                    if (typeName == "androidx.lifecycle.LifecycleOwner" ||
+                        typeName == "androidx.appcompat.app.AppCompatActivity" ||
+                        typeName == "androidx.fragment.app.Fragment" ||
+                        typeName == "androidx.activity.ComponentActivity") {
+                        return true
+                    }
+                }
+            }
+            current = current.uastParent
+        }
+        return false
+    }
+
+    /**
+     * Checks if the file is a test file based on naming convention.
+     */
+    fun isTestFile(context: JavaContext, element: UElement): Boolean {
+        val file = element.sourcePsi?.containingFile ?: return false
+        val fileName = file.name
+        
+        return fileName.endsWith("Test.kt") ||
+            fileName.endsWith("Tests.kt") ||
+            fileName.endsWith("Spec.kt") ||
+            fileName.contains("/test/") ||
+            fileName.contains("/androidTest/")
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/CoroutineLintUtils.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/CoroutineLintUtils.kt
@@ -1,0 +1,268 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.utils
+
+import com.android.tools.lint.detector.api.JavaContext
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.uast.*
+
+/**
+ * Utility functions for detecting coroutine patterns in Android Lint rules.
+ */
+object CoroutineLintUtils {
+
+    /**
+     * Coroutine builder function names.
+     */
+    val COROUTINE_BUILDERS = setOf(
+        "launch",
+        "async",
+        "runBlocking",
+        "withContext",
+        "coroutineScope",
+        "supervisorScope"
+    )
+
+    /**
+     * Framework scope property names (Android/Compose).
+     */
+    val FRAMEWORK_SCOPE_PROPERTIES = setOf(
+        "viewModelScope",
+        "lifecycleScope"
+    )
+
+    /**
+     * Framework scope function names (Compose).
+     */
+    val FRAMEWORK_SCOPE_FUNCTIONS = setOf(
+        "rememberCoroutineScope"
+    )
+
+    /**
+     * Checks if a UCallExpression is a GlobalScope call.
+     */
+    fun isGlobalScopeCall(call: UCallExpression): Boolean {
+        val receiver = call.receiver as? UQualifiedReferenceExpression
+        return receiver?.receiver?.asSourceString() == "GlobalScope" &&
+            call.methodName in COROUTINE_BUILDERS
+    }
+
+    /**
+     * Checks if a UCallExpression is a framework scope call (viewModelScope, lifecycleScope, etc.).
+     */
+    fun isFrameworkScopeCall(call: UCallExpression): Boolean {
+        val receiver = call.receiver
+        
+        // Handle UReferenceExpression (direct property access: viewModelScope.launch)
+        if (receiver is UReferenceExpression) {
+            val receiverName = receiver.asSourceString()
+            if (receiverName in FRAMEWORK_SCOPE_PROPERTIES) {
+                return true
+            }
+        }
+        
+        // Handle UQualifiedReferenceExpression (qualified access: this.viewModelScope.launch)
+        if (receiver is UQualifiedReferenceExpression) {
+            val receiverName = receiver.receiver.asSourceString()
+            if (receiverName in FRAMEWORK_SCOPE_PROPERTIES) {
+                return true
+            }
+        }
+        
+        // Check function-based scopes (rememberCoroutineScope())
+        val methodName = call.methodName
+        if (methodName in FRAMEWORK_SCOPE_FUNCTIONS) {
+            return true
+        }
+        
+        return false
+    }
+
+    /**
+     * Checks if a UCallExpression is an inline CoroutineScope creation.
+     * Example: CoroutineScope(Dispatchers.IO).launch { }
+     */
+    fun isInlineCoroutineScopeCreation(call: UCallExpression): Boolean {
+        val receiver = call.receiver as? UCallExpression
+        return receiver?.methodName == "CoroutineScope" &&
+            call.methodName in COROUTINE_BUILDERS
+    }
+
+    /**
+     * Checks if a UCallExpression is a runBlocking call.
+     */
+    fun isRunBlockingCall(call: UCallExpression): Boolean {
+        return call.methodName == "runBlocking"
+    }
+
+    /**
+     * Checks if a UCallExpression uses Dispatchers.Unconfined.
+     */
+    fun usesUnconfinedDispatcher(call: UCallExpression): Boolean {
+        val arguments = call.valueArguments
+        for (arg in arguments) {
+            val argSource = arg.asSourceString()
+            if (argSource.contains("Dispatchers.Unconfined") || 
+                argSource.contains("Dispatchers.UNCONFINED")) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Checks if a UCallExpression uses Dispatchers.Main.
+     */
+    fun usesMainDispatcher(call: UCallExpression): Boolean {
+        val arguments = call.valueArguments
+        for (arg in arguments) {
+            val argSource = arg.asSourceString()
+            if (argSource.contains("Dispatchers.Main") || 
+                argSource.contains("Dispatchers.Main.immediate")) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Checks if the element is inside a suspend function.
+     */
+    fun isInSuspendFunction(context: JavaContext, element: UElement): Boolean {
+        var current: UElement? = element
+        while (current != null) {
+            // UMethod represents both Java methods and Kotlin functions in UAST
+            if (current is UMethod) {
+                val method = current.javaPsi
+                if (isSuspendMethod(method)) {
+                    return true
+                }
+                // Also check source code for Kotlin suspend functions
+                val source = current.sourcePsi?.text ?: ""
+                if (source.contains("suspend fun") || source.contains("suspend ")) {
+                    return true
+                }
+            }
+            
+            current = current.uastParent
+        }
+        return false
+    }
+
+    /**
+     * Checks if a PsiMethod is a suspend function.
+     */
+    private fun isSuspendMethod(method: PsiMethod): Boolean {
+        // For Kotlin suspend functions, check the source code
+        val source = method.text
+        if (source.contains("suspend fun") || source.contains("suspend ")) {
+            return true
+        }
+        
+        // Check for @JvmSynthetic annotation (often used for suspend functions)
+        val annotations = method.annotations
+        for (annotation in annotations) {
+            if (annotation.qualifiedName == "kotlin.jvm.JvmSynthetic") {
+                // Check if it's likely a suspend function by examining the signature
+                val returnType = method.returnType?.canonicalText
+                if (returnType != null && returnType.contains("Continuation")) {
+                    return true
+                }
+            }
+        }
+        
+        return false
+    }
+
+    /**
+     * Gets the fully qualified name of a method call.
+     */
+    fun getFullyQualifiedMethodName(call: UCallExpression): String {
+        val methodName = call.methodName ?: return ""
+        val receiver = call.receiver
+        
+        return when (receiver) {
+            is UQualifiedReferenceExpression -> {
+                val receiverName = receiver.receiver.asSourceString()
+                "$receiverName.$methodName"
+            }
+            is UCallExpression -> {
+                val receiverName = receiver.methodName
+                "$receiverName.$methodName"
+            }
+            else -> methodName
+        }
+    }
+
+    /**
+     * Checks if a call is a coroutine builder call.
+     */
+    fun isCoroutineBuilderCall(call: UCallExpression): Boolean {
+        return call.methodName in COROUTINE_BUILDERS
+    }
+
+    /**
+     * Checks if a class extends CancellationException.
+     */
+    fun extendsCancellationException(context: JavaContext, classElement: UClass): Boolean {
+        val superTypes = classElement.uastSuperTypes
+        for (superType in superTypes) {
+            val typeName = superType.type.canonicalText
+            if (typeName == "kotlinx.coroutines.CancellationException" ||
+                typeName == "java.util.concurrent.CancellationException") {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Checks if a call expression is inside a finally block.
+     */
+    fun isInFinallyBlock(element: UElement): Boolean {
+        var current: UElement? = element
+        while (current != null) {
+            if (current is UTryExpression) {
+                val finallyClause = current.finallyClause
+                if (finallyClause != null) {
+                    val finallyPsi = finallyClause.sourcePsi
+                    val elementPsi = element.sourcePsi
+                    if (finallyPsi != null && elementPsi != null && 
+                        PsiTreeUtil.isAncestor(finallyPsi, elementPsi, false)) {
+                        return true
+                    }
+                }
+            }
+            current = current.uastParent
+        }
+        return false
+    }
+
+    /**
+     * Checks if a call is wrapped in withContext(NonCancellable).
+     */
+    fun isWrappedInNonCancellable(call: UCallExpression): Boolean {
+        var current: UElement? = call
+        while (current != null) {
+            if (current is UCallExpression && current.methodName == "withContext") {
+                val arguments = current.valueArguments
+                for (arg in arguments) {
+                    val argSource = arg.asSourceString()
+                    if (argSource.contains("NonCancellable")) {
+                        return true
+                    }
+                }
+            }
+            current = current.uastParent
+        }
+        return false
+    }
+}

--- a/lint-rules/src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry
+++ b/lint-rules/src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry
@@ -1,0 +1,1 @@
+io.github.santimattius.structured.lint.StructuredCoroutinesIssueRegistry

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/DispatchersUnconfinedDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/DispatchersUnconfinedDetectorTest.kt
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import org.junit.Test
+
+class DispatchersUnconfinedDetectorTest {
+    
+    @Test
+    fun `detects Dispatchers Unconfined in launch`() {
+        val code = """
+            package test
+            
+            import kotlinx.coroutines.*
+            import androidx.lifecycle.viewModelScope
+            
+            class MyViewModel {
+                fun test() {
+                    viewModelScope.launch(Dispatchers.Unconfined) {
+                        println("test")
+                    }
+                }
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(DispatchersUnconfinedDetector.ISSUE)
+            .run()
+            .expect("""
+                src/test/test.kt:8: Warning: Use an appropriate dispatcher (Dispatchers.Default, Dispatchers.IO, Dispatchers.Main) instead of Dispatchers.Unconfined [DispatchersUnconfined]
+                viewModelScope.launch(Dispatchers.Unconfined) {
+                ^
+            """.trimIndent())
+    }
+    
+    @Test
+    fun `does not detect other dispatchers`() {
+        val code = """
+            package test
+            
+            import kotlinx.coroutines.*
+            import androidx.lifecycle.viewModelScope
+            
+            class MyViewModel {
+                fun test() {
+                    viewModelScope.launch(Dispatchers.IO) {
+                        println("test")
+                    }
+                }
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(DispatchersUnconfinedDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/GlobalScopeUsageDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/GlobalScopeUsageDetectorTest.kt
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import org.junit.Test
+
+class GlobalScopeUsageDetectorTest {
+    
+    @Test
+    fun `detects GlobalScope launch`() {
+        val code = """
+            package test
+            
+            import kotlinx.coroutines.*
+            
+            fun test() {
+                GlobalScope.launch {
+                    println("test")
+                }
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(GlobalScopeUsageDetector.ISSUE)
+            .run()
+            .expect("""
+                src/test/test.kt:6: Error: Use viewModelScope, lifecycleScope, rememberCoroutineScope(), or coroutineScope { } instead of GlobalScope [GlobalScopeUsage]
+                GlobalScope.launch {
+                ^
+            """.trimIndent())
+    }
+    
+    @Test
+    fun `detects GlobalScope async`() {
+        val code = """
+            package test
+            
+            import kotlinx.coroutines.*
+            
+            fun test() {
+                GlobalScope.async {
+                    "result"
+                }
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(GlobalScopeUsageDetector.ISSUE)
+            .run()
+            .expect("""
+                src/test/test.kt:6: Error: Use viewModelScope, lifecycleScope, rememberCoroutineScope(), or coroutineScope { } instead of GlobalScope [GlobalScopeUsage]
+                GlobalScope.async {
+                ^
+            """.trimIndent())
+    }
+    
+    @Test
+    fun `does not detect viewModelScope`() {
+        val code = """
+            package test
+            
+            import androidx.lifecycle.ViewModel
+            import androidx.lifecycle.viewModelScope
+            import kotlinx.coroutines.launch
+            
+            class MyViewModel : ViewModel() {
+                fun load() {
+                    viewModelScope.launch {
+                        println("test")
+                    }
+                }
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(GlobalScopeUsageDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/JobInBuilderContextDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/JobInBuilderContextDetectorTest.kt
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import org.junit.Test
+
+class JobInBuilderContextDetectorTest {
+    
+    @Test
+    fun `detects Job in launch`() {
+        val code = """
+            package test
+            
+            import kotlinx.coroutines.*
+            import androidx.lifecycle.viewModelScope
+            
+            class MyViewModel {
+                fun test() {
+                    viewModelScope.launch(Job()) {
+                        println("test")
+                    }
+                }
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(JobInBuilderContextDetector.ISSUE)
+            .run()
+            .expect("""
+                src/test/test.kt:8: Error: Don't pass Job() or SupervisorJob() to coroutine builders. Use supervisorScope { } for supervisor semantics, or use the scope's Job (default behavior) [JobInBuilderContext]
+                viewModelScope.launch(Job()) {
+                ^
+            """.trimIndent())
+    }
+    
+    @Test
+    fun `detects SupervisorJob in async`() {
+        val code = """
+            package test
+            
+            import kotlinx.coroutines.*
+            import androidx.lifecycle.viewModelScope
+            
+            class MyViewModel {
+                fun test() {
+                    viewModelScope.async(SupervisorJob()) {
+                        "result"
+                    }
+                }
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(JobInBuilderContextDetector.ISSUE)
+            .run()
+            .expect("""
+                src/test/test.kt:8: Error: Don't pass Job() or SupervisorJob() to coroutine builders. Use supervisorScope { } for supervisor semantics, or use the scope's Job (default behavior) [JobInBuilderContext]
+                viewModelScope.async(SupervisorJob()) {
+                ^
+            """.trimIndent())
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/MainDispatcherMisuseDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/MainDispatcherMisuseDetectorTest.kt
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import org.junit.Test
+
+class MainDispatcherMisuseDetectorTest {
+    
+    @Test
+    fun `detects Thread sleep on Main dispatcher`() {
+        val code = """
+            package test
+            
+            import kotlinx.coroutines.*
+            import androidx.lifecycle.viewModelScope
+            
+            class MyViewModel {
+                fun test() {
+                    viewModelScope.launch(Dispatchers.Main) {
+                        Thread.sleep(1000)
+                    }
+                }
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(MainDispatcherMisuseDetector.ISSUE)
+            .run()
+            .expect("""
+                src/test/test.kt:9: Error: Blocking call on Main dispatcher. Move this to Dispatchers.IO using withContext(Dispatchers.IO) { } [MainDispatcherMisuse]
+                Thread.sleep(1000)
+                ^
+            """.trimIndent())
+    }
+    
+    @Test
+    fun `does not detect blocking call on IO dispatcher`() {
+        val code = """
+            package test
+            
+            import kotlinx.coroutines.*
+            import androidx.lifecycle.viewModelScope
+            
+            class MyViewModel {
+                fun test() {
+                    viewModelScope.launch(Dispatchers.IO) {
+                        Thread.sleep(1000)
+                    }
+                }
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(MainDispatcherMisuseDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/RunBlockingInSuspendDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/RunBlockingInSuspendDetectorTest.kt
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2024 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import org.junit.Test
+
+class RunBlockingInSuspendDetectorTest {
+    
+    @Test
+    fun `detects runBlocking in suspend function`() {
+        val code = """
+            package test
+            
+            import kotlinx.coroutines.*
+            
+            suspend fun fetchData() {
+                runBlocking {
+                    delay(1000)
+                }
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(RunBlockingInSuspendDetector.ISSUE)
+            .run()
+            .expect("""
+                src/test/test.kt:6: Error: Remove runBlocking wrapper. Inside suspend functions, use suspend calls directly or withContext(Dispatchers.IO) for blocking operations [RunBlockingInSuspend]
+                runBlocking {
+                ^
+            """.trimIndent())
+    }
+    
+    @Test
+    fun `does not detect runBlocking in non-suspend function`() {
+        val code = """
+            package test
+            
+            import kotlinx.coroutines.*
+            
+            fun main() = runBlocking {
+                delay(1000)
+            }
+        """.trimIndent()
+        
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code))
+            .issues(RunBlockingInSuspendDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,5 +5,6 @@ include(
     ":compiler",
     ":gradle-plugin",
     ":detekt-rules",
+    ":lint-rules",
     ":sample"
 )


### PR DESCRIPTION
## 📱 Fase 3: Android Lint Rules

### Objetivo

Proporcionar un conjunto completo de reglas Android Lint que permitan a los usuarios usar **solo Android Lint Rules** y tener control sobre todas las prácticas de `BEST_PRACTICES_COROUTINES.md`, similar a cómo Detekt Rules ofrece una alternativa completa al Compiler Plugin.

### Ventajas de Android Lint sobre Detekt/Compiler Plugin

- ✅ **Integración nativa con Android Studio** - Detección en tiempo real en el IDE
- ✅ **Quick fixes integrados** - Sugerencias automáticas de corrección
- ✅ **Análisis de recursos XML** - Puede detectar problemas en layouts
- ✅ **Acceso a información del manifest** - Contexto de componentes Android
- ✅ **Detección Android-específica** - Main dispatcher, ViewModel lifecycle, etc.
- ✅ **No bloquea compilación** - Warnings/Errors configurables
- ✅ **Integración CI/CD** - `./gradlew lint` en pipelines