### PR TITLE
Add plugin check task and use project version

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -34,3 +34,10 @@ mavenPublishing {
         version = project.version.toString()
     )
 }
+
+// Custom task that runs all checks for the Gradle plugin
+tasks.register("structuredCoroutinesCheck") {
+    group = "verification"
+    description = "Runs all checks for the Gradle plugin (validatePlugins + test) and validates execution in sample"
+    dependsOn(tasks.validatePlugins, tasks.test)
+}

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -9,11 +9,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
-    
+
     compilerOptions {
         // Enable the structured coroutines compiler plugin
         freeCompilerArgs.addAll(
-            "-Xplugin=${project(":compiler").layout.buildDirectory.get().asFile}/libs/compiler-0.1.0.jar"
+            "-Xplugin=${project(":compiler").layout.buildDirectory.get().asFile}/libs/compiler-${project.version}.jar"
         )
     }
 }


### PR DESCRIPTION
Add a structuredCoroutinesCheck verification task to the Gradle plugin project that depends on validatePlugins and test and groups these checks for convenience. Update the sample build to reference the compiler JAR using project.version (compiler-${project.version}.jar) instead of a hardcoded 0.1.0 filename so the sample uses the current compiler artifact.