### PR TITLE
Add Kotlin Coroutines Agent Skill

### DIFF
--- a/kotlin-coroutines-skill/.claude-plugin/plugin.json
+++ b/kotlin-coroutines-skill/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "kotlin-coroutines-skill",
+  "description": "Expert guidance for Kotlin Coroutines: structured concurrency, safe scopes, Dispatchers, cancellation, exception handling, and testing. Use when reviewing or writing Kotlin/Android async code. Includes a playbook and per-practice reference files.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Santiago Mattiauda"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/santimattius/structured-coroutines",
+  "repository": "https://github.com/santimattius/structured-coroutines"
+}

--- a/kotlin-coroutines-skill/CONFIG.json
+++ b/kotlin-coroutines-skill/CONFIG.json
@@ -1,0 +1,64 @@
+{
+  "name": "Kotlin Coroutines Agent Skill",
+  "slug": "kotlin-coroutines-skill",
+  "description": "Expert guidance for Kotlin Coroutines: structured concurrency, safe scopes, Dispatchers, cancellation, exception handling, and testing. Aligned with Kotlin 1.9/2.0+ best practices. Use when reviewing or writing Kotlin/Android async code.",
+  "version": "1.0.0",
+  "author": "Santiago Mattiauda",
+  "license": "MIT",
+  "triggers": [
+    "Kotlin Coroutines",
+    "coroutines",
+    "GlobalScope",
+    "viewModelScope",
+    "lifecycleScope",
+    "Dispatchers",
+    "runBlocking",
+    "suspend function",
+    "CancellationException",
+    "SupervisorJob",
+    "structured concurrency",
+    "kotlinx-coroutines",
+    "async/await",
+    "launch",
+    "withContext",
+    "coroutineScope",
+    "runTest",
+    "kotlinx-coroutines-test"
+  ],
+  "files": {
+    "systemPrompt": "SYSTEM_PROMPT.md",
+    "playbook": "SKILL.md",
+    "examples": "EXAMPLES_SUITE.kt",
+    "reference": "../docs/BEST_PRACTICES_COROUTINES.md",
+    "references": "references/"
+  },
+  "referenceIndex": [
+    "ref-1-1-global-scope.md",
+    "ref-1-2-async-without-await.md",
+    "ref-1-3-breaking-structured-concurrency.md",
+    "ref-2-1-launch-last-line-coroutine-scope.md",
+    "ref-2-2-runblocking-in-suspend.md",
+    "ref-3-1-blocking-wrong-dispatchers.md",
+    "ref-3-2-dispatchers-unconfined.md",
+    "ref-3-3-job-context-builders.md",
+    "ref-4-1-cancellation-intensive-loops.md",
+    "ref-4-2-swallowing-cancellation-exception.md",
+    "ref-4-3-suspend-cleanup-noncancellable.md",
+    "ref-4-4-reusing-cancelled-scope.md",
+    "ref-5-1-supervisor-job-single-builder.md",
+    "ref-5-2-cancellation-exception-domain-errors.md",
+    "ref-6-1-slow-tests-real-delays.md",
+    "ref-6-2-uncontrolled-fire-and-forget-tests.md",
+    "ref-7-1-channel-close.md",
+    "ref-7-2-consume-each-multiple-consumers.md",
+    "ref-8-architecture-patterns.md"
+  ],
+  "outputFormat": {
+    "sections": [
+      "Análisis del problema",
+      "Fragmento de código Erróneo",
+      "Fragmento de código Optimizado",
+      "Explicación técnica de la mejora"
+    ]
+  }
+}

--- a/kotlin-coroutines-skill/EXAMPLES_SUITE.kt
+++ b/kotlin-coroutines-skill/EXAMPLES_SUITE.kt
@@ -1,0 +1,86 @@
+// Package optional: use for copy-paste into agent prompts or integrate into your project.
+// import kotlinx.coroutines.*
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * EXAMPLES_SUITE.kt
+ *
+ * Three intentional anti-patterns for testing the Kotlin Coroutines Agent Skill.
+ * Each example violates best practices; the agent should suggest an optimized version
+ * following Structured Concurrency and the skill's strict rules.
+ */
+
+// =============================================================================
+// EXAMPLE 1: Memory / lifecycle leak — GlobalScope and no tied lifecycle
+// =============================================================================
+
+class UserRepositoryErroneous {
+
+    fun syncUser(userId: String) {
+        GlobalScope.launch {
+            // Simulates network call; outlives any caller (Activity/ViewModel).
+            delay(2000)
+            saveToCache(userId)
+        }
+    }
+
+    private suspend fun saveToCache(userId: String) {
+        withContext(Dispatchers.IO) {
+            // Persist user...
+        }
+    }
+}
+
+// =============================================================================
+// EXAMPLE 2: Wrong exception handling — swallowing CancellationException
+// =============================================================================
+
+class PaymentServiceErroneous {
+
+    suspend fun processPayment(amount: Double): Result<Unit> = runBlocking {
+        try {
+            withContext(Dispatchers.Default) {
+                validateAmount(amount)
+                chargePayment(amount)
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            // BAD: CancellationException is an Exception; cancellation won't propagate.
+            Result.failure(e)
+        }
+    }
+
+    private fun validateAmount(amount: Double) {}
+    private suspend fun chargePayment(amount: Double) { delay(100) }
+}
+
+// =============================================================================
+// EXAMPLE 3: Wrong Dispatchers — blocking I/O on Default / Main
+// =============================================================================
+
+class FileLoaderErroneous(
+    private val scope: CoroutineScope
+) {
+
+    fun loadConfig(path: String, onResult: (String) -> Unit) {
+        scope.launch(Dispatchers.Default) {
+            // BAD: File I/O is blocking; Default is for CPU-bound work.
+            val content = File(path).readText()
+            onResult(content)
+        }
+    }
+
+    suspend fun loadConfigSuspend(path: String): String {
+        // BAD: Blocking read on whatever dispatcher the caller uses (e.g. Main).
+        return File(path).readText()
+    }
+}

--- a/kotlin-coroutines-skill/LICENSE
+++ b/kotlin-coroutines-skill/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Santiago Mattiauda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/kotlin-coroutines-skill/README.md
+++ b/kotlin-coroutines-skill/README.md
@@ -1,0 +1,171 @@
+# Kotlin Coroutines Agent Skill
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Expert guidance for any AI coding tool that supports Agent Skills or custom instructions — **safe structured concurrency**, performance, and Kotlin 1.9/2.0+ best practices for Coroutines.
+
+Inspired by the [Swift Concurrency Agent Skill](https://github.com/AvdLee/Swift-Concurrency-Agent-Skill) model: industry-standard practices, no forced architecture. This skill helps agents give **consistent, correct** advice on Kotlin Coroutines without pushing a specific app structure.
+
+---
+
+## Why This Skill Exists
+
+- **Structured Concurrency is easy to get wrong:** `GlobalScope`, wrong Dispatchers, swallowed `CancellationException`, and misuse of `SupervisorJob` lead to leaks, ANRs, and flaky behavior. Many AI answers repeat these mistakes.
+- **One source of truth:** This skill encodes a single set of rules (scopes, dispatchers, exceptions, cancellation, testing) so that ChatGPT, Claude, Cursor, or other agents give **aligned** recommendations.
+- **Faster reviews and migrations:** Teams adopting coroutines or moving to strict structured concurrency can point their AI at this skill and get code that follows the same checklist (no GlobalScope, proper scopes, `withContext(IO)`, virtual-time tests, etc.).
+
+---
+
+## What’s Included
+
+| Asset | Description |
+|-------|-------------|
+| **SYSTEM_PROMPT.md** | Full system prompt: identity, strict rules, tone, and required output format (analysis → erroneous code → optimized code → explanation). |
+| **SKILL.md** | Playbook (triage): maps topic/error to the right reference file so the agent can jump to the relevant practice. |
+| **references/** | One markdown file per best practice (see table below). Each has Bad / Recommended / Why / Quick fix. |
+| **CONFIG.json** | Metadata for the skill: name, description, version, triggers, and reference index. |
+| **EXAMPLES_SUITE.kt** | Three Kotlin examples with intentional anti-patterns (scope leaks, exception handling, Dispatchers) for testing the agent. |
+| **.claude-plugin/** | Claude Code plugin manifest for use with Claude Code (`/plugin` or `--plugin-dir`). |
+| **skills/kotlin-coroutines/SKILL.md** | Claude Code Agent Skill entry point (playbook + rules + reference paths). |
+| **BEST_PRACTICES_COROUTINES.md** | Full guide lives in the parent repo (`docs/BEST_PRACTICES_COROUTINES.md`); this skill is derived from it. |
+
+### References (per practice)
+
+Each practice from the best-practices doc has a dedicated reference file in **references/**:
+
+| # | Topic | File |
+|---|--------|------|
+| 1.1 | GlobalScope in production | `references/ref-1-1-global-scope.md` |
+| 1.2 | async without await | `references/ref-1-2-async-without-await.md` |
+| 1.3 | Breaking structured concurrency | `references/ref-1-3-breaking-structured-concurrency.md` |
+| 2.1 | launch on last line of coroutineScope | `references/ref-2-1-launch-last-line-coroutine-scope.md` |
+| 2.2 | runBlocking inside suspend | `references/ref-2-2-runblocking-in-suspend.md` |
+| 3.1 | Blocking code with wrong Dispatchers | `references/ref-3-1-blocking-wrong-dispatchers.md` |
+| 3.2 | Dispatchers.Unconfined | `references/ref-3-2-dispatchers-unconfined.md` |
+| 3.3 | Job()/SupervisorJob() as builder context | `references/ref-3-3-job-context-builders.md` |
+| 4.1 | Cancellation in intensive loops | `references/ref-4-1-cancellation-intensive-loops.md` |
+| 4.2 | Swallowing CancellationException | `references/ref-4-2-swallowing-cancellation-exception.md` |
+| 4.3 | Suspend cleanup without NonCancellable | `references/ref-4-3-suspend-cleanup-noncancellable.md` |
+| 4.4 | Reusing cancelled scope | `references/ref-4-4-reusing-cancelled-scope.md` |
+| 5.1 | SupervisorJob in single builder | `references/ref-5-1-supervisor-job-single-builder.md` |
+| 5.2 | CancellationException for domain errors | `references/ref-5-2-cancellation-exception-domain-errors.md` |
+| 6.1 | Slow tests with real delays | `references/ref-6-1-slow-tests-real-delays.md` |
+| 6.2 | Uncontrolled fire-and-forget in tests | `references/ref-6-2-uncontrolled-fire-and-forget-tests.md` |
+| 7.1 | Channel not closed | `references/ref-7-1-channel-close.md` |
+| 7.2 | consumeEach with multiple consumers | `references/ref-7-2-consume-each-multiple-consumers.md` |
+| 8 | Architecture patterns | `references/ref-8-architecture-patterns.md` |
+
+The agent should use **SKILL.md** (playbook) to choose which reference(s) apply, then apply the strict rules from **SYSTEM_PROMPT.md** and the bad/recommended/quick-fix from the reference(s).
+
+---
+
+## Installation
+
+### Option A: ChatGPT (Custom GPTs)
+
+1. Create a new **Custom GPT** (ChatGPT Plus or Team).
+2. In **Configure** → **Instructions**, paste the full content of **SYSTEM_PROMPT.md** (from this repo).
+3. Optionally add in **Instructions** or **Knowledge**:  
+   *“When the user asks about Kotlin Coroutines, structured concurrency, GlobalScope, Dispatchers, or cancellation, follow the Kotlin Coroutines Agent system prompt and answer in the required format (analysis, erroneous code, optimized code, explanation).”*
+4. Save and name the GPT (e.g. “Kotlin Coroutines Expert”).
+
+**Quick test:** Ask: *“Why shouldn’t I use GlobalScope.launch in an Android ViewModel?”* — You should get analysis, bad snippet, good snippet, and explanation.
+
+---
+
+### Option B: Claude (Projects)
+
+1. In Claude, open **Projects** and create or select a project.
+2. Go to **Project settings** → **Custom instructions** (or the instructions field for that project).
+3. Paste the full content of **SYSTEM_PROMPT.md**.
+4. Add a short line: *“For Kotlin Coroutines questions, always use the structured output format: 1) Analysis, 2) Erroneous code, 3) Optimized code, 4) Technical explanation.”*
+5. Save.
+
+Use this project when working on Kotlin/Android codebases so Claude consistently applies the same rules.
+
+---
+
+### Option C: Cursor (Rules for AI)
+
+1. In your repo or user config, open or create the **Cursor rules** directory (e.g. `.cursor/rules/` or the path your Cursor version uses for “Rules for AI”).
+2. Create a rule file, e.g. **kotlin-coroutines-skill.mdc** or **kotlin-coroutines-skill.md**.
+3. Paste the full content of **SYSTEM_PROMPT.md** into that file.
+4. If your setup supports it, add a **globs** or **when** condition so the rule applies to Kotlin files, e.g. `**/*.kt`, or to a specific module (e.g. `**/app/**/*.kt`).
+5. Reload Cursor / rules so the new rule is active.
+
+**Verification:** Open a `.kt` file with `GlobalScope.launch { }` and ask Cursor to refactor it to follow structured concurrency; the answer should match the skill’s format and rules.
+
+---
+
+### Option D: Claude Code (Plugin)
+
+Claude Code can load this folder as a **plugin** so the Kotlin Coroutines skill (playbook + references) is available as an Agent Skill.
+
+1. **Prerequisites:** [Claude Code](https://code.claude.com/docs) installed and authenticated; version **1.0.33 or later** (run `claude --version`).
+2. **Install from a local directory (e.g. this repo):**
+   ```bash
+   claude --plugin-dir /path/to/structured-coroutines/kotlin-coroutines-skill
+   ```
+   Replace `/path/to/structured-coroutines/kotlin-coroutines-skill` with the actual path to this `kotlin-coroutines-skill` folder.
+3. After Claude Code starts, the skill **kotlin-coroutines** is loaded. Use it when working on Kotlin/Android code or when you ask about coroutines, GlobalScope, Dispatchers, cancellation, testing, or channels.
+4. **Install from a marketplace (if you publish this plugin):**  
+   See [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins). You can add a marketplace that points at this repo and then run something like:
+   ```bash
+   /plugin marketplace add owner/repo
+   /plugin install kotlin-coroutines-skill
+   ```
+5. **Verify:** Ask Claude Code to “Review this coroutine code for best practices” on a file that uses `GlobalScope.launch` or `runBlocking` in a suspend function. The response should follow the playbook, reference the relevant `references/ref-*.md`, and use the output format (Analysis → Erroneous → Optimized → Explanation).
+
+**Plugin layout:** The plugin root is `kotlin-coroutines-skill/`. It contains `.claude-plugin/plugin.json`, `skills/kotlin-coroutines/SKILL.md`, and `references/*.md`. The skill is namespaced (e.g. `kotlin-coroutines-skill:kotlin-coroutines` when listed).
+
+---
+
+## Example Prompts to Try
+
+Use these to validate that the agent is following the skill:
+
+1. **Scopes & leaks**  
+   *“Refactor this code to avoid GlobalScope and follow structured concurrency.”*  
+   (Use a snippet that uses `GlobalScope.launch` or `GlobalScope.async`.)
+
+2. **Dispatchers**  
+   *“I’m reading a file with `Dispatchers.Default`. Is that correct? Suggest an optimized version.”*
+
+3. **Exceptions**  
+   *“This catch block catches `Exception` and logs it. How should I handle CancellationException?”*
+
+4. **Format check**  
+   *“Review this coroutine code and give me: 1) Analysis, 2) Erroneous snippet, 3) Optimized snippet, 4) Explanation.”*
+
+5. **Testing**  
+   *“Replace runBlocking and real delay() in this test with kotlinx-coroutines-test and virtual time.”*
+
+---
+
+## Reference: Quick Checklist (from the skill)
+
+The agent is instructed to enforce (among others):
+
+- No `GlobalScope`; use framework or injected scopes.
+- `async` only when you need a value; otherwise `launch`.
+- No `runBlocking` inside suspend functions.
+- Blocking I/O on `Dispatchers.IO` (e.g. `withContext(Dispatchers.IO)`).
+- No `Dispatchers.Unconfined` in production.
+- No `Job()` / `SupervisorJob()` passed directly to builders; use `supervisorScope` or a scope with `SupervisorJob()`.
+- Do not swallow `CancellationException`; rethrow it in catch.
+- Suspend cleanup in `finally` inside `withContext(NonCancellable)`.
+- Tests use `runTest` and virtual time where possible.
+
+Full checklist and rationale are in **SYSTEM_PROMPT.md**, in **SKILL.md** (playbook), in the **references/** files, and in the parent repo’s **docs/BEST_PRACTICES_COROUTINES.md**.
+
+---
+
+## License
+
+MIT License. See [LICENSE](LICENSE) in this directory or the repo root.
+
+---
+
+## Contributing
+
+Improvements to the system prompt, CONFIG, or examples that stay aligned with Kotlin’s structured concurrency and the existing checklist are welcome (e.g. via pull requests to the parent **structured-coroutines** repository).

--- a/kotlin-coroutines-skill/SKILL.md
+++ b/kotlin-coroutines-skill/SKILL.md
@@ -1,0 +1,36 @@
+# Kotlin Coroutines Agent Skill — Playbook
+
+Use this playbook to route to the right reference. For any Kotlin Coroutines question or code review, **identify the topic below** and **open the linked reference file** in `references/` for the detailed rule, bad/good practice, and quick fix.
+
+## Triage: Topic → Reference
+
+| Topic / Error / Question | Reference file |
+|--------------------------|----------------|
+| **GlobalScope**, scope lifetime, “where should I launch?” | [ref-1-1-global-scope.md](references/ref-1-1-global-scope.md) |
+| **async without await**, fire-and-forget with async | [ref-1-2-async-without-await.md](references/ref-1-2-async-without-await.md) |
+| **Breaking structured concurrency**, launching in external scope from suspend | [ref-1-3-breaking-structured-concurrency.md](references/ref-1-3-breaking-structured-concurrency.md) |
+| **coroutineScope { launch { } }** as last line, “wait vs don’t wait” | [ref-2-1-launch-last-line-coroutine-scope.md](references/ref-2-1-launch-last-line-coroutine-scope.md) |
+| **runBlocking** inside suspend, blocking in coroutines | [ref-2-2-runblocking-in-suspend.md](references/ref-2-2-runblocking-in-suspend.md) |
+| **Blocking I/O on Default/Main**, wrong Dispatchers for I/O | [ref-3-1-blocking-wrong-dispatchers.md](references/ref-3-1-blocking-wrong-dispatchers.md) |
+| **Dispatchers.Unconfined** in production | [ref-3-2-dispatchers-unconfined.md](references/ref-3-2-dispatchers-unconfined.md) |
+| **Job() / SupervisorJob()** passed to launch/async/withContext | [ref-3-3-job-context-builders.md](references/ref-3-3-job-context-builders.md) |
+| **Cancellation in loops**, long loops not responding to cancel | [ref-4-1-cancellation-intensive-loops.md](references/ref-4-1-cancellation-intensive-loops.md) |
+| **Swallowing CancellationException**, catch Exception and cancel | [ref-4-2-swallowing-cancellation-exception.md](references/ref-4-2-swallowing-cancellation-exception.md) |
+| **Suspend in finally**, cleanup that needs to suspend | [ref-4-3-suspend-cleanup-noncancellable.md](references/ref-4-3-suspend-cleanup-noncancellable.md) |
+| **Reusing scope after cancel()**, cancelChildren vs cancel | [ref-4-4-reusing-cancelled-scope.md](references/ref-4-4-reusing-cancelled-scope.md) |
+| **SupervisorJob() in a single builder** | [ref-5-1-supervisor-job-single-builder.md](references/ref-5-1-supervisor-job-single-builder.md) |
+| **CancellationException for domain errors** (e.g. UserNotFound) | [ref-5-2-cancellation-exception-domain-errors.md](references/ref-5-2-cancellation-exception-domain-errors.md) |
+| **Slow tests**, real delay() in tests | [ref-6-1-slow-tests-real-delays.md](references/ref-6-1-slow-tests-real-delays.md) |
+| **Uncontrolled fire-and-forget in tests**, can’t wait in tests | [ref-6-2-uncontrolled-fire-and-forget-tests.md](references/ref-6-2-uncontrolled-fire-and-forget-tests.md) |
+| **Channel not closed**, manual Channel without close() | [ref-7-1-channel-close.md](references/ref-7-1-channel-close.md) |
+| **consumeEach with multiple consumers** | [ref-7-2-consume-each-multiple-consumers.md](references/ref-7-2-consume-each-multiple-consumers.md) |
+| **Architecture**, layers (Data/Domain/Presentation), suspend vs callbacks | [ref-8-architecture-patterns.md](references/ref-8-architecture-patterns.md) |
+
+## Agent behavior
+
+1. **Identify** the practice or error from the user’s code or question (e.g. GlobalScope, runBlocking in suspend, swallowing CancellationException).
+2. **Open** the corresponding reference from the table above (in `references/`).
+3. **Apply** the strict rules from **SYSTEM_PROMPT.md** and the **bad / recommended / quick fix** from the reference.
+4. **Respond** in the required format: Analysis → Erroneous code → Optimized code → Explanation.
+
+If several practices apply (e.g. GlobalScope + wrong Dispatchers), use each relevant reference and combine the fixes in one optimized snippet.

--- a/kotlin-coroutines-skill/SYSTEM_PROMPT.md
+++ b/kotlin-coroutines-skill/SYSTEM_PROMPT.md
@@ -1,0 +1,88 @@
+# Kotlin Coroutines Agent — System Prompt
+
+## Identity
+
+You are a **senior Kotlin engineer** specializing in **asynchronous performance** and **safe concurrency**. Your expertise covers Kotlin Coroutines, Structured Concurrency (Kotlin 1.9/2.0+), Dispatchers, cancellation, exception handling, and integration with Android/JVM (viewModelScope, lifecycleScope, etc.). You give **precise, actionable** advice and always align with **Structured Concurrency** and official Kotlin Coroutines best practices.
+
+---
+
+## Strict Rules (Mandatory)
+
+Apply these rules in every response. Do not suggest or leave code that violates them.
+
+### Scopes & Builders
+
+- **Never recommend or leave `GlobalScope`** in production code. Use framework scopes (`viewModelScope`, `lifecycleScope`, `rememberCoroutineScope`), injected scopes (`applicationScope`, `backgroundScope`), or local scopes (`coroutineScope { }`, `withContext { }`). If an external scope is required, it must be justified and documented.
+- **Use `async` only when a return value is needed.** If `await()` is never called, use `launch` instead. Do not use `async` as fire-and-forget.
+- **Preserve Structured Concurrency.** Inside suspend functions, create subtasks with `coroutineScope { }` + `async`/`launch`. Do not launch in an external scope from inside a suspend function unless the work must outlive the current flow (e.g. offline analytics), and then document it.
+
+### Blocking & runBlocking
+
+- **Never use `runBlocking` inside suspend functions or coroutine-based code.** Use it only as a bridge from blocking entry points (main, scripts, legacy APIs). Inside suspend functions use suspend APIs or `withContext(Dispatchers.IO)` for blocking work.
+- **Do not end a suspend function with `coroutineScope { launch { } }` as the last line** unless you explicitly document that you are breaking structured concurrency. Prefer executing the body directly or launching in an explicit external scope.
+
+### Dispatchers & Context
+
+- **Use explicit, appropriate Dispatchers:** `Dispatchers.Default` for CPU-bound work, `Dispatchers.Main`/`Main.immediate` for UI, `withContext(Dispatchers.IO)` (or limited parallelism) for blocking I/O. Never perform blocking I/O on `Default` or `Main`.
+- **Do not use `Dispatchers.Unconfined` in production** unless for a rare, documented special case. Prefer Default, Main, IO, or single-thread dispatchers.
+- **Never pass `Job()` or `SupervisorJob()` directly to builders** (e.g. `launch(Job()) { }`). Use the scope’s Job. For supervisor semantics use `supervisorScope { }` or a scope defined as `CoroutineScope(SupervisorJob() + dispatcher + handler)`.
+
+### Cancellation & Lifecycle
+
+- **Never swallow `CancellationException`.** In catch blocks, rethrow it: `catch (e: CancellationException) { throw e }` before handling other exceptions, or use `ensureActive()` inside catch.
+- **Do not subclass `CancellationException` for domain errors.** Use normal `Exception`/`RuntimeException` for business errors. Reserve `CancellationException` for real cancellation.
+- **In long loops or CPU-intensive suspend code,** add cooperation points: `yield()` or `ensureActive()`/`isActive` checks so cancellation is respected.
+- **For suspend calls in `finally` (e.g. DB close, remote cleanup),** wrap them in `withContext(NonCancellable) { }` so cleanup runs even when the coroutine is cancelling.
+- **Do not reuse a scope after `scope.cancel()`.** To only stop children, use `coroutineContext.job.cancelChildren()`.
+
+### Exceptions & SupervisorJob
+
+- **Use `SupervisorJob` at scope level** (e.g. `CoroutineScope(SupervisorJob() + ...)`) or `supervisorScope { }` when children must not cancel each other. Do not pass `SupervisorJob()` as an argument to a single builder.
+
+### Testing
+
+- **In tests, avoid real `delay()` with `runBlocking`.** Use `kotlinx-coroutines-test`: `runTest`, virtual time, `advanceTimeBy`, `advanceUntilIdle`, and inject `TestDispatcher`/`StandardTestDispatcher`.
+
+### Channels
+
+- **Prefer `produce { }`** so channels are closed when the coroutine ends. If using manual `Channel`, define and document when `close()` is called.
+- **Do not share `consumeEach` across multiple consumers.** Use `for (x in channel)` per consumer for fan-out.
+
+---
+
+## Tone & Style
+
+- **Technical and direct:** Use correct Kotlin and coroutines terminology (scope, job, dispatcher, structured concurrency, suspend).
+- **Educational:** Briefly explain *why* a change is better (e.g. cancellation, leaks, thread usage), not only *what* to change.
+- **Opinionated where the rules above apply:** Do not suggest alternatives that violate these rules (e.g. no “you could use GlobalScope here”).
+- **Concise:** Prefer short, clear code snippets and bullet points over long prose unless the user asks for depth.
+
+---
+
+## Output Format (Required)
+
+Structure every code-review or refactor response as follows:
+
+1. **Análisis del problema**  
+   Short description of what is wrong (e.g. scope lifetime, dispatcher, exception handling) and the risk (leaks, ANRs, flaky tests).
+
+2. **Fragmento de código "Erróneo"**  
+   The original or problematic code snippet (clearly labeled).
+
+3. **Fragmento de código "Optimizado"**  
+   Refactored code that follows the guidelines above (Structured Concurrency, correct scopes, Dispatchers, exception/cancellation handling).
+
+4. **Explicación técnica de la mejora**  
+   Why the optimized version is safer or more correct: e.g. lifecycle, cancellation propagation, thread usage, testability.
+
+If the user only asks a conceptual question (no code), you may skip the erroneous/optimized snippets and focus on analysis and explanation, but keep the same tone and rules.
+
+---
+
+## References and playbook
+
+- **Playbook:** Use **SKILL.md** (triage) to map the user’s topic or error to the right reference. Open the linked file under **references/** for the exact bad practice, recommended practice, and quick fix.
+- **Per-topic references:** Each practice from the Kotlin Coroutines Best Practices has a dedicated file in **references/** (e.g. `ref-1-1-global-scope.md`, `ref-4-2-swallowing-cancellation-exception.md`). When reviewing code or answering a question, **identify which practice(s) apply** and **use those reference files** so your answer stays aligned with the guidelines.
+- **Full checklist:** The full best-practices document (e.g. **docs/BEST_PRACTICES_COROUTINES.md** in the repo) contains the complete checklist; the references are the same content split by topic for fast lookup.
+
+When in doubt, align with the project’s **Kotlin Coroutines Best Practices** (Structured Concurrency, no GlobalScope, explicit Dispatchers, proper handling of CancellationException and SupervisorJob, and testing with virtual time). Target **Kotlin 1.9+** and **Kotlin 2.0+** conventions.

--- a/kotlin-coroutines-skill/references/ref-1-1-global-scope.md
+++ b/kotlin-coroutines-skill/references/ref-1-1-global-scope.md
@@ -1,0 +1,25 @@
+# 1.1 Using GlobalScope in Production Code
+
+## Bad Practice
+
+Launching coroutines in `GlobalScope` (e.g., `GlobalScope.launch { }` or `GlobalScope.async { }`). This breaks the coroutine tree, preventing proper cancellation and exception propagation, making it difficult to reason about job lifetimes.
+
+## Recommended
+
+Always use a meaningful `CoroutineScope`:
+
+- **Framework scopes:** `viewModelScope`, `lifecycleScope`, `rememberCoroutineScope`
+- **Injected scopes:** `applicationScope`, `backgroundScope`
+- **Local scopes in suspend functions:** `coroutineScope { }`, `withContext { }`
+
+Only launch independent processes in an external scope when absolutely necessary, and document it clearly.
+
+## Why
+
+`GlobalScope` is not bound to any parent. Work launched there is not cancelled when the caller (e.g. ViewModel, Activity) is destroyed, leading to leaks and wasted work. Structured concurrency requires a clear parent-child relationship so cancellation and exceptions propagate correctly.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `GlobalScope.launch { fetchData() }` | `viewModelScope.launch { fetchData() }` (Android) or inject `CoroutineScope` and use `scope.launch { }` |

--- a/kotlin-coroutines-skill/references/ref-1-2-async-without-await.md
+++ b/kotlin-coroutines-skill/references/ref-1-2-async-without-await.md
@@ -1,0 +1,22 @@
+# 1.2 Using async Without Calling await
+
+## Bad Practice
+
+Using `async` just to launch work without consuming the `Deferred` (e.g., `scope.async { doWork() }` without `await()`). This confuses readers and can hide exceptions inside the `Deferred`.
+
+## Recommended
+
+- Use **`launch`** for fire-and-forget work.
+- Use **`async`** only when you need a return value.
+- Simple rule: **if you never call `await`, you should use `launch`.**
+
+## Why
+
+Unconsumed `Deferred` hides failures (exceptions are only thrown when `await()` is called). Using `async` without `await` also suggests parallelism that isn’t being used and makes the code’s intent unclear.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `scope.async { doWork() }` (no await) | `scope.launch { doWork() }` |
+| When you need a result: `scope.async { doWork() }` and never await | Either `launch { doWork() }` or `async { doWork() }.await()` (or use inside `coroutineScope { async { }.await() }`) |

--- a/kotlin-coroutines-skill/references/ref-1-3-breaking-structured-concurrency.md
+++ b/kotlin-coroutines-skill/references/ref-1-3-breaking-structured-concurrency.md
@@ -1,0 +1,22 @@
+# 1.3 Breaking Structured Concurrency
+
+## Bad Practice
+
+Inside a suspend function or `coroutineScope`, launching work in an **external scope** without justification (e.g., `backgroundScope.launch { }`). This means work won’t be cancelled with the caller, complicating resource cleanup, testing, and traceability.
+
+## Recommended
+
+- Respect structured concurrency by default.
+- Inside suspend functions, create subtasks with **`coroutineScope { }`** + **`async`** / **`launch`**.
+- Only use external scopes for truly background processes that **must survive** the current flow (e.g. offline analytics, deferred cache writes), and **document it**.
+
+## Why
+
+When you launch in an external scope from inside a suspend function, the new coroutine is not a child of the current scope. The caller can finish or be cancelled while that work keeps running, leading to leaks and tests that can’t wait for completion. Structured concurrency keeps parent and children tied so cancellation and ordering are predictable.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| Inside suspend: `backgroundScope.launch { sync() }` | `coroutineScope { launch { sync() } }` so it’s a child and completes/cancels with the caller |
+| Same, when work must outlive caller | Keep external scope but add a comment: “Intentionally outlives caller for offline sync.” |

--- a/kotlin-coroutines-skill/references/ref-2-1-launch-last-line-coroutine-scope.md
+++ b/kotlin-coroutines-skill/references/ref-2-1-launch-last-line-coroutine-scope.md
@@ -1,0 +1,21 @@
+# 2.1 Using launch on the Last Line of coroutineScope
+
+## Bad Practice
+
+Ending a suspend function with **`coroutineScope { launch { } }`**. This looks like fire-and-forget, but `coroutineScope` still **waits for all children** to complete, so the function doesn’t return until that `launch` finishes.
+
+## Recommended
+
+- If you **want** the function to wait: run the body directly inside `coroutineScope` (or in the same scope) **without** wrapping in `launch`.
+- If you **don’t** want to wait: launch in an **explicit external scope** so it’s clear you’re breaking structured concurrency for that task.
+
+## Why
+
+The pattern `coroutineScope { launch { } }` is misleading: readers may think the function returns immediately, but it doesn’t. Making the choice explicit (wait vs. fire-and-forget in another scope) avoids confusion and wrong assumptions about completion and cancellation.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `suspend fun doWork() { coroutineScope { launch { heavy() } } }` (intent: wait) | `suspend fun doWork() { coroutineScope { heavy() } }` or `launch { heavy() }` inside same scope |
+| Same (intent: don’t wait) | `externalScope.launch { heavy() }` and document that it outlives the caller |

--- a/kotlin-coroutines-skill/references/ref-2-2-runblocking-in-suspend.md
+++ b/kotlin-coroutines-skill/references/ref-2-2-runblocking-in-suspend.md
@@ -1,0 +1,21 @@
+# 2.2 Using runBlocking Inside Suspend Functions
+
+## Bad Practice
+
+Calling **`runBlocking`** from coroutine-based code, especially **inside suspend functions**. This blocks the current thread, breaks the non-blocking model, and can cause deadlocks or ANRs on Android.
+
+## Recommended
+
+- Use **`runBlocking`** only as a **bridge** from purely blocking code to coroutines (e.g. `main()`, console scripts, legacy APIs that are not suspend).
+- Inside suspend functions: use **suspend APIs** or wrap blocking operations with **`withContext(Dispatchers.IO)`**.
+
+## Why
+
+`runBlocking` blocks the thread until the block completes. From inside a suspend function you’re often on a limited pool (e.g. Main or Default); blocking can freeze the UI or exhaust threads and lead to deadlocks. Suspend + `withContext(IO)` keeps the model non-blocking and avoids ANRs.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `suspend fun load() { runBlocking { delay(100) } }` | `suspend fun load() { delay(100) }` or `withContext(Dispatchers.IO) { blockingCall() }` |
+| In `main()` or test entry: `runBlocking { }` | Keep `runBlocking` only at the boundary; inside use suspend/Flow. |

--- a/kotlin-coroutines-skill/references/ref-3-1-blocking-wrong-dispatchers.md
+++ b/kotlin-coroutines-skill/references/ref-3-1-blocking-wrong-dispatchers.md
@@ -1,0 +1,23 @@
+# 3.1 Mixing Blocking Code with Wrong Dispatchers
+
+## Bad Practice
+
+Performing **blocking I/O** (files, JDBC, synchronous libraries) on **`Dispatchers.Default`** or **`Dispatchers.Main`**. This can freeze the UI or exhaust the thread pool through prolonged blocking.
+
+## Recommended
+
+- **`Dispatchers.Default`**: CPU-bound work.
+- **`Dispatchers.Main`** / **`Main.immediate`**: UI updates.
+- **`withContext(Dispatchers.IO)`** or a **limited parallelism dispatcher**: blocking I/O.
+- Prefer **suspend APIs** over wrapping synchronous APIs where possible.
+
+## Why
+
+Default and Main have a limited number of threads. Blocking them with I/O stalls other coroutines (and on Android, the UI). `Dispatchers.IO` is sized for blocking work and avoids starving the rest of the app.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `launch(Dispatchers.Default) { File(path).readText() }` | `withContext(Dispatchers.IO) { File(path).readText() }` or suspend API |
+| `Dispatchers.Main` with file/network blocking | Switch to `withContext(Dispatchers.IO) { }` for the blocking part; use Main only for UI. |

--- a/kotlin-coroutines-skill/references/ref-3-2-dispatchers-unconfined.md
+++ b/kotlin-coroutines-skill/references/ref-3-2-dispatchers-unconfined.md
@@ -1,0 +1,21 @@
+# 3.2 Abusing Dispatchers.Unconfined
+
+## Bad Practice
+
+Using **`Dispatchers.Unconfined`** in production to avoid thread switches. Code runs on whatever thread **resumes** it, making execution unpredictable and potentially running blocking calls on the UI thread.
+
+## Recommended
+
+- Reserve **`Dispatchers.Unconfined`** for **special cases** or legacy testing.
+- In production, use an explicit dispatcher: **Default**, **Main**, **IO**, single-thread, or (on JVM) a custom dispatcher or Loom.
+
+## Why
+
+Unconfined doesn’t pin the coroutine to any thread; it resumes on the thread that resumes it. That can be the Main thread, so blocking or CPU-heavy work can cause ANRs or non-deterministic behavior. Explicit dispatchers make thread usage clear and safe.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `launch(Dispatchers.Unconfined) { api.call() }` | `launch(Dispatchers.IO) { api.call() }` or `withContext(Dispatchers.Default) { }` for CPU |
+| Unconfined in tests to avoid switching | Prefer `StandardTestDispatcher` / `runTest` with virtual time. |

--- a/kotlin-coroutines-skill/references/ref-3-3-job-context-builders.md
+++ b/kotlin-coroutines-skill/references/ref-3-3-job-context-builders.md
@@ -1,0 +1,23 @@
+# 3.3 Passing Job() Directly as Context to Builders
+
+## Bad Practice
+
+Using **`launch(Job()) { }`** or **`withContext(SupervisorJob()) { }`** to control errors. This **breaks the parent-child relationship** and structured concurrency: the new Job becomes an independent parent.
+
+## Recommended
+
+- Let builders use the **Job from the current scope** so the coroutine tree stays intact.
+- For supervisor semantics:
+  - Inside suspend functions: **`supervisorScope { }`**.
+  - At scope level: **`CoroutineScope(SupervisorJob() + dispatcher + handler)`** (do not pass that Job into individual builders).
+
+## Why
+
+Passing a new `Job()` or `SupervisorJob()` into `launch`/`async`/`withContext` makes that job the parent of the new coroutine, not the scope’s job. The scope no longer waits for or cancels this work, and exception behavior becomes inconsistent. Supervisor semantics should be at the scope (or `supervisorScope`) level, not per builder.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `launch(Job()) { }` | `launch { }` (use scope’s job) |
+| `launch(SupervisorJob()) { }` | `supervisorScope { launch { } }` or use a scope created with `SupervisorJob()` and then `scope.launch { }`. |

--- a/kotlin-coroutines-skill/references/ref-4-1-cancellation-intensive-loops.md
+++ b/kotlin-coroutines-skill/references/ref-4-1-cancellation-intensive-loops.md
@@ -1,0 +1,21 @@
+# 4.1 Ignoring Cancellation in Intensive Loops
+
+## Bad Practice
+
+Long loops or heavy computation **without suspension points or cancellation checks**. The coroutine won’t respond to cancellation until the calculation finishes or a delay occurs.
+
+## Recommended
+
+- Add **cooperation points**: **`yield()`** periodically in CPU-intensive suspend functions, or **`coroutineContext.isActive`** / **`ensureActive()`** in loops.
+- For blocking code, use an appropriate dispatcher and cancellable APIs where available.
+
+## Why
+
+Coroutine cancellation is cooperative. If the coroutine never suspends and doesn’t check `isActive`, it will keep running until the end. That can block shutdown or waste resources when the user or parent has already requested cancellation.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `while (true) { heavyComputation() }` in a coroutine | `while (isActive) { heavyComputation(); yield() }` or `ensureActive()` in the loop |
+| Large list processing without checks | Add `yield()` or `ensureActive()` every N iterations. |

--- a/kotlin-coroutines-skill/references/ref-4-2-swallowing-cancellation-exception.md
+++ b/kotlin-coroutines-skill/references/ref-4-2-swallowing-cancellation-exception.md
@@ -1,0 +1,21 @@
+# 4.2 Swallowing CancellationException
+
+## Bad Practice
+
+Catching **`Exception`** and treating **`CancellationException`** like any other error. This prevents cancellation from propagating and can leave coroutines alive when they should terminate.
+
+## Recommended
+
+- Treat **`CancellationException`** separately: **`catch (e: CancellationException) { throw e }`** (rethrow) **before** catching other exceptions.
+- Alternative: call **`ensureActive()`** inside catch blocks so that if the coroutine is cancelled, it rethrows.
+
+## Why
+
+`CancellationException` is how cancellation is propagated. If you catch it and don’t rethrow, the coroutine won’t cancel and the parent may assume it has stopped. Always rethrow so cancellation continues to propagate.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `catch (e: Exception) { log(e); Result.failure(e) }` | `catch (e: CancellationException) { throw e }; catch (e: Exception) { log(e); Result.failure(e) }` |
+| `catch (e: Throwable) { ... }` without rethrowing cancellation | Add a dedicated `catch (e: CancellationException) { throw e }` first. |

--- a/kotlin-coroutines-skill/references/ref-4-3-suspend-cleanup-noncancellable.md
+++ b/kotlin-coroutines-skill/references/ref-4-3-suspend-cleanup-noncancellable.md
@@ -1,0 +1,20 @@
+# 4.3 Suspendable Cleanup Without NonCancellable
+
+## Bad Practice
+
+Making **suspend calls in `finally` blocks** (e.g. DB writes, closing remote sessions) **without `withContext(NonCancellable)`**. If the coroutine is cancelling, any suspension can throw `CancellationException` again and cleanup may not run.
+
+## Recommended
+
+For critical cleanup that **must suspend**, wrap the suspend calls in **`withContext(NonCancellable) { }`** inside `finally`.
+
+## Why
+
+When a coroutine is cancelled, further suspend points throw `CancellationException`. A `finally` block that calls `delay()` or other suspend functions can throw before the rest of the cleanup runs. `NonCancellable` allows that block to run to completion despite cancellation.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `finally { db.close() }` where `close()` is suspend | `finally { withContext(NonCancellable) { db.close() } }` |
+| `finally { sendLogToServer() }` (suspend) | `finally { withContext(NonCancellable) { sendLogToServer() } }` |

--- a/kotlin-coroutines-skill/references/ref-4-4-reusing-cancelled-scope.md
+++ b/kotlin-coroutines-skill/references/ref-4-4-reusing-cancelled-scope.md
@@ -1,0 +1,21 @@
+# 4.4 Reusing a Cancelled CoroutineScope
+
+## Bad Practice
+
+Calling **`scope.cancel()`** and then trying to **launch more coroutines** in that scope. A cancelled Job doesn’t accept new children, and subsequent launches **fail silently** (or behave unpredictably).
+
+## Recommended
+
+- To **stop children but keep the scope usable**: use **`coroutineContext.job.cancelChildren()`**.
+- **Cancel the scope’s Job** only when the scope will **no longer be reused**.
+
+## Why
+
+After `scope.cancel()`, the scope’s Job is in a terminal state. New `launch`/`async` calls on that scope are either ignored or immediately cancelled. If you need to reuse the scope (e.g. for retries or a new flow), cancel only the children, not the scope itself.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `scope.cancel(); scope.launch { newWork() }` | Don’t cancel the scope if you need to launch again; use `scope.coroutineContext.job.cancelChildren()` to stop current work only. |
+| One-off scope that should stop all work | `scope.cancel()` is correct; do not launch again on that scope. |

--- a/kotlin-coroutines-skill/references/ref-5-1-supervisor-job-single-builder.md
+++ b/kotlin-coroutines-skill/references/ref-5-1-supervisor-job-single-builder.md
@@ -1,0 +1,20 @@
+# 5.1 Using SupervisorJob as an Argument in a Single Builder
+
+## Bad Practice
+
+Passing **`SupervisorJob()`** to protect a single coroutine: **`launch(SupervisorJob()) { }`**. The SupervisorJob becomes the parent of that coroutine, but the **real parent** (the scope’s Job) still uses a normal Job and can be cancelled when a sibling fails, so the intent is unclear and behavior is wrong.
+
+## Recommended
+
+- Use **SupervisorJob at the scope level**: **`CoroutineScope(SupervisorJob() + dispatcher + handler)`** so that **children** don’t cancel each other.
+- Inside a suspend function, use **`supervisorScope { }`** when you want children to fail independently.
+
+## Why
+
+SupervisorJob is meant to define a scope where child failures don’t cancel the scope or siblings. Passing it into a single `launch` doesn’t create that scope; it only changes the immediate parent of that one coroutine and can break the existing scope hierarchy. Apply supervisor semantics at the scope (or `supervisorScope`) level.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `scope.launch(SupervisorJob()) { }` | Create a scope with `SupervisorJob()` once: `CoroutineScope(SupervisorJob() + Dispatchers.Default)` and use `scope.launch { }`. Or use `supervisorScope { launch { } }` inside a suspend function. |

--- a/kotlin-coroutines-skill/references/ref-5-2-cancellation-exception-domain-errors.md
+++ b/kotlin-coroutines-skill/references/ref-5-2-cancellation-exception-domain-errors.md
@@ -1,0 +1,21 @@
+# 5.2 Extending CancellationException for Domain Errors
+
+## Bad Practice
+
+Defining **domain errors** that inherit from **`CancellationException`** (e.g. `class UserNotFoundException : CancellationException()`). These exceptions **don’t propagate upward** like normal exceptions; they only cancel the current coroutine and children, so callers can’t handle them as business errors.
+
+## Recommended
+
+- Use normal **`Exception`** or **`RuntimeException`** (or your own domain hierarchy) for **domain/business errors**.
+- Reserve **`CancellationException`** for **true cancellation** (user cancel, timeout, scope cancelled) only.
+
+## Why
+
+`CancellationException` is treated specially by the coroutines runtime: it’s used to propagate cancellation and is often not logged or propagated as a “failure”. If you use it for “user not found” or similar, callers won’t see it as a regular error and handling (e.g. UI messages, retries) becomes inconsistent.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `class UserNotFoundException : CancellationException()` | `class UserNotFoundException : RuntimeException()` or `Exception()` |
+| `throw CancellationException()` for “no data” | Use a dedicated domain exception (e.g. `NoDataException`) that does not extend `CancellationException`. |

--- a/kotlin-coroutines-skill/references/ref-6-1-slow-tests-real-delays.md
+++ b/kotlin-coroutines-skill/references/ref-6-1-slow-tests-real-delays.md
@@ -1,0 +1,21 @@
+# 6.1 Slow Tests with Real Delays
+
+## Bad Practice
+
+Tests using **`runBlocking`** + real **`delay()`** to simulate network or backoff. This makes tests **slow**, **fragile**, and **machine-dependent**.
+
+## Recommended
+
+- Use **`kotlinx-coroutines-test`**: **`runTest { }`** with **virtual time**, **`advanceTimeBy`**, **`advanceUntilIdle`**, **`runCurrent`**.
+- Inject **dispatchers** and replace them with **`StandardTestDispatcher`** (or **`UnconfinedTestDispatcher`** where appropriate) in tests.
+
+## Why
+
+Real delays make tests take seconds or minutes and can flake under load. Virtual time lets the test control “time” so delays complete instantly from the test’s perspective, giving fast, deterministic tests.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `runBlocking { delay(5000); doSomething() }` in test | `runTest { delay(5000); doSomething() }; advanceUntilIdle()` (or `advanceTimeBy(5000)`) so delay is virtual |
+| Production code using `Dispatchers.Main`/`IO` without injection | Inject `CoroutineDispatcher` and in tests use `StandardTestDispatcher`; in `runTest` time is virtual. |

--- a/kotlin-coroutines-skill/references/ref-6-2-uncontrolled-fire-and-forget-tests.md
+++ b/kotlin-coroutines-skill/references/ref-6-2-uncontrolled-fire-and-forget-tests.md
@@ -1,0 +1,21 @@
+# 6.2 Uncontrolled Fire-and-Forget Coroutines in Tests
+
+## Bad Practice
+
+Classes that **launch work in external scopes** (e.g. GlobalScope or an injected “background” scope) **without a way to control them in tests**. You can’t wait for completion or manipulate time, so tests become flaky or slow.
+
+## Recommended
+
+- **Inject `CoroutineScope`** (or a factory) so tests can pass a **`TestScope`** or a scope that shares the **`TestCoroutineScheduler`** with **`runTest`**.
+- Use **`backgroundScope`** from **`runTest`** when you need parallel processes under the same virtual time.
+
+## Why
+
+If production code uses a hard-coded or global scope, tests can’t advance virtual time for that work or wait for it to finish. Injecting the scope allows tests to use `runTest` and `TestScope` so all coroutines are driven by the same scheduler and tests stay deterministic and fast.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| Class uses `GlobalScope.launch { }` | Inject `CoroutineScope` (e.g. `applicationScope`); in tests inject `runTest { backgroundScope }` or a scope with `StandardTestDispatcher`. |
+| Test can’t wait for “background” work | Ensure the scope used for that work is the test scope or shares its scheduler so `advanceUntilIdle()` or `runCurrent()` runs it. |

--- a/kotlin-coroutines-skill/references/ref-7-1-channel-close.md
+++ b/kotlin-coroutines-skill/references/ref-7-1-channel-close.md
@@ -1,0 +1,21 @@
+# 7.1 Forgetting to Close Manual Channels
+
+## Bad Practice
+
+Creating a **`Channel`** manually and **never calling `close()`**. Consumers that use **`for (x in channel)`** will **block forever** when the producer stops sending.
+
+## Recommended
+
+- Prefer the **`produce { }`** builder, which **closes the channel automatically** when the coroutine terminates.
+- If you manage channels manually, **define clearly** when and where **`close()`** is called (e.g. when producer is done or on error).
+
+## Why
+
+An open channel keeps consumers waiting for the next element. If the producer stops without closing, consumers never complete. `produce` ties the channel’s lifetime to the coroutine, so when the block finishes (or is cancelled), the channel is closed and consumers can finish.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| `val ch = Channel<Int>(); launch { repeat(10) { ch.send(it) } }; for (x in ch) { }` (consumer blocks) | Use `produce { repeat(10) { send(it) } }` and iterate, or call `ch.close()` after the last `send`. |
+| Manual channel in a function | Document: “Caller must close when done” or use `produce` so closing is automatic. |

--- a/kotlin-coroutines-skill/references/ref-7-2-consume-each-multiple-consumers.md
+++ b/kotlin-coroutines-skill/references/ref-7-2-consume-each-multiple-consumers.md
@@ -1,0 +1,21 @@
+# 7.2 Sharing consumeEach Among Multiple Consumers
+
+## Bad Practice
+
+Using **`consumeEach`** from **multiple coroutines** on the same channel. **`consumeEach`** consumes the channel (it’s a single-consumer API) and cancels/closes the channel when the block finishes, **breaking other consumers**.
+
+## Recommended
+
+- For **fan-out** (multiple consumers): use **`for (value in channel)`** in **each** consumer so they share the channel without one consumer “taking” it exclusively.
+- Reserve **`consumeEach`** for **single-consumer** scenarios only.
+
+## Why
+
+`consumeEach` runs a block for each element until the channel is closed; it’s intended for one consumer. Using it from several coroutines leads to concurrent consumption of the same channel, which is not supported for regular channels, and to one consumer closing or cancelling the channel for everyone else.
+
+## Quick fix
+
+| Erroneous | Optimized |
+|-----------|-----------|
+| Two coroutines both calling `channel.consumeEach { }` | Each consumer uses `for (value in channel) { ... }` (or use a broadcast channel / flow if you need true fan-out semantics). |
+| Single consumer | `consumeEach` is fine. |

--- a/kotlin-coroutines-skill/references/ref-8-architecture-patterns.md
+++ b/kotlin-coroutines-skill/references/ref-8-architecture-patterns.md
@@ -1,0 +1,23 @@
+# 8. Architecture Patterns
+
+## General Recommendations
+
+| Pattern | Description |
+|--------|-------------|
+| **Favor suspend and Flow APIs** | Prefer suspend functions and Flow over callbacks, `Future`, or Rx. Use `suspendCancellableCoroutine` for well-made, cancellable bridges to callback-based APIs. |
+| **Maintain structured concurrency** | Use clear scopes, parent/child hierarchy, `coroutineScope` in domain functions, and `SupervisorJob` only where decoupling failures makes sense. |
+| **Separate responsibilities by layer** | **Data:** repositories with encapsulated suspend APIs. **Domain:** orchestration with `coroutineScope` + `async` for controlled concurrency. **Presentation:** launch in UI scopes (e.g. `viewModelScope`, `lifecycleScope`) so work is cancelled with the lifecycle. |
+| **Test coroutines properly** | Use virtual time and controlled scopes (`runTest`, `TestDispatcher`, injected scope) instead of real delays and global scopes. |
+
+## Layer summary
+
+- **Data:** Expose suspend/Flow; no raw `GlobalScope` or unstructured launches.
+- **Domain:** Use `coroutineScope` and `async`/`launch` for parallelism; avoid launching in external scopes unless documented.
+- **Presentation:** Use `viewModelScope` / `lifecycleScope` / `rememberCoroutineScope` so cancellation is automatic when the screen or ViewModel is destroyed.
+
+## Related references
+
+- Scopes and structured concurrency: ref-1-1, ref-1-3
+- Dispatchers and blocking: ref-3-1, ref-3-2
+- Exceptions and SupervisorJob: ref-4-2, ref-5-1, ref-5-2
+- Testing: ref-6-1, ref-6-2

--- a/kotlin-coroutines-skill/skills/kotlin-coroutines/SKILL.md
+++ b/kotlin-coroutines-skill/skills/kotlin-coroutines/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: kotlin-coroutines
+description: Expert guidance for Kotlin Coroutines and structured concurrency. Use when reviewing or writing Kotlin/Android async code, or when the user asks about GlobalScope, Dispatchers, runBlocking, CancellationException, SupervisorJob, testing with runTest, or channels.
+---
+
+# Kotlin Coroutines Agent Skill
+
+You are a senior Kotlin engineer focused on asynchronous performance and safe concurrency. Follow the rules below and use the **playbook** to route to the right **reference file** in this plugin's `references/` directory (paths like `references/ref-1-1-global-scope.md`).
+
+## Strict rules (mandatory)
+
+- **No GlobalScope** in production. Use framework scopes (viewModelScope, lifecycleScope, rememberCoroutineScope), injected scopes, or local coroutineScope/withContext.
+- **Use async only when you need a return value.** If you never call await(), use launch.
+- **Preserve structured concurrency.** Inside suspend functions use coroutineScope { } + async/launch; do not launch in an external scope unless work must outlive the caller (and document it).
+- **Never runBlocking inside suspend functions.** Use withContext(Dispatchers.IO) or suspend APIs for blocking work.
+- **Use correct Dispatchers:** Default for CPU, Main for UI, withContext(Dispatchers.IO) for blocking I/O. No Dispatchers.Unconfined in production.
+- **Never pass Job() or SupervisorJob() to builders.** Use supervisorScope { } or a scope created with SupervisorJob() at scope level.
+- **Never swallow CancellationException.** Rethrow it before catching other exceptions. Do not subclass CancellationException for domain errors.
+- **Long loops:** add yield() or ensureActive(). **Suspend in finally:** use withContext(NonCancellable). **Do not reuse a scope after scope.cancel();** use cancelChildren() if you need to keep launching.
+- **Tests:** use runTest and virtual time; inject CoroutineScope/TestDispatcher for control.
+- **Channels:** prefer produce { }; if manual, document when close() is called. Do not share consumeEach across multiple consumers.
+
+## Output format (required for code review/refactor)
+
+1. **Análisis del problema** — What is wrong and the risk.
+2. **Fragmento de código "Erróneo"** — The problematic snippet.
+3. **Fragmento de código "Optimizado"** — Refactored code following the rules above.
+4. **Explicación técnica de la mejora** — Why the optimized version is safer or correct.
+
+## Playbook: topic → reference file
+
+Use this table to open the right reference in `references/` (e.g. `references/ref-1-1-global-scope.md`).
+
+| Topic | Reference file |
+|-------|----------------|
+| GlobalScope, scope lifetime | references/ref-1-1-global-scope.md |
+| async without await | references/ref-1-2-async-without-await.md |
+| Breaking structured concurrency | references/ref-1-3-breaking-structured-concurrency.md |
+| coroutineScope { launch { } } last line | references/ref-2-1-launch-last-line-coroutine-scope.md |
+| runBlocking inside suspend | references/ref-2-2-runblocking-in-suspend.md |
+| Blocking I/O on Default/Main | references/ref-3-1-blocking-wrong-dispatchers.md |
+| Dispatchers.Unconfined | references/ref-3-2-dispatchers-unconfined.md |
+| Job()/SupervisorJob() passed to builders | references/ref-3-3-job-context-builders.md |
+| Cancellation in intensive loops | references/ref-4-1-cancellation-intensive-loops.md |
+| Swallowing CancellationException | references/ref-4-2-swallowing-cancellation-exception.md |
+| Suspend in finally (cleanup) | references/ref-4-3-suspend-cleanup-noncancellable.md |
+| Reusing scope after cancel() | references/ref-4-4-reusing-cancelled-scope.md |
+| SupervisorJob() in single builder | references/ref-5-1-supervisor-job-single-builder.md |
+| CancellationException for domain errors | references/ref-5-2-cancellation-exception-domain-errors.md |
+| Slow tests, real delay() | references/ref-6-1-slow-tests-real-delays.md |
+| Uncontrolled fire-and-forget in tests | references/ref-6-2-uncontrolled-fire-and-forget-tests.md |
+| Channel not closed | references/ref-7-1-channel-close.md |
+| consumeEach multiple consumers | references/ref-7-2-consume-each-multiple-consumers.md |
+| Architecture (Data/Domain/Presentation) | references/ref-8-architecture-patterns.md |
+
+## Behavior
+
+1. Identify which practice(s) or error(s) apply from the user's code or question.
+2. Open the corresponding reference file(s) from the table above (in the plugin's `references/` directory).
+3. Apply the bad/recommended/quick-fix from the reference and the strict rules above.
+4. Respond in the required format (Analysis → Erroneous → Optimized → Explanation). If multiple practices apply, combine fixes in one optimized snippet.
+
+Target Kotlin 1.9+ and 2.0+ and official Kotlin Coroutines best practices.


### PR DESCRIPTION
Introduce a new kotlin-coroutines-skill package providing an agent skill for Kotlin Coroutines. Adds plugin manifest (.claude-plugin/plugin.json), CONFIG.json, SKILL.md (playbook), SYSTEM_PROMPT.md (strict rules and output format), README, LICENSE, example suite (EXAMPLES_SUITE.kt), and a comprehensive set of per-topic reference files covering structured concurrency, scopes, dispatchers, cancellation, exception handling, testing, channels, and supervisor semantics. This enables consistent, rule-driven guidance for reviewing or refactoring Kotlin/Android coroutine code.