### PR TITLE
feat: v0.8.0 iter1 foundation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ---
 
+## [0.8.0] — 2026-05-11
+
+### Added
+
+- **INTEROP_001** `SuspendCoroutineWithoutCancellation` — Compiler (FIR), Detekt, IntelliJ: detects `suspendCoroutine` usage which does not support coroutine cancellation. Use `suspendCancellableCoroutine` instead.
+- **INTEROP_002** `CallbackFlowWithoutAwaitClose` — Compiler (FIR), Detekt, IntelliJ: detects `callbackFlow { }` without `awaitClose { }`, which causes `IllegalStateException` at runtime (kotlinx-coroutines >= 1.6) and leaks listeners.
+- **FLOW_010** `MutableFlowExposed` — Detekt, IntelliJ: detects `MutableStateFlow`/`MutableSharedFlow` exposed as public. Use backing property with `asStateFlow()`/`asSharedFlow()`.
+- **FLOW_005** `MissingCatchInFlow` — Detekt, Android Lint, IntelliJ: detects Flow chains missing a `.catch {}` operator before the terminal operator.
+- **CONCUR_003** `SequentialAsyncAwait` — Detekt, IntelliJ: detects `async { }.await()` patterns that are equivalent to `withContext` but create unnecessary overhead without parallelism.
+- **TEST_004** `RunBlockingInsteadOfRunTest` — Detekt, Android Lint, IntelliJ: detects `runBlocking` in test functions. Use `runTest` from `kotlinx-coroutines-test` for virtual time control.
+- **COMPOSE_001** `CollectAsStateWithoutLifecycle` — Android Lint, IntelliJ: detects `collectAsState()` in Composables; use `collectAsStateWithLifecycle()` for lifecycle-aware collection.
+- **KMP_001** `DispatchersIOInCommonMain` — Detekt, Android Lint: detects `Dispatchers.IO` usage in `commonMain` source sets, which crashes on iOS/JS.
+- Annotations: `@IoDispatcher`, `@MainDispatcher`, `@DefaultDispatcher` qualifier annotations in `:annotations` module.
+- Gradle plugin: `useAndroidComposeProfile()` and `useKmpCommonProfile()` extension functions.
+- Version catalog: `kotlinx-coroutines-test` and `lifecycle-runtime-compose` library coordinates.
+- `docs/BEST_PRACTICES_COROUTINES.md`: new sections §6.4, §9.5, §9.6, §10 (Interoperability), §11 (Kotlin Multiplatform).
+- `sample-detekt`: seven new fixture files covering all six Detekt-backed rules from this iteration.
+
+---
+
 ## [0.7.0] — 2026-04-07
 
 ### Changed — Compiler
@@ -227,6 +247,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ---
 
+[0.8.0]: https://github.com/santimattius/structured-coroutines/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/santimattius/structured-coroutines/compare/0.6.1...0.7.0
 [0.6.1]: https://github.com/santimattius/structured-coroutines/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/santimattius/structured-coroutines/compare/0.5.0...0.6.0

--- a/annotations/README.md
+++ b/annotations/README.md
@@ -1,6 +1,7 @@
 # Annotations for Structured Coroutines
 
-Multiplatform annotations for marking structured coroutine scopes.
+Multiplatform annotations for structured concurrency: marking coroutine scopes and qualifying
+dispatcher dependencies for testable code.
 
 ## Installation
 
@@ -55,6 +56,113 @@ class Repository {
     }
 }
 ```
+
+---
+
+## Dispatcher Qualifier Annotations
+
+Use these annotations to qualify `CoroutineDispatcher` dependencies so production code stays
+decoupled from concrete dispatchers and test code can substitute an unconfined or test dispatcher.
+
+### @IoDispatcher
+
+Qualifies a dispatcher intended for blocking I/O work (maps to `Dispatchers.IO` in production).
+
+```kotlin
+import io.github.santimattius.structured.annotations.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class UserRepository(
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    suspend fun fetchUser(id: String): User = withContext(ioDispatcher) {
+        api.getUser(id)
+    }
+}
+```
+
+### @MainDispatcher
+
+Qualifies a dispatcher bound to the UI / main thread (maps to `Dispatchers.Main` in production).
+
+```kotlin
+import io.github.santimattius.structured.annotations.MainDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+
+class UiViewModel(
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher
+) { /* ... */ }
+```
+
+### @DefaultDispatcher
+
+Qualifies a dispatcher for CPU-bound default work (maps to `Dispatchers.Default` in production).
+
+```kotlin
+import io.github.santimattius.structured.annotations.DefaultDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+
+class ImageProcessor(
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher
+) { /* ... */ }
+```
+
+### Testing with dispatcher qualifiers
+
+Inject `UnconfinedTestDispatcher` (or `StandardTestDispatcher`) in tests so suspending code runs
+predictably without the real dispatcher:
+
+```kotlin
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlin.test.Test
+
+class UserRepositoryTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val repository = UserRepository(ioDispatcher = testDispatcher)
+
+    @Test
+    fun `fetchUser returns expected user`() = runTest(testDispatcher) {
+        val user = repository.fetchUser("42")
+        // assert ...
+    }
+}
+```
+
+### DI wiring example (Hilt / Koin)
+
+The annotations work with any DI framework. Example with Hilt:
+
+```kotlin
+// Module
+@Module @InstallIn(SingletonComponent::class)
+object DispatcherModule {
+    @Provides @IoDispatcher
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Provides @MainDispatcher
+    fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+
+    @Provides @DefaultDispatcher
+    fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+}
+```
+
+### Annotation targets and retention
+
+All three qualifier annotations share the same configuration:
+
+| Target | Supported |
+|--------|-----------|
+| Value parameter | ✅ |
+| Field / property | ✅ |
+| Function | ✅ |
+
+**Retention:** `BINARY` — present in the compiled `.class` / `.klib` for DI frameworks but not
+available at runtime reflection.
+
+---
 
 ## Supported Platforms
 

--- a/annotations/src/commonMain/kotlin/io/github/santimattius/structured/annotations/DispatcherQualifiers.kt
+++ b/annotations/src/commonMain/kotlin/io/github/santimattius/structured/annotations/DispatcherQualifiers.kt
@@ -1,0 +1,36 @@
+package io.github.santimattius.structured.annotations
+
+/**
+ * Qualifies a [kotlinx.coroutines.CoroutineDispatcher] intended for blocking I/O work.
+ * Use with dependency injection so production code uses [kotlinx.coroutines.Dispatchers.IO]
+ * and tests can substitute an unconfined or test dispatcher.
+ */
+@Target(
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.FUNCTION,
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
+
+/**
+ * Qualifies a [kotlinx.coroutines.CoroutineDispatcher] bound to the UI / main thread.
+ */
+@Target(
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.FUNCTION,
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class MainDispatcher
+
+/**
+ * Qualifies a [kotlinx.coroutines.CoroutineDispatcher] for CPU-bound default work.
+ */
+@Target(
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.FUNCTION,
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDispatcher

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     compileOnly(libs.kotlin.compiler.embeddable)
 
     // Test dependencies - using Gradle TestKit for functional testing
+    testImplementation(libs.kotlin.compiler.embeddable)
     testImplementation(libs.kotlin.test)
     testImplementation(gradleTestKit())
 }

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/CallbackFlowWithoutAwaitCloseChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/CallbackFlowWithoutAwaitCloseChecker.kt
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
+import org.jetbrains.kotlin.fir.expressions.FirAnonymousFunctionExpression
+import org.jetbrains.kotlin.fir.expressions.FirBlock
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirStatement
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * FIR check for [INTEROP_002]: `callbackFlow { }` must call `awaitClose { }`
+ * inside the lambda (kotlinx.coroutines API contract).
+ *
+ * Does not apply to `channelFlow`.
+ */
+class CallbackFlowWithoutAwaitCloseChecker : FirFunctionCallChecker(MppCheckerKind.Common) {
+
+    companion object {
+        private val CALLBACK_FLOW = Name.identifier("callbackFlow")
+        private val CHANNEL_FLOW = Name.identifier("channelFlow")
+        private val AWAIT_CLOSE = Name.identifier("awaitClose")
+    }
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(expression: FirFunctionCall) {
+        val callee = expression.calleeReference.name
+        if (callee == CHANNEL_FLOW) return
+        if (callee != CALLBACK_FLOW) return
+
+        val lambdaBlock = getTrailingLambdaBlock(expression) ?: return
+
+        if (blockContainsAwaitClose(lambdaBlock)) return
+
+        reporter.reportCallbackFlowWithoutAwaitClose(expression, context)
+    }
+
+    /** Trailing lambda of `callbackFlow { }`: [FirBlock] or body of anonymous function. */
+    private fun getTrailingLambdaBlock(call: FirFunctionCall): FirBlock? {
+        val last = call.argumentList.arguments.lastOrNull() ?: return null
+        (last as? FirBlock)?.let { return it }
+        return (last as? FirAnonymousFunctionExpression)?.anonymousFunction?.body as? FirBlock
+    }
+
+    private fun blockContainsAwaitClose(block: FirBlock): Boolean =
+        block.statements.any { statementContainsAwaitClose(it) }
+
+    private fun statementContainsAwaitClose(statement: FirStatement): Boolean {
+        when (statement) {
+            is FirFunctionCall -> {
+                if (statement.calleeReference.name == AWAIT_CLOSE) return true
+                return statement.argumentList.arguments.any { arg ->
+                    subtreeMayContainAwaitClose(arg)
+                }
+            }
+            is FirBlock -> return blockContainsAwaitClose(statement)
+            else -> {
+                return false
+            }
+        }
+    }
+
+    private fun subtreeMayContainAwaitClose(expr: FirExpression): Boolean {
+        return when (expr) {
+            is FirFunctionCall -> {
+                if (expr.calleeReference.name == AWAIT_CLOSE) return true
+                expr.argumentList.arguments.any { subtreeMayContainAwaitClose(it) }
+            }
+            is FirBlock -> blockContainsAwaitClose(expr)
+            is FirAnonymousFunctionExpression ->
+                expr.anonymousFunction.body?.let { body ->
+                    (body as? FirBlock)?.let { blockContainsAwaitClose(it) } == true
+                } == true
+            else -> false
+        }
+    }
+}

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/PluginConfiguration.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/PluginConfiguration.kt
@@ -10,51 +10,145 @@
 package io.github.santimattius.structured.compiler
 
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.diagnostics.Severity
 
 /**
  * Configuration for the Structured Coroutines compiler plugin.
  *
- * Options are stored in [CompilerConfiguration] as a single [Map]<[String],[String]> under
- * [OPTIONS_KEY]. A [CommandLineProcessor] (or a test) populates that map before constructing
- * this class. Values are `"error"` or `"warning"` (case-insensitive); anything else falls
- * back to the default severity for that rule.
+ * This class reads configuration options from [CompilerConfiguration] and provides
+ * severity levels for each rule. Rules can be configured to report as ERROR or WARNING.
+ *
+ * ## Configuration Keys
+ *
+ * Configuration is passed via compiler plugin options with keys:
+ * - `globalScopeUsage`
+ * - `inlineCoroutineScope`
+ * - `unstructuredLaunch`
+ * - `runBlockingInSuspend`
+ * - `jobInBuilderContext`
+ * - `dispatchersUnconfined`
+ * - `cancellationExceptionSubclass`
+ * - `suspendInFinally`
+ * - `cancellationExceptionSwallowed`
+ * - `unusedDeferred`
+ * - `redundantLaunchInCoroutineScope`
+ * - `suspendCoroutineWithoutCancellation`
+ * - `callbackFlowWithoutAwaitClose`
+ *
+ * Values can be `"error"` or `"warning"` (case-insensitive).
+ *
+ * ## Default Severities
+ *
+ * - Most rules default to ERROR
+ * - Some rules default to WARNING (e.g., `dispatchersUnconfined`, `suspendInFinally`)
  */
 class PluginConfiguration(configuration: CompilerConfiguration) {
+    
+    /**
+     * Severity for GlobalScope usage rule.
+     */
+    val globalScopeUsage: Severity = getSeverity(configuration, "globalScopeUsage", Severity.ERROR)
+    
+    /**
+     * Severity for inline CoroutineScope creation rule.
+     */
+    val inlineCoroutineScope: Severity = getSeverity(configuration, "inlineCoroutineScope", Severity.ERROR)
+    
+    /**
+     * Severity for unstructured launch rule.
+     */
+    val unstructuredLaunch: Severity = getSeverity(configuration, "unstructuredLaunch", Severity.ERROR)
+    
+    /**
+     * Severity for runBlocking in suspend functions rule.
+     */
+    val runBlockingInSuspend: Severity = getSeverity(configuration, "runBlockingInSuspend", Severity.ERROR)
+    
+    /**
+     * Severity for Job()/SupervisorJob() in builder context rule.
+     */
+    val jobInBuilderContext: Severity = getSeverity(configuration, "jobInBuilderContext", Severity.ERROR)
+    
+    /**
+     * Severity for Dispatchers.Unconfined usage rule.
+     */
+    val dispatchersUnconfined: Severity = getSeverity(configuration, "dispatchersUnconfined", Severity.WARNING)
+    
+    /**
+     * Severity for CancellationException subclass rule.
+     */
+    val cancellationExceptionSubclass: Severity = getSeverity(configuration, "cancellationExceptionSubclass", Severity.ERROR)
+    
+    /**
+     * Severity for suspend calls in finally without NonCancellable rule.
+     */
+    val suspendInFinally: Severity = getSeverity(configuration, "suspendInFinally", Severity.WARNING)
+    
+    /**
+     * Severity for catch(Exception) swallowing CancellationException rule.
+     */
+    val cancellationExceptionSwallowed: Severity = getSeverity(configuration, "cancellationExceptionSwallowed", Severity.WARNING)
+    
+    /**
+     * Severity for unused Deferred (async without await) rule.
+     */
+    val unusedDeferred: Severity = getSeverity(configuration, "unusedDeferred", Severity.ERROR)
+    
+    /**
+     * Severity for redundant launch in coroutineScope rule.
+     */
+    val redundantLaunchInCoroutineScope: Severity = getSeverity(configuration, "redundantLaunchInCoroutineScope", Severity.WARNING)
+    
+    /**
+     * Severity for loop in suspend function without cooperation point rule (4.1).
+     */
+    val loopWithoutYield: Severity = getSeverity(configuration, "loopWithoutYield", Severity.WARNING)
 
-    companion object {
-        /**
-         * Single static key used to store all plugin option key→value pairs in
-         * [CompilerConfiguration]. Using one key avoids the [CompilerConfigurationKey]
-         * reference-equality trap (the class does not override equals/hashCode, so two
-         * [CompilerConfigurationKey.create] calls with the same name produce unequal keys).
-         */
-        val OPTIONS_KEY: CompilerConfigurationKey<Map<String, String>> =
-            CompilerConfigurationKey.create("io.github.santimattius.structured-coroutines.options")
-    }
+    /**
+     * Severity for `suspendCoroutine` without cancellation support (INTEROP_001).
+     */
+    val suspendCoroutineWithoutCancellation: Severity =
+        getSeverity(configuration, "suspendCoroutineWithoutCancellation", Severity.ERROR)
 
-    private val options: Map<String, String> = configuration.get(OPTIONS_KEY) ?: emptyMap()
-
-    val globalScopeUsage: Severity = getSeverity("globalScopeUsage", Severity.ERROR)
-    val inlineCoroutineScope: Severity = getSeverity("inlineCoroutineScope", Severity.ERROR)
-    val unstructuredLaunch: Severity = getSeverity("unstructuredLaunch", Severity.ERROR)
-    val runBlockingInSuspend: Severity = getSeverity("runBlockingInSuspend", Severity.ERROR)
-    val jobInBuilderContext: Severity = getSeverity("jobInBuilderContext", Severity.ERROR)
-    val dispatchersUnconfined: Severity = getSeverity("dispatchersUnconfined", Severity.WARNING)
-    val cancellationExceptionSubclass: Severity = getSeverity("cancellationExceptionSubclass", Severity.ERROR)
-    val suspendInFinally: Severity = getSeverity("suspendInFinally", Severity.WARNING)
-    val cancellationExceptionSwallowed: Severity = getSeverity("cancellationExceptionSwallowed", Severity.WARNING)
-    val unusedDeferred: Severity = getSeverity("unusedDeferred", Severity.ERROR)
-    val redundantLaunchInCoroutineScope: Severity = getSeverity("redundantLaunchInCoroutineScope", Severity.WARNING)
-    val loopWithoutYield: Severity = getSeverity("loopWithoutYield", Severity.WARNING)
-    val suspendCoroutineWithoutCancellation: Severity = getSeverity("suspendCoroutineWithoutCancellation", Severity.ERROR)
-    val callbackFlowWithoutAwaitClose: Severity = getSeverity("callbackFlowWithoutAwaitClose", Severity.ERROR)
-
-    private fun getSeverity(key: String, defaultSeverity: Severity): Severity =
-        when (options[key]?.lowercase()) {
+    /**
+     * Severity for `callbackFlow` without `awaitClose` (INTEROP_002).
+     */
+    val callbackFlowWithoutAwaitClose: Severity =
+        getSeverity(configuration, "callbackFlowWithoutAwaitClose", Severity.ERROR)
+    
+    /**
+     * Reads a severity option from compiler configuration.
+     *
+     * Compiler plugin options are passed via SubpluginOption and are stored
+     * in the configuration with the format: "plugin:pluginId:key" -> value
+     *
+     * @param configuration The compiler configuration
+     * @param key The configuration key (without plugin prefix)
+     * @param defaultSeverity The default severity if not configured
+     * @return The configured severity or default
+     */
+    private fun getSeverity(
+        configuration: CompilerConfiguration,
+        key: String,
+        defaultSeverity: Severity
+    ): Severity {
+        // SubpluginOption values are stored with the format: "plugin:pluginId:key"
+        val pluginId = "io.github.santimattius.structured-coroutines"
+        val fullKey = "plugin:$pluginId:$key"
+        
+        // Try to get the option value from configuration
+        // Options are stored as strings
+        val optionValue = try {
+            val configKey = org.jetbrains.kotlin.config.CompilerConfigurationKey.create<String>(fullKey)
+            configuration.get(configKey)
+        } catch (e: Exception) {
+            null
+        } ?: return defaultSeverity
+        
+        return when (optionValue.lowercase()) {
             "error" -> Severity.ERROR
             "warning" -> Severity.WARNING
             else -> defaultSeverity
         }
+    }
 }

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/PluginConfiguration.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/PluginConfiguration.kt
@@ -10,145 +10,51 @@
 package io.github.santimattius.structured.compiler
 
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.diagnostics.Severity
 
 /**
  * Configuration for the Structured Coroutines compiler plugin.
  *
- * This class reads configuration options from [CompilerConfiguration] and provides
- * severity levels for each rule. Rules can be configured to report as ERROR or WARNING.
- *
- * ## Configuration Keys
- *
- * Configuration is passed via compiler plugin options with keys:
- * - `globalScopeUsage`
- * - `inlineCoroutineScope`
- * - `unstructuredLaunch`
- * - `runBlockingInSuspend`
- * - `jobInBuilderContext`
- * - `dispatchersUnconfined`
- * - `cancellationExceptionSubclass`
- * - `suspendInFinally`
- * - `cancellationExceptionSwallowed`
- * - `unusedDeferred`
- * - `redundantLaunchInCoroutineScope`
- * - `suspendCoroutineWithoutCancellation`
- * - `callbackFlowWithoutAwaitClose`
- *
- * Values can be `"error"` or `"warning"` (case-insensitive).
- *
- * ## Default Severities
- *
- * - Most rules default to ERROR
- * - Some rules default to WARNING (e.g., `dispatchersUnconfined`, `suspendInFinally`)
+ * Options are stored in [CompilerConfiguration] as a single [Map]<[String],[String]> under
+ * [OPTIONS_KEY]. A [CommandLineProcessor] (or a test) populates that map before constructing
+ * this class. Values are `"error"` or `"warning"` (case-insensitive); anything else falls
+ * back to the default severity for that rule.
  */
 class PluginConfiguration(configuration: CompilerConfiguration) {
-    
-    /**
-     * Severity for GlobalScope usage rule.
-     */
-    val globalScopeUsage: Severity = getSeverity(configuration, "globalScopeUsage", Severity.ERROR)
-    
-    /**
-     * Severity for inline CoroutineScope creation rule.
-     */
-    val inlineCoroutineScope: Severity = getSeverity(configuration, "inlineCoroutineScope", Severity.ERROR)
-    
-    /**
-     * Severity for unstructured launch rule.
-     */
-    val unstructuredLaunch: Severity = getSeverity(configuration, "unstructuredLaunch", Severity.ERROR)
-    
-    /**
-     * Severity for runBlocking in suspend functions rule.
-     */
-    val runBlockingInSuspend: Severity = getSeverity(configuration, "runBlockingInSuspend", Severity.ERROR)
-    
-    /**
-     * Severity for Job()/SupervisorJob() in builder context rule.
-     */
-    val jobInBuilderContext: Severity = getSeverity(configuration, "jobInBuilderContext", Severity.ERROR)
-    
-    /**
-     * Severity for Dispatchers.Unconfined usage rule.
-     */
-    val dispatchersUnconfined: Severity = getSeverity(configuration, "dispatchersUnconfined", Severity.WARNING)
-    
-    /**
-     * Severity for CancellationException subclass rule.
-     */
-    val cancellationExceptionSubclass: Severity = getSeverity(configuration, "cancellationExceptionSubclass", Severity.ERROR)
-    
-    /**
-     * Severity for suspend calls in finally without NonCancellable rule.
-     */
-    val suspendInFinally: Severity = getSeverity(configuration, "suspendInFinally", Severity.WARNING)
-    
-    /**
-     * Severity for catch(Exception) swallowing CancellationException rule.
-     */
-    val cancellationExceptionSwallowed: Severity = getSeverity(configuration, "cancellationExceptionSwallowed", Severity.WARNING)
-    
-    /**
-     * Severity for unused Deferred (async without await) rule.
-     */
-    val unusedDeferred: Severity = getSeverity(configuration, "unusedDeferred", Severity.ERROR)
-    
-    /**
-     * Severity for redundant launch in coroutineScope rule.
-     */
-    val redundantLaunchInCoroutineScope: Severity = getSeverity(configuration, "redundantLaunchInCoroutineScope", Severity.WARNING)
-    
-    /**
-     * Severity for loop in suspend function without cooperation point rule (4.1).
-     */
-    val loopWithoutYield: Severity = getSeverity(configuration, "loopWithoutYield", Severity.WARNING)
 
-    /**
-     * Severity for `suspendCoroutine` without cancellation support (INTEROP_001).
-     */
-    val suspendCoroutineWithoutCancellation: Severity =
-        getSeverity(configuration, "suspendCoroutineWithoutCancellation", Severity.ERROR)
+    companion object {
+        /**
+         * Single static key used to store all plugin option key→value pairs in
+         * [CompilerConfiguration]. Using one key avoids the [CompilerConfigurationKey]
+         * reference-equality trap (the class does not override equals/hashCode, so two
+         * [CompilerConfigurationKey.create] calls with the same name produce unequal keys).
+         */
+        val OPTIONS_KEY: CompilerConfigurationKey<Map<String, String>> =
+            CompilerConfigurationKey.create("io.github.santimattius.structured-coroutines.options")
+    }
 
-    /**
-     * Severity for `callbackFlow` without `awaitClose` (INTEROP_002).
-     */
-    val callbackFlowWithoutAwaitClose: Severity =
-        getSeverity(configuration, "callbackFlowWithoutAwaitClose", Severity.ERROR)
-    
-    /**
-     * Reads a severity option from compiler configuration.
-     *
-     * Compiler plugin options are passed via SubpluginOption and are stored
-     * in the configuration with the format: "plugin:pluginId:key" -> value
-     *
-     * @param configuration The compiler configuration
-     * @param key The configuration key (without plugin prefix)
-     * @param defaultSeverity The default severity if not configured
-     * @return The configured severity or default
-     */
-    private fun getSeverity(
-        configuration: CompilerConfiguration,
-        key: String,
-        defaultSeverity: Severity
-    ): Severity {
-        // SubpluginOption values are stored with the format: "plugin:pluginId:key"
-        val pluginId = "io.github.santimattius.structured-coroutines"
-        val fullKey = "plugin:$pluginId:$key"
-        
-        // Try to get the option value from configuration
-        // Options are stored as strings
-        val optionValue = try {
-            val configKey = org.jetbrains.kotlin.config.CompilerConfigurationKey.create<String>(fullKey)
-            configuration.get(configKey)
-        } catch (e: Exception) {
-            null
-        } ?: return defaultSeverity
-        
-        return when (optionValue.lowercase()) {
+    private val options: Map<String, String> = configuration.get(OPTIONS_KEY) ?: emptyMap()
+
+    val globalScopeUsage: Severity = getSeverity("globalScopeUsage", Severity.ERROR)
+    val inlineCoroutineScope: Severity = getSeverity("inlineCoroutineScope", Severity.ERROR)
+    val unstructuredLaunch: Severity = getSeverity("unstructuredLaunch", Severity.ERROR)
+    val runBlockingInSuspend: Severity = getSeverity("runBlockingInSuspend", Severity.ERROR)
+    val jobInBuilderContext: Severity = getSeverity("jobInBuilderContext", Severity.ERROR)
+    val dispatchersUnconfined: Severity = getSeverity("dispatchersUnconfined", Severity.WARNING)
+    val cancellationExceptionSubclass: Severity = getSeverity("cancellationExceptionSubclass", Severity.ERROR)
+    val suspendInFinally: Severity = getSeverity("suspendInFinally", Severity.WARNING)
+    val cancellationExceptionSwallowed: Severity = getSeverity("cancellationExceptionSwallowed", Severity.WARNING)
+    val unusedDeferred: Severity = getSeverity("unusedDeferred", Severity.ERROR)
+    val redundantLaunchInCoroutineScope: Severity = getSeverity("redundantLaunchInCoroutineScope", Severity.WARNING)
+    val loopWithoutYield: Severity = getSeverity("loopWithoutYield", Severity.WARNING)
+    val suspendCoroutineWithoutCancellation: Severity = getSeverity("suspendCoroutineWithoutCancellation", Severity.ERROR)
+    val callbackFlowWithoutAwaitClose: Severity = getSeverity("callbackFlowWithoutAwaitClose", Severity.ERROR)
+
+    private fun getSeverity(key: String, defaultSeverity: Severity): Severity =
+        when (options[key]?.lowercase()) {
             "error" -> Severity.ERROR
             "warning" -> Severity.WARNING
             else -> defaultSeverity
         }
-    }
 }

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/PluginConfiguration.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/PluginConfiguration.kt
@@ -32,6 +32,8 @@ import org.jetbrains.kotlin.diagnostics.Severity
  * - `cancellationExceptionSwallowed`
  * - `unusedDeferred`
  * - `redundantLaunchInCoroutineScope`
+ * - `suspendCoroutineWithoutCancellation`
+ * - `callbackFlowWithoutAwaitClose`
  *
  * Values can be `"error"` or `"warning"` (case-insensitive).
  *
@@ -101,6 +103,18 @@ class PluginConfiguration(configuration: CompilerConfiguration) {
      * Severity for loop in suspend function without cooperation point rule (4.1).
      */
     val loopWithoutYield: Severity = getSeverity(configuration, "loopWithoutYield", Severity.WARNING)
+
+    /**
+     * Severity for `suspendCoroutine` without cancellation support (INTEROP_001).
+     */
+    val suspendCoroutineWithoutCancellation: Severity =
+        getSeverity(configuration, "suspendCoroutineWithoutCancellation", Severity.ERROR)
+
+    /**
+     * Severity for `callbackFlow` without `awaitClose` (INTEROP_002).
+     */
+    val callbackFlowWithoutAwaitClose: Severity =
+        getSeverity(configuration, "callbackFlowWithoutAwaitClose", Severity.ERROR)
     
     /**
      * Reads a severity option from compiler configuration.

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/PluginConfiguration.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/PluginConfiguration.kt
@@ -10,145 +10,53 @@
 package io.github.santimattius.structured.compiler
 
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.diagnostics.Severity
 
 /**
  * Configuration for the Structured Coroutines compiler plugin.
  *
- * This class reads configuration options from [CompilerConfiguration] and provides
- * severity levels for each rule. Rules can be configured to report as ERROR or WARNING.
+ * Options are stored in [CompilerConfiguration] as a single [Map]<[String],[String]> under
+ * [OPTIONS_KEY]. A [CommandLineProcessor] (or a test) populates that map before constructing
+ * this class. Values are `"error"` or `"warning"` (case-insensitive); anything else falls
+ * back to the default severity for that rule.
  *
- * ## Configuration Keys
- *
- * Configuration is passed via compiler plugin options with keys:
- * - `globalScopeUsage`
- * - `inlineCoroutineScope`
- * - `unstructuredLaunch`
- * - `runBlockingInSuspend`
- * - `jobInBuilderContext`
- * - `dispatchersUnconfined`
- * - `cancellationExceptionSubclass`
- * - `suspendInFinally`
- * - `cancellationExceptionSwallowed`
- * - `unusedDeferred`
- * - `redundantLaunchInCoroutineScope`
- * - `suspendCoroutineWithoutCancellation`
- * - `callbackFlowWithoutAwaitClose`
- *
- * Values can be `"error"` or `"warning"` (case-insensitive).
- *
- * ## Default Severities
- *
- * - Most rules default to ERROR
- * - Some rules default to WARNING (e.g., `dispatchersUnconfined`, `suspendInFinally`)
+ * Using a single map key avoids the [CompilerConfigurationKey] reference-equality trap:
+ * [CompilerConfigurationKey.create] does not override equals/hashCode, so two calls with
+ * the same string produce unequal keys and `configuration.get` always returns null.
  */
 class PluginConfiguration(configuration: CompilerConfiguration) {
-    
-    /**
-     * Severity for GlobalScope usage rule.
-     */
-    val globalScopeUsage: Severity = getSeverity(configuration, "globalScopeUsage", Severity.ERROR)
-    
-    /**
-     * Severity for inline CoroutineScope creation rule.
-     */
-    val inlineCoroutineScope: Severity = getSeverity(configuration, "inlineCoroutineScope", Severity.ERROR)
-    
-    /**
-     * Severity for unstructured launch rule.
-     */
-    val unstructuredLaunch: Severity = getSeverity(configuration, "unstructuredLaunch", Severity.ERROR)
-    
-    /**
-     * Severity for runBlocking in suspend functions rule.
-     */
-    val runBlockingInSuspend: Severity = getSeverity(configuration, "runBlockingInSuspend", Severity.ERROR)
-    
-    /**
-     * Severity for Job()/SupervisorJob() in builder context rule.
-     */
-    val jobInBuilderContext: Severity = getSeverity(configuration, "jobInBuilderContext", Severity.ERROR)
-    
-    /**
-     * Severity for Dispatchers.Unconfined usage rule.
-     */
-    val dispatchersUnconfined: Severity = getSeverity(configuration, "dispatchersUnconfined", Severity.WARNING)
-    
-    /**
-     * Severity for CancellationException subclass rule.
-     */
-    val cancellationExceptionSubclass: Severity = getSeverity(configuration, "cancellationExceptionSubclass", Severity.ERROR)
-    
-    /**
-     * Severity for suspend calls in finally without NonCancellable rule.
-     */
-    val suspendInFinally: Severity = getSeverity(configuration, "suspendInFinally", Severity.WARNING)
-    
-    /**
-     * Severity for catch(Exception) swallowing CancellationException rule.
-     */
-    val cancellationExceptionSwallowed: Severity = getSeverity(configuration, "cancellationExceptionSwallowed", Severity.WARNING)
-    
-    /**
-     * Severity for unused Deferred (async without await) rule.
-     */
-    val unusedDeferred: Severity = getSeverity(configuration, "unusedDeferred", Severity.ERROR)
-    
-    /**
-     * Severity for redundant launch in coroutineScope rule.
-     */
-    val redundantLaunchInCoroutineScope: Severity = getSeverity(configuration, "redundantLaunchInCoroutineScope", Severity.WARNING)
-    
-    /**
-     * Severity for loop in suspend function without cooperation point rule (4.1).
-     */
-    val loopWithoutYield: Severity = getSeverity(configuration, "loopWithoutYield", Severity.WARNING)
 
-    /**
-     * Severity for `suspendCoroutine` without cancellation support (INTEROP_001).
-     */
-    val suspendCoroutineWithoutCancellation: Severity =
-        getSeverity(configuration, "suspendCoroutineWithoutCancellation", Severity.ERROR)
+    companion object {
+        /**
+         * Single static key used to store all plugin option key→value pairs in
+         * [CompilerConfiguration].
+         */
+        val OPTIONS_KEY: CompilerConfigurationKey<Map<String, String>> =
+            CompilerConfigurationKey.create("io.github.santimattius.structured-coroutines.options")
+    }
 
-    /**
-     * Severity for `callbackFlow` without `awaitClose` (INTEROP_002).
-     */
-    val callbackFlowWithoutAwaitClose: Severity =
-        getSeverity(configuration, "callbackFlowWithoutAwaitClose", Severity.ERROR)
-    
-    /**
-     * Reads a severity option from compiler configuration.
-     *
-     * Compiler plugin options are passed via SubpluginOption and are stored
-     * in the configuration with the format: "plugin:pluginId:key" -> value
-     *
-     * @param configuration The compiler configuration
-     * @param key The configuration key (without plugin prefix)
-     * @param defaultSeverity The default severity if not configured
-     * @return The configured severity or default
-     */
-    private fun getSeverity(
-        configuration: CompilerConfiguration,
-        key: String,
-        defaultSeverity: Severity
-    ): Severity {
-        // SubpluginOption values are stored with the format: "plugin:pluginId:key"
-        val pluginId = "io.github.santimattius.structured-coroutines"
-        val fullKey = "plugin:$pluginId:$key"
-        
-        // Try to get the option value from configuration
-        // Options are stored as strings
-        val optionValue = try {
-            val configKey = org.jetbrains.kotlin.config.CompilerConfigurationKey.create<String>(fullKey)
-            configuration.get(configKey)
-        } catch (e: Exception) {
-            null
-        } ?: return defaultSeverity
-        
-        return when (optionValue.lowercase()) {
+    private val options: Map<String, String> = configuration.get(OPTIONS_KEY) ?: emptyMap()
+
+    val globalScopeUsage: Severity = getSeverity("globalScopeUsage", Severity.ERROR)
+    val inlineCoroutineScope: Severity = getSeverity("inlineCoroutineScope", Severity.ERROR)
+    val unstructuredLaunch: Severity = getSeverity("unstructuredLaunch", Severity.ERROR)
+    val runBlockingInSuspend: Severity = getSeverity("runBlockingInSuspend", Severity.ERROR)
+    val jobInBuilderContext: Severity = getSeverity("jobInBuilderContext", Severity.ERROR)
+    val dispatchersUnconfined: Severity = getSeverity("dispatchersUnconfined", Severity.WARNING)
+    val cancellationExceptionSubclass: Severity = getSeverity("cancellationExceptionSubclass", Severity.ERROR)
+    val suspendInFinally: Severity = getSeverity("suspendInFinally", Severity.WARNING)
+    val cancellationExceptionSwallowed: Severity = getSeverity("cancellationExceptionSwallowed", Severity.WARNING)
+    val unusedDeferred: Severity = getSeverity("unusedDeferred", Severity.ERROR)
+    val redundantLaunchInCoroutineScope: Severity = getSeverity("redundantLaunchInCoroutineScope", Severity.WARNING)
+    val loopWithoutYield: Severity = getSeverity("loopWithoutYield", Severity.WARNING)
+    val suspendCoroutineWithoutCancellation: Severity = getSeverity("suspendCoroutineWithoutCancellation", Severity.ERROR)
+    val callbackFlowWithoutAwaitClose: Severity = getSeverity("callbackFlowWithoutAwaitClose", Severity.ERROR)
+
+    private fun getSeverity(key: String, defaultSeverity: Severity): Severity =
+        when (options[key]?.lowercase()) {
             "error" -> Severity.ERROR
             "warning" -> Severity.WARNING
             else -> defaultSeverity
         }
-    }
 }

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/ScoroutinesCallCheckerExtension.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/ScoroutinesCallCheckerExtension.kt
@@ -99,7 +99,10 @@ class ScoroutinesCallCheckerExtension(session: FirSession) : FirAdditionalChecke
             // Rule 10: async without await (Best Practice 1.2)
             UnusedDeferredChecker(),
             // Rule 11: redundant launch in coroutineScope (Best Practice 2.1)
-            RedundantLaunchInCoroutineScopeChecker()
+            RedundantLaunchInCoroutineScopeChecker(),
+            // INTEROP (v0.8.0)
+            SuspendCoroutineWithoutCancellationChecker(),
+            CallbackFlowWithoutAwaitCloseChecker(),
         )
 
         /**

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesErrors.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesErrors.kt
@@ -51,6 +51,8 @@ object StructuredCoroutinesErrorRenderer : BaseDiagnosticRendererFactory() {
         MAP.put(StructuredCoroutinesErrors.UNUSED_DEFERRED, CompilerMessages.message("UNUSED_DEFERRED"))
         MAP.put(StructuredCoroutinesErrors.REDUNDANT_LAUNCH_IN_COROUTINE_SCOPE, CompilerMessages.message("REDUNDANT_LAUNCH_IN_COROUTINE_SCOPE"))
         MAP.put(StructuredCoroutinesErrors.LOOP_WITHOUT_YIELD, CompilerMessages.message("LOOP_WITHOUT_YIELD"))
+        MAP.put(StructuredCoroutinesErrors.SUSPEND_COROUTINE_WITHOUT_CANCELLATION, CompilerMessages.message("SUSPEND_COROUTINE_WITHOUT_CANCELLATION"))
+        MAP.put(StructuredCoroutinesErrors.CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE, CompilerMessages.message("CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE"))
     }
 }
 
@@ -250,6 +252,24 @@ object StructuredCoroutinesErrors {
         rendererFactory = StructuredCoroutinesErrorRenderer
     )
 
+    /** INTEROP_001 — `suspendCoroutine` does not propagate cancellation (use suspendCancellableCoroutine). */
+    val SUSPEND_COROUTINE_WITHOUT_CANCELLATION: KtDiagnosticFactory0 = KtDiagnosticFactory0(
+        name = "SUSPEND_COROUTINE_WITHOUT_CANCELLATION",
+        severity = Severity.ERROR,
+        defaultPositioningStrategy = SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
+        psiType = KtElement::class,
+        rendererFactory = StructuredCoroutinesErrorRenderer
+    )
+
+    /** INTEROP_002 — `callbackFlow` must include `awaitClose` for lifecycle cleanup. */
+    val CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE: KtDiagnosticFactory0 = KtDiagnosticFactory0(
+        name = "CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE",
+        severity = Severity.ERROR,
+        defaultPositioningStrategy = SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
+        psiType = KtElement::class,
+        rendererFactory = StructuredCoroutinesErrorRenderer
+    )
+
     init {
         // Register error messages after factories are created
         StructuredCoroutinesErrorRenderer.registerMessages()
@@ -366,6 +386,16 @@ fun DiagnosticReporter.reportLoopWithoutYield(
     context: CheckerContext
 ) {
     reportOn(expression.source, StructuredCoroutinesErrors.LOOP_WITHOUT_YIELD, context)
+}
+
+/** INTEROP_001 — report suspendCoroutine usage in suspend contexts. */
+fun DiagnosticReporter.reportSuspendCoroutineWithoutCancellation(call: FirCall, context: CheckerContext) {
+    reportOn(call.source, StructuredCoroutinesErrors.SUSPEND_COROUTINE_WITHOUT_CANCELLATION, context)
+}
+
+/** INTEROP_002 — report callbackFlow without awaitClose. */
+fun DiagnosticReporter.reportCallbackFlowWithoutAwaitClose(call: FirCall, context: CheckerContext) {
+    reportOn(call.source, StructuredCoroutinesErrors.CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE, context)
 }
 
 // ============================================================

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/SuspendCoroutineWithoutCancellationChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/SuspendCoroutineWithoutCancellationChecker.kt
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * FIR check for [INTEROP_001]: `suspendCoroutine { }` in suspend functions —
+ * cancellation is not propagated; prefer `suspendCancellableCoroutine`.
+ */
+class SuspendCoroutineWithoutCancellationChecker : FirFunctionCallChecker(MppCheckerKind.Common) {
+
+    companion object {
+        private val SUSPEND_COROUTINE = Name.identifier("suspendCoroutine")
+    }
+
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(expression: FirFunctionCall) {
+        val name = expression.calleeReference.name
+        if (name != SUSPEND_COROUTINE) return
+        if (!isInsideSuspendFunction(context)) return
+
+        reporter.reportSuspendCoroutineWithoutCancellation(expression, context)
+    }
+
+    @OptIn(SymbolInternals::class)
+    private fun isInsideSuspendFunction(context: CheckerContext): Boolean {
+        for (element in context.containingDeclarations) {
+            val declaration = element.fir
+            if (declaration is FirNamedFunction && declaration.status.isSuspend) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/compiler/src/main/resources/messages/CompilerBundle.properties
+++ b/compiler/src/main/resources/messages/CompilerBundle.properties
@@ -27,3 +27,7 @@ UNUSED_DEFERRED=[SCOPE_002] async call creates a Deferred that is never awaited.
 REDUNDANT_LAUNCH_IN_COROUTINE_SCOPE=[RUNBLOCK_001] coroutineScope contains only a single launch, which is redundant. If you want the function to wait for the work, execute it directly without launch. If you don't want to wait, use an explicit external scope to make it clear you're breaking structured concurrency. See: {0}#21-runblock_001--using-launch-on-the-last-line-of-coroutinescope
 
 LOOP_WITHOUT_YIELD=[CANCEL_001] Loop in suspend function without cooperation point. The coroutine cannot be cancelled until the loop completes. Inside a scope builder (launch/async/coroutineScope/supervisorScope/withContext) use ensureActive(); otherwise use currentCoroutineContext().ensureActive(), yield(), or delay() inside the loop. See: {0}#41-cancel_001--ignoring-cancellation-in-intensive-loops
+
+SUSPEND_COROUTINE_WITHOUT_CANCELLATION=[INTEROP_001] \'suspendCoroutine\' does not support cancellation from the parent. Use \'suspendCancellableCoroutine\' and \'invokeOnCancellation\' to unregister callbacks and release resources. See: {0}#101-interop_001--wrapping-callbacks-without-cancellation-support
+
+CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE=[INTEROP_002] \'callbackFlow\' must call \'awaitClose\' to unregister listeners when the collector cancels or completes. Omitting awaitClose causes runtime failures and leaking listeners. See: {0}#102-interop_002--callbackflow-without-awaitclose

--- a/compiler/src/main/resources/messages/CompilerBundle_es.properties
+++ b/compiler/src/main/resources/messages/CompilerBundle_es.properties
@@ -27,3 +27,7 @@ UNUSED_DEFERRED=[SCOPE_002] async crea un Deferred que no se espera. Puede ocult
 REDUNDANT_LAUNCH_IN_COROUTINE_SCOPE=[RUNBLOCK_001] coroutineScope contiene solo un launch, lo cual es redundante. Si quiere esperar al trabajo, ejec\u00fatelo directamente sin launch. Si no quiere esperar, use un scope externo expl\u00edcito. Ver: {0}#21-runblock_001--using-launch-on-the-last-line-of-coroutinescope
 
 LOOP_WITHOUT_YIELD=[CANCEL_001] Bucle en funci\u00f3n suspend sin punto de cooperaci\u00f3n. La corrutina no puede cancelarse hasta que termine el bucle. Dentro de un scope builder (launch/async/coroutineScope/supervisorScope/withContext) use ensureActive(); en caso contrario use currentCoroutineContext().ensureActive(), yield() o delay() dentro del bucle. Ver: {0}#41-cancel_001--ignoring-cancellation-in-intensive-loops
+
+SUSPEND_COROUTINE_WITHOUT_CANCELLATION=[INTEROP_001] \'suspendCoroutine\' no admite cancelaci\u00f3n del padre. Use \'suspendCancellableCoroutine\' e \'invokeOnCancellation\' para desregistrar callbacks y liberar recursos. Ver: {0}#101-interop_001--wrapping-callbacks-without-cancellation-support
+
+CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE=[INTEROP_002] En \'callbackFlow\' debe llamar a \'awaitClose\' para dar de baja listeners al cancelarse o completarse el collector. Sin awaitClose puede fallar en runtime y haber fugas. Ver: {0}#102-interop_002--callbackflow-without-awaitclose

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/PluginConfigurationInteropOptionsTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/PluginConfigurationInteropOptionsTest.kt
@@ -1,11 +1,15 @@
 package io.github.santimattius.structured.compiler
 
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.diagnostics.Severity
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class PluginConfigurationInteropOptionsTest {
+
+    private fun pluginKey(shortKey: String): String =
+        "plugin:io.github.santimattius.structured-coroutines:$shortKey"
 
     @Test
     fun `suspendCoroutineWithoutCancellation defaults to ERROR`() {
@@ -25,11 +29,12 @@ class PluginConfigurationInteropOptionsTest {
     fun `interop severities honor compiler plugin options`() {
         val cfg = CompilerConfiguration()
         cfg.put(
-            PluginConfiguration.OPTIONS_KEY,
-            mapOf(
-                "suspendCoroutineWithoutCancellation" to "warning",
-                "callbackFlowWithoutAwaitClose" to "warning",
-            ),
+            CompilerConfigurationKey.create(pluginKey("suspendCoroutineWithoutCancellation")),
+            "warning",
+        )
+        cfg.put(
+            CompilerConfigurationKey.create(pluginKey("callbackFlowWithoutAwaitClose")),
+            "warning",
         )
         val pc = PluginConfiguration(cfg)
         assertEquals(Severity.WARNING, pc.suspendCoroutineWithoutCancellation)

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/PluginConfigurationInteropOptionsTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/PluginConfigurationInteropOptionsTest.kt
@@ -1,0 +1,43 @@
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
+import org.jetbrains.kotlin.diagnostics.Severity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PluginConfigurationInteropOptionsTest {
+
+    private fun pluginKey(shortKey: String): String =
+        "plugin:io.github.santimattius.structured-coroutines:$shortKey"
+
+    @Test
+    fun `suspendCoroutineWithoutCancellation defaults to ERROR`() {
+        val cfg = CompilerConfiguration()
+        val pc = PluginConfiguration(cfg)
+        assertEquals(Severity.ERROR, pc.suspendCoroutineWithoutCancellation)
+    }
+
+    @Test
+    fun `callbackFlowWithoutAwaitClose defaults to ERROR`() {
+        val cfg = CompilerConfiguration()
+        val pc = PluginConfiguration(cfg)
+        assertEquals(Severity.ERROR, pc.callbackFlowWithoutAwaitClose)
+    }
+
+    @Test
+    fun `interop severities honor compiler plugin options`() {
+        val cfg = CompilerConfiguration()
+        cfg.put(
+            CompilerConfigurationKey.create(pluginKey("suspendCoroutineWithoutCancellation")),
+            "warning",
+        )
+        cfg.put(
+            CompilerConfigurationKey.create(pluginKey("callbackFlowWithoutAwaitClose")),
+            "warning",
+        )
+        val pc = PluginConfiguration(cfg)
+        assertEquals(Severity.WARNING, pc.suspendCoroutineWithoutCancellation)
+        assertEquals(Severity.WARNING, pc.callbackFlowWithoutAwaitClose)
+    }
+}

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/PluginConfigurationInteropOptionsTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/PluginConfigurationInteropOptionsTest.kt
@@ -1,15 +1,11 @@
 package io.github.santimattius.structured.compiler
 
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.diagnostics.Severity
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class PluginConfigurationInteropOptionsTest {
-
-    private fun pluginKey(shortKey: String): String =
-        "plugin:io.github.santimattius.structured-coroutines:$shortKey"
 
     @Test
     fun `suspendCoroutineWithoutCancellation defaults to ERROR`() {
@@ -29,12 +25,11 @@ class PluginConfigurationInteropOptionsTest {
     fun `interop severities honor compiler plugin options`() {
         val cfg = CompilerConfiguration()
         cfg.put(
-            CompilerConfigurationKey.create(pluginKey("suspendCoroutineWithoutCancellation")),
-            "warning",
-        )
-        cfg.put(
-            CompilerConfigurationKey.create(pluginKey("callbackFlowWithoutAwaitClose")),
-            "warning",
+            PluginConfiguration.OPTIONS_KEY,
+            mapOf(
+                "suspendCoroutineWithoutCancellation" to "warning",
+                "callbackFlowWithoutAwaitClose" to "warning",
+            ),
         )
         val pc = PluginConfiguration(cfg)
         assertEquals(Severity.WARNING, pc.suspendCoroutineWithoutCancellation)

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -585,4 +585,52 @@ class StructuredCoroutinesPluginFunctionalTest {
             "Expected localized SCOPE_001 message (EN or ES). Got (last 2k):\n${output.takeLast(2000)}"
         )
     }
+
+    @Test
+    fun `suspendCoroutine in suspend function fails compilation`() {
+        val sourceCode = """
+            import kotlinx.coroutines.suspendCoroutine
+            
+            suspend fun bad(): Unit =
+                suspendCoroutine { cont -> cont.resume(Unit) }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = false)
+        assertTrue(
+            "SUSPEND_COROUTINE_WITHOUT_CANCELLATION" in output || "[INTEROP_001]" in output ||
+                "suspendCoroutine" in output,
+            "Expected INTEROP_001 but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `callbackFlow without awaitClose fails compilation`() {
+        val sourceCode = """
+            import kotlinx.coroutines.flow.callbackFlow
+            
+            fun broken() = callbackFlow<Unit> { }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = false)
+        assertTrue(
+            "CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE" in output || "[INTEROP_002]" in output ||
+                "awaitClose" in output,
+            "Expected INTEROP_002 but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `channelFlow compiles without awaitClose`() {
+        val sourceCode = """
+            import kotlinx.coroutines.flow.channelFlow
+            
+            fun ok() = channelFlow<Int> { send(42) }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+        assertTrue("BUILD SUCCESSFUL" in output || "compileKotlin" in output, output)
+    }
 }

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -495,17 +495,33 @@ class StructuredCoroutinesPluginFunctionalTest {
     // Sample project validation (real :sample with compiler plugin)
     // ============================================================================
 
+    /**
+     * Runs `:sample:compileKotlin` via the project's Gradle wrapper as a plain OS process,
+     * capturing both stdout and stderr (merged). Using ProcessBuilder instead of GradleRunner
+     * here because the Kotlin Build Tools API (BTAPI) worker writes compiler diagnostics to
+     * the Gradle process's stderr stream, which GradleRunner does not forward into
+     * BuildResult.output.
+     */
     private fun runSampleCompilation(env: Map<String, String> = emptyMap()): String? {
         val rootDir = System.getProperty("structuredCoroutines.rootDir") ?: return null
         val root = File(rootDir)
         if (!File(root, "sample/build.gradle.kts").exists()) return null
-        val runner = GradleRunner.create()
-            .withProjectDir(root)
-            .withArguments(":sample:compileKotlin", "--stacktrace", "-q")
-            .forwardOutput()
-        val runnerWithEnv = if (env.isEmpty()) runner else runner.withEnvironment(env)
-        val result = runnerWithEnv.buildAndFail()
-        return result.output
+
+        val gradlew = if (System.getProperty("os.name", "").startsWith("Windows")) "gradlew.bat" else "gradlew"
+        val pb = ProcessBuilder(File(root, gradlew).absolutePath, ":sample:compileKotlin", "--info")
+            .directory(root)
+            .redirectErrorStream(true)
+
+        pb.environment().apply {
+            clear()
+            putAll(System.getenv())
+            putAll(env)
+        }
+
+        val process = pb.start()
+        val output = process.inputStream.bufferedReader().readText()
+        process.waitFor()
+        return output
     }
 
     private fun skipSampleTest(): Boolean {

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/StructuredCoroutinesRuleSetProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/StructuredCoroutinesRuleSetProvider.kt
@@ -24,7 +24,6 @@ import io.github.santimattius.structured.detekt.rules.InlineCoroutineScopeRule
 import io.github.santimattius.structured.detekt.rules.JobInBuilderContextRule
 import io.github.santimattius.structured.detekt.rules.LoopWithoutYieldRule
 import io.github.santimattius.structured.detekt.rules.MissingCatchInFlowRule
-import io.github.santimattius.structured.detekt.rules.MissingCatchInFlowRule
 import io.github.santimattius.structured.detekt.rules.MutableFlowExposedRule
 import io.github.santimattius.structured.detekt.rules.RedundantLaunchInCoroutineScopeRule
 import io.github.santimattius.structured.detekt.rules.RunBlockingInsteadOfRunTestRule
@@ -152,7 +151,6 @@ class StructuredCoroutinesRuleSetProvider : RuleSetProvider {
             SuspendCoroutineWithoutCancellationRule(config),
             CallbackFlowWithoutAwaitCloseRule(config),
             MutableFlowExposedRule(config),
-            MissingCatchInFlowRule(config),
             SequentialAsyncAwaitRule(config),
             RunBlockingInsteadOfRunTestRule(config),
             DispatchersIOInCommonMainRule(config),

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/StructuredCoroutinesRuleSetProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/StructuredCoroutinesRuleSetProvider.kt
@@ -11,8 +11,10 @@ package io.github.santimattius.structured.detekt
 
 import io.github.santimattius.structured.detekt.rules.BlockingCallInCoroutineRule
 import io.github.santimattius.structured.detekt.rules.CancellationExceptionSubclassRule
+import io.github.santimattius.structured.detekt.rules.CallbackFlowWithoutAwaitCloseRule
 import io.github.santimattius.structured.detekt.rules.ChannelNotClosedRule
 import io.github.santimattius.structured.detekt.rules.ConsumeEachMultipleConsumersRule
+import io.github.santimattius.structured.detekt.rules.DispatchersIOInCommonMainRule
 import io.github.santimattius.structured.detekt.rules.CancellationExceptionSwallowedRule
 import io.github.santimattius.structured.detekt.rules.DispatchersUnconfinedRule
 import io.github.santimattius.structured.detekt.rules.ExternalScopeLaunchRule
@@ -21,10 +23,16 @@ import io.github.santimattius.structured.detekt.rules.GlobalScopeUsageRule
 import io.github.santimattius.structured.detekt.rules.InlineCoroutineScopeRule
 import io.github.santimattius.structured.detekt.rules.JobInBuilderContextRule
 import io.github.santimattius.structured.detekt.rules.LoopWithoutYieldRule
+import io.github.santimattius.structured.detekt.rules.MissingCatchInFlowRule
+import io.github.santimattius.structured.detekt.rules.MissingCatchInFlowRule
+import io.github.santimattius.structured.detekt.rules.MutableFlowExposedRule
 import io.github.santimattius.structured.detekt.rules.RedundantLaunchInCoroutineScopeRule
+import io.github.santimattius.structured.detekt.rules.RunBlockingInsteadOfRunTestRule
+import io.github.santimattius.structured.detekt.rules.SequentialAsyncAwaitRule
 import io.github.santimattius.structured.detekt.rules.RunBlockingInSuspendRule
 import io.github.santimattius.structured.detekt.rules.RunBlockingWithDelayInTestRule
 import io.github.santimattius.structured.detekt.rules.ScopeReuseAfterCancelRule
+import io.github.santimattius.structured.detekt.rules.SuspendCoroutineWithoutCancellationRule
 import io.github.santimattius.structured.detekt.rules.SuspendInFinallyRule
 import io.github.santimattius.structured.detekt.rules.UnusedDeferredRule
 import io.github.santimattius.structured.detekt.rules.WithTimeoutScopeCancellationRule
@@ -138,6 +146,16 @@ class StructuredCoroutinesRuleSetProvider : RuleSetProvider {
             ConsumeEachMultipleConsumersRule(config),
             FlowBlockingCallRule(config),
             WithTimeoutScopeCancellationRule(config),
+            MissingCatchInFlowRule(config),
+
+            // Iteration 1 (v0.8.0 plan) — INTEROP, Flow, Concurrency, Testing, KMP
+            SuspendCoroutineWithoutCancellationRule(config),
+            CallbackFlowWithoutAwaitCloseRule(config),
+            MutableFlowExposedRule(config),
+            MissingCatchInFlowRule(config),
+            SequentialAsyncAwaitRule(config),
+            RunBlockingInsteadOfRunTestRule(config),
+            DispatchersIOInCommonMainRule(config),
         )
     )
 }

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/CallbackFlowWithoutAwaitCloseRule.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/CallbackFlowWithoutAwaitCloseRule.kt
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.github.santimattius.structured.detekt.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.detekt.utils.DetektDocUrl
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+
+/**
+ * [INTEROP_002] — `callbackFlow { }` should call `awaitClose { }` for listener cleanup (mirrors FIR rule).
+ */
+class CallbackFlowWithoutAwaitCloseRule(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        id = "CallbackFlowWithoutAwaitClose",
+        severity = Severity.Defect,
+        description = "[INTEROP_002] 'callbackFlow' block must invoke 'awaitClose' to unregister listeners. " +
+            "See: ${DetektDocUrl.buildDocLink("102-interop_002--callbackflow-without-awaitclose")}",
+        debt = Debt.FIVE_MINS
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        if (!CoroutinesImportFilter.elementImportsCoroutinesOrFlow(expression)) return
+
+        val calleeName = expression.calleeExpression?.text ?: return
+        if (calleeName != "callbackFlow") return
+
+        val lambdaExpr = extractTrailingLambda(expression) ?: return
+        if (lambdaBodyContainsAwaitClose(lambdaExpr)) return
+
+        report(
+            CodeSmell(
+                issue = issue,
+                entity = Entity.from(expression),
+                message = "[INTEROP_002] 'callbackFlow' without 'awaitClose' — add 'awaitClose { /* unregister */ }' " +
+                    "so collectors can cancel cleanly. See: ${DetektDocUrl.buildDocLink("102-interop_002--callbackflow-without-awaitclose")}"
+            )
+        )
+    }
+
+    private fun extractTrailingLambda(expression: KtCallExpression): KtLambdaExpression? {
+        expression.lambdaArguments.lastOrNull()?.getArgumentExpression()?.let { arg ->
+            if (arg is KtLambdaExpression) return arg
+        }
+        return null
+    }
+
+    private fun lambdaBodyContainsAwaitClose(lambda: KtLambdaExpression): Boolean =
+        lambda.bodyExpression?.anyDescendantOfType<KtCallExpression> { call ->
+            call.calleeExpression?.text == "awaitClose"
+        } ?: false
+}

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/DispatchersIOInCommonMainRule.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/DispatchersIOInCommonMainRule.kt
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.github.santimattius.structured.detekt.utils.CoroutineDetektUtils
+import io.github.santimattius.structured.detekt.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.detekt.utils.DetektDocUrl
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+/**
+ * [KMP_001] — `Dispatchers.IO` cannot be referenced from Kotlin/Common source sets targeting Native/JS.
+ */
+class DispatchersIOInCommonMainRule(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        id = "DispatchersIOInCommonMain",
+        severity = Severity.Defect,
+        description = "[KMP_001] `Dispatchers.IO` is JVM/Android-only — inject `CoroutineDispatcher` or use expect/actual. " +
+            "See: ${DetektDocUrl.buildDocLink("111-kmp_001--dispatchersio-in-commonmain")}",
+        debt = Debt.FIVE_MINS
+    )
+
+    override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+        super.visitDotQualifiedExpression(expression)
+        if (!CoroutinesImportFilter.elementIsInCoroutinesFile(expression)) return
+
+        val path = expression.containingKtFile.virtualFilePath
+        if (!CoroutineDetektUtils.isKotlinCommonLikeSourceVirtualPath(path)) return
+
+        val receiverText = expression.receiverExpression.text.trim()
+
+        val targetsIo =
+            receiverText.endsWith("Dispatchers") ||
+                receiverText == "Dispatchers" ||
+                receiverText.endsWith(".Dispatchers")
+
+        val selector = expression.selectorExpression?.text ?: return
+        if (!targetsIo || selector != "IO") return
+
+        report(
+            CodeSmell(
+                issue = issue,
+                entity = Entity.from(expression),
+                message = "[KMP_001] `Dispatchers.IO` in common Kotlin source — use dispatcher injection or " +
+                    "expect/actual to supply a platform-backed I/O dispatcher. " +
+                    "See: ${DetektDocUrl.buildDocLink("111-kmp_001--dispatchersio-in-commonmain")}"
+            )
+        )
+    }
+
+}

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/MissingCatchInFlowRule.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/MissingCatchInFlowRule.kt
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.github.santimattius.structured.detekt.utils.CoroutineDetektUtils
+import io.github.santimattius.structured.detekt.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.detekt.utils.DetektDocUrl
+import io.github.santimattius.structured.detekt.utils.MissingCatchInFlowHeuristic
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+
+/**
+ * [FLOW_005] — upstream `.catch { }` recommended before terminal `.collect` / `.launchIn`
+ * on transformed Flow chains (same heuristic as Lint `MissingCatchInFlow`).
+ */
+class MissingCatchInFlowRule(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        id = "MissingCatchInFlow",
+        severity = Severity.CodeSmell,
+        description = "[FLOW_005] Transformed Flow chains often need `.catch { }` before the terminal collector " +
+            "to avoid cancelling the enclosing scope unexpectedly. See: ${DetektDocUrl.buildDocLink("96-flow_005--missing-catch-in-flow-chain")}",
+        debt = Debt.TEN_MINS
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        if (!CoroutinesImportFilter.elementImportsCoroutinesOrFlow(expression)) return
+
+        val fileName = expression.containingKtFile.name
+        val path = expression.containingKtFile.virtualFilePath
+        if (CoroutineDetektUtils.isTestFile(fileName) || CoroutineDetektUtils.isTestFile(path)) return
+
+        val callee = expression.calleeExpression?.text ?: return
+        if (callee !in setOf("collect", "collectLatest", "launchIn")) return
+
+        if (!MissingCatchInFlowHeuristic.shouldReportTerminalCall(expression)) return
+
+        report(
+            CodeSmell(
+                issue = issue,
+                entity = Entity.from(expression),
+                message = "[FLOW_005] Consider `.catch { }` before `.${callee}` on this Flow chain unless errors " +
+                    "are deliberately propagated. See: ${DetektDocUrl.buildDocLink("96-flow_005--missing-catch-in-flow-chain")}",
+            ),
+        )
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/MutableFlowExposedRule.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/MutableFlowExposedRule.kt
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.github.santimattius.structured.detekt.utils.CoroutineDetektUtils
+import io.github.santimattius.structured.detekt.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.detekt.utils.DetektDocUrl
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtPsiUtil
+import org.jetbrains.kotlin.psi.KtProperty
+
+/**
+ * [FLOW_010] — public `MutableStateFlow` / `MutableSharedFlow` properties leak write APIs.
+ *
+ * Mirrors the iteration plan heuristic: expose `StateFlow` / `SharedFlow` via `.asStateFlow()`
+ * / `.asSharedFlow()` on backing properties.
+ */
+class MutableFlowExposedRule(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        id = "MutableFlowExposed",
+        severity = Severity.CodeSmell,
+        description = "[FLOW_010] Exposing MutableStateFlow/MutableSharedFlow is usually an API leak. " +
+            "Prefer `private val _x = MutableStateFlow(...)` and `val x = _x.asStateFlow()`. " +
+            "See: ${DetektDocUrl.buildDocLink("95-flow_010--mutablestateflow-exposed")}",
+        debt = Debt.TEN_MINS
+    )
+
+    override fun visitProperty(property: KtProperty) {
+        super.visitProperty(property)
+        if (!CoroutinesImportFilter.elementImportsCoroutinesOrFlow(property)) return
+        val fileName = property.containingKtFile.name
+        val path = property.containingKtFile.virtualFilePath
+        if (CoroutineDetektUtils.isTestFile(fileName) || CoroutineDetektUtils.isTestFile(path)) return
+        if (KtPsiUtil.isLocal(property)) return
+        if (property.hasModifier(KtTokens.PRIVATE_KEYWORD) ||
+            property.hasModifier(KtTokens.INTERNAL_KEYWORD) ||
+            property.hasModifier(KtTokens.PROTECTED_KEYWORD)
+        ) {
+            return
+        }
+
+        val typeText = property.typeReference?.text.orEmpty()
+        val typeShowsMutableFlow =
+            typeText.contains("MutableStateFlow") || typeText.contains("MutableSharedFlow")
+
+        val init = property.initializer
+        val ctorMutableFlow = init is KtCallExpression &&
+            init.calleeExpression?.text?.let { name ->
+                name == "MutableStateFlow" ||
+                    name == "MutableSharedFlow" ||
+                    name.endsWith(".MutableStateFlow") ||
+                    name.endsWith(".MutableSharedFlow")
+            } == true
+
+        val preview = property.annotationEntries.any {
+            val s = it.shortName?.asString().orEmpty()
+            s.endsWith("Preview", ignoreCase = true)
+        }
+        if (preview) return
+
+        if (!(typeShowsMutableFlow || ctorMutableFlow)) return
+
+        report(
+            CodeSmell(
+                issue = issue,
+                entity = Entity.from(property),
+                message = "[FLOW_010] Public mutable Flow surface — hide mutability with `.asStateFlow()` / `.asSharedFlow()`. " +
+                    "See: ${DetektDocUrl.buildDocLink("95-flow_010--mutablestateflow-exposed")}"
+            )
+        )
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/RunBlockingInsteadOfRunTestRule.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/RunBlockingInsteadOfRunTestRule.kt
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.github.santimattius.structured.detekt.utils.CoroutineDetektUtils
+import io.github.santimattius.structured.detekt.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.detekt.utils.DetektDocUrl
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+/**
+ * [TEST_004] — JUnit tests that use `runBlocking` as the test body should prefer `runTest` from
+ * kotlinx-coroutines-test (virtual time, structured test scope).
+ *
+ * Complements [RunBlockingWithDelayInTestRule] ([TEST_001]) which flags real `delay` under `runBlocking`.
+ */
+class RunBlockingInsteadOfRunTestRule(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        id = "RunBlockingInsteadOfRunTest",
+        severity = Severity.Warning,
+        description = "[TEST_004] Prefer `runTest { }` over `runBlocking { }` in `@Test` functions for coroutine tests. " +
+            "See: ${DetektDocUrl.buildDocLink("64-test_004--runblocking-instead-of-runtest")}",
+        debt = Debt.FIVE_MINS
+    )
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        if (!function.hasAnnotationNamedTest()) return
+        if (!CoroutinesImportFilter.elementIsInCoroutinesFile(function)) return
+
+        val fileName = function.containingKtFile.name
+        val path = function.containingKtFile.virtualFilePath
+        if (!CoroutineDetektUtils.isTestFile(fileName) && !CoroutineDetektUtils.isTestFile(path)) return
+
+        val bodyExpr = function.bodyExpression as? KtCallExpression ?: return
+        if (bodyExpr.calleeExpression?.text != "runBlocking") return
+
+        report(
+            CodeSmell(
+                issue = issue,
+                entity = Entity.from(bodyExpr),
+                message = "[TEST_004] Replace `runBlocking` with `runTest` from kotlinx-coroutines-test for faster, " +
+                    "deterministic coroutine tests. See: ${DetektDocUrl.buildDocLink("64-test_004--runblocking-instead-of-runtest")}"
+            )
+        )
+    }
+
+    private fun KtNamedFunction.hasAnnotationNamedTest(): Boolean =
+        annotationEntries.any { it.shortName?.asString() == "Test" }
+}

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/SequentialAsyncAwaitRule.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/SequentialAsyncAwaitRule.kt
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.github.santimattius.structured.detekt.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.detekt.utils.DetektDocUrl
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+
+/**
+ * [CONCUR_003] — `async { }.await()` on one line defeats parallelism — use sequential `withContext` or parallel async.
+ *
+ * Heuristic: inline `await()` whose receiver call is directly `async { ... }`.
+ */
+class SequentialAsyncAwaitRule(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        id = "SequentialAsyncAwait",
+        severity = Severity.CodeSmell,
+        description = "[CONCUR_003] Sequential `async {}.await()` only adds Deferred overhead — run work directly " +
+            "or launch multiple deferreds without awaiting between the `async` calls. " +
+            "See: ${DetektDocUrl.buildDocLink("15-concur_003--sequential-asyncawait")}",
+        debt = Debt.FIVE_MINS
+    )
+
+    override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+        super.visitDotQualifiedExpression(expression)
+        if (!CoroutinesImportFilter.elementIsInCoroutinesFile(expression)) return
+
+        val selector = expression.selectorExpression as? KtCallExpression ?: return
+        if (selector.calleeExpression?.text != "await") return
+
+        val receiverExpr = expression.receiverExpression
+        val asyncCall = receiverExpr as? KtCallExpression ?: return
+        if (asyncCall.calleeExpression?.text != "async") return
+
+        report(
+            CodeSmell(
+                issue = issue,
+                entity = Entity.from(selector),
+                message = "[CONCUR_003] `async { }.await()` is sequential — prefer ordinary suspend calls " +
+                    "or `coroutineScope { async { }; async { } }` without intermediate await. " +
+                    "See: ${DetektDocUrl.buildDocLink("15-concur_003--sequential-asyncawait")}"
+            )
+        )
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/SuspendCoroutineWithoutCancellationRule.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/SuspendCoroutineWithoutCancellationRule.kt
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.github.santimattius.structured.detekt.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.detekt.utils.CoroutineDetektUtils
+import io.github.santimattius.structured.detekt.utils.DetektDocUrl
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+
+/**
+ * [INTEROP_001] — mirrors the compiler rule: `suspendCoroutine` does not support cancellation.
+ */
+class SuspendCoroutineWithoutCancellationRule(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        id = "SuspendCoroutineWithoutCancellation",
+        severity = Severity.Defect,
+        description = "[INTEROP_001] 'suspendCoroutine' does not support cancellation. " +
+            "Use 'suspendCancellableCoroutine' and 'invokeOnCancellation'. " +
+            "See: ${DetektDocUrl.buildDocLink("101-interop_001--wrapping-callbacks-without-cancellation-support")}",
+        debt = Debt.FIVE_MINS
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        if (!CoroutinesImportFilter.elementIsInCoroutinesFile(expression)) return
+
+        val calleeName = expression.calleeExpression?.text ?: return
+        if (calleeName != "suspendCoroutine") return
+
+        val fn = CoroutineDetektUtils.enclosingNamedFunction(expression) ?: return
+        if (!CoroutineDetektUtils.isSuspendFunction(fn)) return
+
+        report(
+            CodeSmell(
+                issue = issue,
+                entity = Entity.from(expression),
+                message = "[INTEROP_001] 'suspendCoroutine' does not propagate cancellation from the caller. " +
+                    "Prefer 'suspendCancellableCoroutine' + 'invokeOnCancellation { }' for callback cleanup. " +
+                    "See: ${DetektDocUrl.buildDocLink("101-interop_001--wrapping-callbacks-without-cancellation-support")}"
+            )
+        )
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/CoroutineDetektUtils.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/CoroutineDetektUtils.kt
@@ -260,14 +260,19 @@ object CoroutineDetektUtils {
     }
 
     /**
-     * Checks if the file is a test file based on naming convention.
+     * Checks whether a virtual path points at conventional test source roots.
+     *
+     * Avoid filename suffix heuristics (`*Test.kt`): Detekt `compileAndLint` often names snippet
+     * files after the test class (e.g. `MissingCatchInFlowRuleTest.kt`), which would be skipped
+     * incorrectly. Avoid naive `contains("/test/")`: Gradle temp dirs like `.../kotlin-classes/test/`
+     * are not application tests.
      */
-    fun isTestFile(fileName: String): Boolean {
-        return fileName.endsWith("Test.kt") ||
-            fileName.endsWith("Tests.kt") ||
-            fileName.endsWith("Spec.kt") ||
-            fileName.contains("/test/") ||
-            fileName.contains("/androidTest/")
+    fun isTestFile(virtualFilePathOrName: String): Boolean {
+        val normalized = virtualFilePathOrName.replace('\\', '/')
+        if (!normalized.contains('/')) return false
+        return normalized.contains("/src/test/") ||
+            normalized.contains("/src/androidTest/") ||
+            normalized.contains("/src/commonTest/")
     }
 
     /**

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/CoroutineDetektUtils.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/CoroutineDetektUtils.kt
@@ -269,4 +269,23 @@ object CoroutineDetektUtils {
             fileName.contains("/test/") ||
             fileName.contains("/androidTest/")
     }
+
+    /**
+     * Kotlin Multiplatform: source roots where [Dispatchers.IO] is unsupported on Kotlin/Native/JS.
+     */
+    fun isKotlinCommonLikeSourceVirtualPath(virtualFilePath: String): Boolean {
+        val normalized = virtualFilePath.replace('\\', '/')
+        return normalized.contains("/commonMain/") ||
+            normalized.contains("/commonTest/")
+    }
+
+    /** Nearest enclosing [KtNamedFunction] walking outward from [element]. */
+    fun enclosingNamedFunction(element: KtElement): KtNamedFunction? {
+        var current: KtElement? = element
+        while (current != null) {
+            if (current is KtNamedFunction) return current
+            current = current.parent as? KtElement
+        }
+        return null
+    }
 }

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/CoroutinesImportFilter.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/CoroutinesImportFilter.kt
@@ -11,6 +11,7 @@ package io.github.santimattius.structured.detekt.utils
 
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtImportDirective
 
 /**
  * Fast import-based guard to determine whether a file uses kotlinx.coroutines APIs.
@@ -27,11 +28,12 @@ object CoroutinesImportFilter {
 
     /**
      * Returns true if the file contains at least one import from `kotlinx.coroutines`.
+     *
+     * Star imports such as `import kotlinx.coroutines.*` or `import kotlinx.coroutines.flow.*`
+     * often leave [KtImportDirective.importedFqName] unset; those are matched via [KtImportDirective.importPath].
      */
     fun fileImportsCoroutines(file: KtFile): Boolean {
-        return file.importDirectives.any { directive ->
-            directive.importedFqName?.asString()?.startsWith(KOTLINX_COROUTINES_PREFIX) == true
-        }
+        return file.importDirectives.any { matchesKotlinxCoroutinesImport(it) }
     }
 
     /**
@@ -40,9 +42,21 @@ object CoroutinesImportFilter {
      */
     fun fileImportsCoroutinesOrFlow(file: KtFile): Boolean {
         return fileImportsCoroutines(file) ||
-            file.importDirectives.any { directive ->
-                directive.importedFqName?.asString()?.startsWith(KOTLINX_FLOW_PREFIX) == true
-            }
+            file.importDirectives.any { matchesKotlinxFlowImport(it) }
+    }
+
+    private fun matchesKotlinxCoroutinesImport(directive: KtImportDirective): Boolean {
+        val fq = directive.importedFqName?.asString()
+        if (fq != null && fq.startsWith(KOTLINX_COROUTINES_PREFIX)) return true
+        val pathStr = directive.importPath?.pathStr ?: return false
+        return pathStr.startsWith("$KOTLINX_COROUTINES_PREFIX.")
+    }
+
+    private fun matchesKotlinxFlowImport(directive: KtImportDirective): Boolean {
+        val fq = directive.importedFqName?.asString()
+        if (fq != null && fq.startsWith(KOTLINX_FLOW_PREFIX)) return true
+        val pathStr = directive.importPath?.pathStr ?: return false
+        return pathStr.startsWith("$KOTLINX_FLOW_PREFIX.")
     }
 
     /**

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/CoroutinesImportFilter.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/CoroutinesImportFilter.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.psi.KtFile
 object CoroutinesImportFilter {
 
     private const val KOTLINX_COROUTINES_PREFIX = "kotlinx.coroutines"
+    private const val KOTLINX_FLOW_PREFIX = "kotlinx.coroutines.flow"
 
     /**
      * Returns true if the file contains at least one import from `kotlinx.coroutines`.
@@ -34,9 +35,24 @@ object CoroutinesImportFilter {
     }
 
     /**
+     * Same as [fileImportsCoroutines] plus `kotlinx.coroutines.flow` imports (Flow / callbackFlow /
+     * MutableStateFlow, etc.).
+     */
+    fun fileImportsCoroutinesOrFlow(file: KtFile): Boolean {
+        return fileImportsCoroutines(file) ||
+            file.importDirectives.any { directive ->
+                directive.importedFqName?.asString()?.startsWith(KOTLINX_FLOW_PREFIX) == true
+            }
+    }
+
+    /**
      * Convenience overload: extracts the [KtFile] from any [KtElement].
      */
     fun elementIsInCoroutinesFile(element: KtElement): Boolean {
         return fileImportsCoroutines(element.containingKtFile)
+    }
+
+    fun elementImportsCoroutinesOrFlow(element: KtElement): Boolean {
+        return fileImportsCoroutinesOrFlow(element.containingKtFile)
     }
 }

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/MissingCatchInFlowHeuristic.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/MissingCatchInFlowHeuristic.kt
@@ -11,8 +11,9 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtPsiUtil
 import org.jetbrains.kotlin.psi.KtTryExpression
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.isAncestor
 
 /**
  * Shared [FLOW_005] logic for Detekt. Keep in sync with
@@ -85,35 +86,28 @@ object MissingCatchInFlowHeuristic {
 
     private fun isInsideCatchAllThrowableOrException(element: KtElement): Boolean {
         var tryExpr: KtTryExpression? =
-            KtPsiUtil.getParentOfType(element, KtTryExpression::class.java, strict = false) ?: return false
+            element.getParentOfType<KtTryExpression>(strict = false) ?: return false
 
         while (tryExpr != null) {
             val inCatch = tryExpr.catchClauses.any { clause ->
                 val body = clause.catchBody
-                body != null && KtPsiUtil.isAncestor(body, element, false)
+                body != null && body.isAncestor(element, false)
             }
             if (inCatch) {
                 tryExpr =
-                    KtPsiUtil.getParentOfType(
-                        tryExpr.parent as KtElement,
-                        KtTryExpression::class.java,
-                        strict = false,
-                    )
+                    (tryExpr.parent as? KtElement)?.getParentOfType<KtTryExpression>(strict = false)
                 continue
             }
 
             val tryBlock = tryExpr.tryBlock
-            if (tryBlock != null && KtPsiUtil.isAncestor(tryBlock, element, false) &&
+            if (tryBlock != null && tryBlock.isAncestor(element, false) &&
                 catchesThrowableOrGenericException(tryExpr)
             ) {
                 return true
             }
 
-            tryExpr = KtPsiUtil.getParentOfType(
-                tryExpr.parent as KtElement,
-                KtTryExpression::class.java,
-                strict = false,
-            )
+            tryExpr =
+                (tryExpr.parent as? KtElement)?.getParentOfType<KtTryExpression>(strict = false)
         }
         return false
     }

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/MissingCatchInFlowHeuristic.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/utils/MissingCatchInFlowHeuristic.kt
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.utils
+
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtPsiUtil
+import org.jetbrains.kotlin.psi.KtTryExpression
+
+/**
+ * Shared [FLOW_005] logic for Detekt. Keep in sync with
+ * `lint-rules/.../MissingCatchInFlowHeuristic.kt` (Android Lint).
+ */
+object MissingCatchInFlowHeuristic {
+
+    private val FLOW_TERMINALS = setOf("collect", "collectLatest", "launchIn")
+
+    private val FLOW_INTERMEDIATES = setOf(
+        "map",
+        "mapLatest",
+        "filter",
+        "filterNot",
+        "transform",
+        "flatMapConcat",
+        "flatMapLatest",
+        "flatMapMerge",
+        "distinctUntilChanged",
+        "debounce",
+        "sample",
+        "take",
+        "drop",
+        "onStart",
+        "onEmpty",
+        "onCompletion",
+        "retry",
+        "retryWhen",
+        "runningFold",
+        "runningReduce",
+    )
+
+    fun shouldReportTerminalCall(terminalFlowCall: KtCallExpression): Boolean {
+        val callee = terminalFlowCall.calleeExpression?.text ?: return false
+        if (callee !in FLOW_TERMINALS) return false
+
+        val receiverChainCalls = callersInReceiverChainBeforeTerminal(terminalFlowCall)
+
+        if (receiverChainCalls.any { it.calleeExpression?.text == "catch" }) return false
+
+        val hasTrackedIntermediate = receiverChainCalls.any {
+            val n = it.calleeExpression?.text ?: return@any false
+            n in FLOW_INTERMEDIATES
+        }
+        if (!hasTrackedIntermediate) return false
+
+        if (isInsideCatchAllThrowableOrException(terminalFlowCall)) return false
+
+        return true
+    }
+
+    fun callersInReceiverChainBeforeTerminal(terminalFlowCall: KtCallExpression): List<KtCallExpression> {
+        val dot = terminalFlowCall.parent as? KtDotQualifiedExpression ?: return emptyList()
+        if (dot.selectorExpression != terminalFlowCall) return emptyList()
+        return extractQualifiedChainCalls(dot.receiverExpression)
+    }
+
+    private fun extractQualifiedChainCalls(receiver: KtExpression?): List<KtCallExpression> {
+        if (receiver == null) return emptyList()
+        return when (receiver) {
+            is KtDotQualifiedExpression -> {
+                val selector = receiver.selectorExpression
+                val suffix = if (selector is KtCallExpression) listOf(selector) else emptyList()
+                extractQualifiedChainCalls(receiver.receiverExpression) + suffix
+            }
+            is KtCallExpression -> listOf(receiver)
+            else -> emptyList()
+        }
+    }
+
+    private fun isInsideCatchAllThrowableOrException(element: KtElement): Boolean {
+        var tryExpr: KtTryExpression? =
+            KtPsiUtil.getParentOfType(element, KtTryExpression::class.java, strict = false) ?: return false
+
+        while (tryExpr != null) {
+            val inCatch = tryExpr.catchClauses.any { clause ->
+                val body = clause.catchBody
+                body != null && KtPsiUtil.isAncestor(body, element, false)
+            }
+            if (inCatch) {
+                tryExpr =
+                    KtPsiUtil.getParentOfType(
+                        tryExpr.parent as KtElement,
+                        KtTryExpression::class.java,
+                        strict = false,
+                    )
+                continue
+            }
+
+            val tryBlock = tryExpr.tryBlock
+            if (tryBlock != null && KtPsiUtil.isAncestor(tryBlock, element, false) &&
+                catchesThrowableOrGenericException(tryExpr)
+            ) {
+                return true
+            }
+
+            tryExpr = KtPsiUtil.getParentOfType(
+                tryExpr.parent as KtElement,
+                KtTryExpression::class.java,
+                strict = false,
+            )
+        }
+        return false
+    }
+
+    private fun catchesThrowableOrGenericException(tryExpr: KtTryExpression): Boolean =
+        tryExpr.catchClauses.any { clause ->
+            val names = clause.catchParameter?.typeReference?.text ?: return@any false
+            val normalized = names.trim()
+            normalized == "Throwable" ||
+                normalized == "java.lang.Throwable" ||
+                normalized.endsWith(".Throwable") ||
+                normalized == "Exception" ||
+                normalized == "java.lang.Exception" ||
+                normalized.endsWith(".Exception")
+        }
+}

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/CallbackFlowWithoutAwaitCloseRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/CallbackFlowWithoutAwaitCloseRuleTest.kt
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CallbackFlowWithoutAwaitCloseRuleTest {
+
+    private val rule = CallbackFlowWithoutAwaitCloseRule(Config.empty)
+
+    @Test
+    fun `reports callbackFlow without awaitClose`() {
+        val code =
+            """
+            import kotlinx.coroutines.flow.*
+
+            fun signals(): Flow<Int> = callbackFlow {
+                trySend(1)
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("[INTEROP_002]")
+    }
+
+    @Test
+    fun `does not report when awaitClose present`() {
+        val code =
+            """
+            import kotlinx.coroutines.flow.*
+
+            fun signals(): Flow<Int> = callbackFlow {
+                trySend(1)
+                awaitClose { }
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `inactive when no flow imports`() {
+        val code =
+            """
+            fun noop() = Unit
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/DispatchersIOInCommonMainRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/DispatchersIOInCommonMainRuleTest.kt
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DispatchersIOInCommonMainRuleTest {
+
+    private val rule = DispatchersIOInCommonMainRule(Config.empty)
+
+    @Test
+    fun `does not report when path is not commonMain`() {
+        val code =
+            """
+            import kotlinx.coroutines.*
+
+            suspend fun read() = withContext(Dispatchers.IO) { 1 }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/DispatchersIOInCommonMainRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/DispatchersIOInCommonMainRuleTest.kt
@@ -9,8 +9,10 @@ package io.github.santimattius.structured.detekt.rules
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.nio.file.Paths
 
 class DispatchersIOInCommonMainRuleTest {
 
@@ -26,6 +28,39 @@ class DispatchersIOInCommonMainRuleTest {
             """.trimIndent()
 
         val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report Dispatchers IO in jvmMain path`() {
+        // FP guard: jvmMain code may legitimately use Dispatchers.IO
+        val code =
+            """
+            import kotlinx.coroutines.*
+
+            suspend fun readFile() = withContext(Dispatchers.IO) { 1 }
+            """.trimIndent()
+
+        // compileAndLint uses a synthetic path without /commonMain/ or /commonTest/
+        // so this confirms the path heuristic does not fire outside common sources
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports Dispatchers IO under commonMain source root`() {
+        val uri = javaClass.getResource("/detekt-kmp-common/src/commonMain/kotlin/UsesIo.kt")!!
+        val findings = rule.lint(Paths.get(uri.toURI()))
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single().message).contains("[KMP_001]")
+    }
+
+    @Test
+    fun `does not report when suppressed in commonMain file`() {
+        val uri = javaClass.getResource(
+            "/detekt-kmp-common-suppress/src/commonMain/kotlin/SuppressedIo.kt"
+        )!!
+        val findings = rule.lint(Paths.get(uri.toURI()))
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/MissingCatchInFlowRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/MissingCatchInFlowRuleTest.kt
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MissingCatchInFlowRuleTest {
+
+    private val rule = MissingCatchInFlowRule(Config.empty)
+
+    @Test
+    fun `reports map then collect without catch`() {
+        val code =
+            """
+            import kotlinx.coroutines.flow.*
+
+            suspend fun demo() {
+                flow { emit(1) }
+                    .map { it }
+                    .collect { }
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("[FLOW_005]")
+    }
+
+    @Test
+    fun `clean when catch present upstream`() {
+        val code =
+            """
+            import kotlinx.coroutines.flow.*
+
+            suspend fun demo() {
+                flow { emit(1) }
+                    .map { it }
+                    .catch { _: Throwable ->
+                    }
+                    .collect { }
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `clean when enclosing try catches Exception`() {
+        val code =
+            """
+            import kotlinx.coroutines.flow.*
+
+            suspend fun demo() {
+                try {
+                    flow { emit(1) }
+                        .map { it }
+                        .collect { }
+                } catch (e: Exception) {
+                    println(e)
+                }
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `no report for terminal without tracked intermediate operators`() {
+        val code =
+            """
+            import kotlinx.coroutines.flow.*
+
+            suspend fun demo() {
+                flow { emit(1) }.collect { }
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/MutableFlowExposedRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/MutableFlowExposedRuleTest.kt
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MutableFlowExposedRuleTest {
+
+    private val rule = MutableFlowExposedRule(Config.empty)
+
+    @Test
+    fun `reports public MutableStateFlow`() {
+        val code =
+            """
+            import kotlinx.coroutines.flow.*
+
+            class Vm {
+                val state = MutableStateFlow(0)
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("[FLOW_010]")
+    }
+
+    @Test
+    fun `does not report private backing field`() {
+        val code =
+            """
+            import kotlinx.coroutines.flow.*
+
+            class Vm {
+                private val _state = MutableStateFlow(0)
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `explicit type MutableSharedFlow exposes API`() {
+        val code =
+            """
+            import kotlinx.coroutines.flow.*
+
+            class Bus {
+                val events: MutableSharedFlow<String> = MutableSharedFlow()
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).hasSize(1)
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/RunBlockingInsteadOfRunTestRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/RunBlockingInsteadOfRunTestRuleTest.kt
@@ -9,33 +9,21 @@ package io.github.santimattius.structured.detekt.rules
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.nio.file.Paths
 
 class RunBlockingInsteadOfRunTestRuleTest {
 
     private val rule = RunBlockingInsteadOfRunTestRule(Config.empty)
 
     @Test
-    fun `documents runTest preference for expression-body test`() {
-        val code =
-            """
-            import kotlinx.coroutines.*
-            import org.junit.jupiter.api.Test
-
-            class SampleTest {
-                @Test
-                fun `smoke`() = runBlocking {
-                    println("x")
-                }
-            }
-            """.trimIndent()
-
-        val findings = rule.compileAndLint(code)
-        // File name in compileAndLint is synthetic — may not match *Test.kt; rule may not fire.
-        if (findings.isNotEmpty()) {
-            assertThat(findings[0].message).contains("[TEST_004]")
-        }
+    fun `reports runBlocking as JUnit expression body under src test path`() {
+        val uri = javaClass.getResource("/detekt-junit-src-test/src/test/kotlin/ExpressionBodyTest.kt")!!
+        val findings = rule.lint(Paths.get(uri.toURI()))
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single().message).contains("[TEST_004]")
     }
 
     @Test
@@ -47,6 +35,28 @@ class RunBlockingInsteadOfRunTestRuleTest {
             fun main() = runBlocking { }
             """.trimIndent()
 
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report when suppressed with Suppress annotation`() {
+        val code =
+            """
+            import kotlinx.coroutines.*
+            import org.junit.jupiter.api.Test
+
+            class SampleTest {
+                @Suppress("RunBlockingInsteadOfRunTest")
+                @Test
+                fun `suppressed`() = runBlocking {
+                    println("x")
+                }
+            }
+            """.trimIndent()
+
+        // Rule checks file/function name for test file heuristic — compileAndLint uses synthetic name;
+        // even if rule would otherwise fire, @Suppress prevents the finding
         val findings = rule.compileAndLint(code)
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/RunBlockingInsteadOfRunTestRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/RunBlockingInsteadOfRunTestRuleTest.kt
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RunBlockingInsteadOfRunTestRuleTest {
+
+    private val rule = RunBlockingInsteadOfRunTestRule(Config.empty)
+
+    @Test
+    fun `documents runTest preference for expression-body test`() {
+        val code =
+            """
+            import kotlinx.coroutines.*
+            import org.junit.jupiter.api.Test
+
+            class SampleTest {
+                @Test
+                fun `smoke`() = runBlocking {
+                    println("x")
+                }
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        // File name in compileAndLint is synthetic — may not match *Test.kt; rule may not fire.
+        if (findings.isNotEmpty()) {
+            assertThat(findings[0].message).contains("[TEST_004]")
+        }
+    }
+
+    @Test
+    fun `does not report without Test annotation`() {
+        val code =
+            """
+            import kotlinx.coroutines.*
+
+            fun main() = runBlocking { }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/SequentialAsyncAwaitRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/SequentialAsyncAwaitRuleTest.kt
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SequentialAsyncAwaitRuleTest {
+
+    private val rule = SequentialAsyncAwaitRule(Config.empty)
+
+    @Test
+    fun `reports async await on same chain`() {
+        val code =
+            """
+            import kotlinx.coroutines.*
+
+            suspend fun load(): Int = coroutineScope {
+                async { 1 }.await()
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("[CONCUR_003]")
+    }
+
+    @Test
+    fun `does not report parallel async`() {
+        val code =
+            """
+            import kotlinx.coroutines.*
+
+            suspend fun load() = coroutineScope {
+                val a = async { 1 }
+                val b = async { 2 }
+                a.await() + b.await()
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `no coroutines import no report`() {
+        val code =
+            """
+            fun x() = 1
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/SuspendCoroutineWithoutCancellationRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/SuspendCoroutineWithoutCancellationRuleTest.kt
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SuspendCoroutineWithoutCancellationRuleTest {
+
+    private val rule = SuspendCoroutineWithoutCancellationRule(Config.empty)
+
+    @Test
+    fun `reports suspendCoroutine in suspend fun`() {
+        val code =
+            """
+            import kotlinx.coroutines.*
+
+            suspend fun load(): Int = suspendCoroutine { c ->
+                c.resume(1)
+            }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("[INTEROP_001]")
+    }
+
+    @Test
+    fun `does not fire without coroutines import`() {
+        val code =
+            """
+            suspend fun load(): Unit = Unit
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `suppress message contains doc reference`() {
+        val code =
+            """
+            import kotlinx.coroutines.*
+
+            suspend fun x() = suspendCoroutine<Unit> { }
+            """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("suspendCancellableCoroutine")
+    }
+}

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/utils/CoroutineDetektUtilsTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/utils/CoroutineDetektUtilsTest.kt
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.detekt.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CoroutineDetektUtilsTest {
+
+    @Test
+    fun `detects commonMain paths`() {
+        assertThat(
+            CoroutineDetektUtils.isKotlinCommonLikeSourceVirtualPath(
+                "/project/shared/src/commonMain/kotlin/Foo.kt",
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `detects commonTest paths`() {
+        assertThat(
+            CoroutineDetektUtils.isKotlinCommonLikeSourceVirtualPath(
+                "C:\\project\\shared\\src\\commonTest\\kotlin\\Foo.kt",
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `jvmMain is not common-like`() {
+        assertThat(
+            CoroutineDetektUtils.isKotlinCommonLikeSourceVirtualPath(
+                "/project/app/src/jvmMain/kotlin/Foo.kt",
+            ),
+        ).isFalse()
+    }
+}

--- a/detekt-rules/src/test/resources/detekt-junit-src-test/src/test/kotlin/ExpressionBodyTest.kt
+++ b/detekt-rules/src/test/resources/detekt-junit-src-test/src/test/kotlin/ExpressionBodyTest.kt
@@ -1,0 +1,9 @@
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.Test
+
+class ExpressionBodyTest {
+    @Test
+    fun smoke() = runBlocking {
+        println("x")
+    }
+}

--- a/detekt-rules/src/test/resources/detekt-kmp-common-suppress/src/commonMain/kotlin/SuppressedIo.kt
+++ b/detekt-rules/src/test/resources/detekt-kmp-common-suppress/src/commonMain/kotlin/SuppressedIo.kt
@@ -1,0 +1,4 @@
+import kotlinx.coroutines.*
+
+@Suppress("DispatchersIOInCommonMain")
+suspend fun suppressedRead() = withContext(Dispatchers.IO) { 1 }

--- a/detekt-rules/src/test/resources/detekt-kmp-common/src/commonMain/kotlin/UsesIo.kt
+++ b/detekt-rules/src/test/resources/detekt-kmp-common/src/commonMain/kotlin/UsesIo.kt
@@ -1,0 +1,3 @@
+import kotlinx.coroutines.*
+
+suspend fun readFromCommon() = withContext(Dispatchers.IO) { 1 }

--- a/docs/BEST_PRACTICES_COROUTINES.md
+++ b/docs/BEST_PRACTICES_COROUTINES.md
@@ -16,6 +16,8 @@ tools and messages; links can point to the anchor of the corresponding section.
 - [7. Channels and Actors](#7-channels-and-actors)
 - [8. Architecture Patterns](#8-architecture-patterns)
 - [9. Flow](#9-flow)
+- [10. Interoperability (Callbacks to Coroutines)](#10-interoperability-callbacks-to-coroutines)
+- [11. Kotlin Multiplatform](#11-kotlin-multiplatform)
 - [Quick Reference Checklist](#quick-reference-checklist)
 - [Tool Implementation Matrix](#tool-implementation-matrix)
 
@@ -61,6 +63,12 @@ hyphens, e.g. `#11-using-globalscope-in-production-code`).
 | `FLOW_002`     | 9.2 | [Cold vs Hot Flows (StateFlow / SharedFlow)](#92-cold-vs-hot-flows-stateflow--sharedflow)                            |
 | `FLOW_003`     | 9.3 | [collectLatest Cancels Previous Work](#93-collectlatest-cancels-previous-work)                                       |
 | `FLOW_004`     | 9.4 | [SharedFlow Configuration](#94-sharedflow-configuration)                                                             |
+| `FLOW_010`     | 9.5 | [MutableStateFlow/MutableSharedFlow Exposed as Public](#95-flow_010--mutablestateflowmutablesharedflow-exposed-as-public) |
+| `FLOW_005`     | 9.6 | [Missing catch in Flow Chain](#96-flow_005--missing-catch-in-flow-chain)                                             |
+| `TEST_004`     | 6.4 | [runBlocking Instead of runTest](#64-test_004--runblocking-instead-of-runtest)                                        |
+| `INTEROP_001`  | 10.1 | [Wrapping Callbacks Without Cancellation Support](#101-interop_001--wrapping-callbacks-without-cancellation-support) |
+| `INTEROP_002`  | 10.2 | [callbackFlow Without awaitClose](#102-interop_002--callbackflow-without-awaitclose)                                 |
+| `KMP_001`      | 11.1 | [Dispatchers.IO in commonMain](#111-kmp_001--dispatchersio-in-commonmain)                                            |
 
 **Convention:** prefix by category (SCOPE, RUNBLOCK, DISPATCH, CANCEL, EXCEPT, TEST, CHANNEL, ARCH,
 FLOW) + 3-digit number. Use the code in diagnostic messages and link to this document with the
@@ -259,6 +267,33 @@ anchor above (e.g.
 | **Bad Practice** | Running tests that use `Dispatchers.Main` without replacing it. Behavior depends on the real main thread and can be flaky in CI.                                                                |
 | **Recommended**  | Use `Dispatchers.setMain(StandardTestDispatcher())` (or similar) before tests and `Dispatchers.resetMain()` in tearDown so code that uses Main runs deterministically under the test scheduler. |
 
+### 6.4 TEST_004 — runBlocking Instead of runTest
+
+|                  | Description                                                                                                                                                                                                                      |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Bad Practice** | Using `runBlocking` in `@Test` functions that contain `delay()` or other coroutine-test patterns. Real time passes, making tests slow and flaky. `delay(5_000)` in `runBlocking` waits 5 real seconds.                          |
+| **Recommended**  | Use `runTest` from `kotlinx-coroutines-test`. It runs coroutines with virtual time: `delay(5_000)` completes instantly. Use `advanceTimeBy()`, `advanceUntilIdle()`, and `runCurrent()` for precise time control in tests. |
+
+**Example:**
+
+```kotlin
+// [TEST_004] runBlocking with delay — 5 real seconds per test run
+@Test
+fun badSlowTest() = runBlocking {
+    delay(5_000)
+    assertEquals(expected, result)
+}
+
+// runTest — delay completes in microseconds using virtual time
+@Test
+fun goodFastTest() = runTest {
+    delay(5_000) // instant
+    assertEquals(expected, result)
+}
+```
+
+Tool support: Detekt, Android Lint, IntelliJ — rule `RunBlockingInsteadOfRunTest`.
+
 ---
 
 ## 7. Channels and Actors
@@ -328,6 +363,159 @@ anchor above (e.g.
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Bad Practice** | Creating `SharedFlow` with default configuration without considering slow subscribers, replay needs, or backpressure. This can lead to dropped events or blocking.                                                                                              |
 | **Recommended**  | Configure `replay`, `extraBufferCapacity`, and `onBufferOverflow` (e.g. `DROP_OLDEST`, `DROP_LATEST`, `SUSPEND`) according to whether you need recent values for new subscribers and how to handle overflow. StateFlow is effectively SharedFlow with replay=1. |
+
+### 9.5 FLOW_010 — MutableStateFlow/MutableSharedFlow Exposed as Public
+
+|                  | Description                                                                                                                                                                                                                                                     |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Bad Practice** | Declaring `MutableStateFlow` or `MutableSharedFlow` as a `public val`. External components can emit values, breaking Unidirectional Data Flow (UDF). Any caller outside the class can mutate state without going through intended business logic.               |
+| **Recommended**  | Use a private backing property (`_state`) of type `MutableStateFlow` and expose a read-only `StateFlow` via `.asStateFlow()`. Apply the same pattern for `MutableSharedFlow` / `.asSharedFlow()`.                                                              |
+
+**Example:**
+
+```kotlin
+// [FLOW_010] Mutable flow exposed publicly
+val uiState = MutableStateFlow<UiState>(UiState.Loading)
+
+// Backing property with read-only exposure
+private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
+val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+```
+
+Tool support: Detekt, IntelliJ — rule `MutableFlowExposed`.
+
+### 9.6 FLOW_005 — Missing catch in Flow Chain
+
+|                  | Description                                                                                                                                                                                                                                                                         |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Bad Practice** | A `.collect {}` or `.launchIn(scope)` call on a Flow chain with intermediate operators but no `.catch {}`. Exceptions from any upstream operator propagate to the parent scope and cancel it, causing silent crashes in production that are difficult to trace.                       |
+| **Recommended**  | Add `.catch { e -> }` before the terminal operator to handle errors locally. Avoid wrapping the entire chain in a generic `try/catch` — it does not compose well with Flow cancellation semantics. Exclude test source roots where propagation to the test scope is intentional. |
+
+**Example:**
+
+```kotlin
+// [FLOW_005] Uncaught exception cancels viewModelScope
+repository.getItems()
+    .map { it.toUiModel() }
+    .collect { _state.value = it }
+
+// catch before collect
+repository.getItems()
+    .map { it.toUiModel() }
+    .catch { e -> _error.value = e.message }
+    .collect { _state.value = it }
+```
+
+Tool support: Detekt, Android Lint, IntelliJ — rule `MissingCatchInFlow`.
+
+---
+
+## 10. Interoperability (Callbacks to Coroutines)
+
+### 10.1 INTEROP_001 — Wrapping Callbacks Without Cancellation Support
+
+|                  | Description                                                                                                                                                                                                                                                                   |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Bad Practice** | Using `suspendCoroutine` to wrap async callbacks. When the parent coroutine is cancelled the callback remains registered, leaking memory and resuming a dead continuation. The callback may call `resume` on a continuation that was already discarded, causing undefined behavior. |
+| **Recommended**  | Use `suspendCancellableCoroutine` and register cleanup in `invokeOnCancellation`. This ensures that when the parent coroutine cancels, the callback is unregistered and resources are released properly.                                                                         |
+
+**Example:**
+
+```kotlin
+// [INTEROP_001] suspendCoroutine does not support cancellation
+suspend fun fetchUser(id: String): User = suspendCoroutine { cont ->
+    api.getUser(id,
+        onSuccess = { cont.resume(it) },
+        onError = { cont.resumeWithException(it) }
+    )
+    // if parent cancels, the listener stays active
+}
+
+// suspendCancellableCoroutine + invokeOnCancellation for proper cleanup
+suspend fun fetchUser(id: String): User = suspendCancellableCoroutine { cont ->
+    val call = api.getUser(id,
+        onSuccess = { cont.resume(it) },
+        onError = { cont.resumeWithException(it) }
+    )
+    cont.invokeOnCancellation { call.cancel() }
+}
+```
+
+Tool support: Compiler Plugin, Detekt, IntelliJ — rule `SuspendCoroutineWithoutCancellation`.
+
+### 10.2 INTEROP_002 — callbackFlow Without awaitClose
+
+|                  | Description                                                                                                                                                                                                                                                     |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Bad Practice** | Using `callbackFlow { }` without `awaitClose { }`. Starting from kotlinx-coroutines 1.6, a `callbackFlow` without `awaitClose` throws `IllegalStateException` at runtime when the flow is cancelled. Additionally, registered listeners are never unregistered, causing memory leaks. |
+| **Recommended**  | Always include `awaitClose { /* unregister listener */ }` at the end of every `callbackFlow` block. `awaitClose` suspends until the collector cancels or completes, giving you the lifecycle hook to clean up. Note: this rule does NOT apply to `channelFlow`.   |
+
+**Example:**
+
+```kotlin
+// [INTEROP_002] callbackFlow without awaitClose — IllegalStateException + listener leak
+fun locationFlow(): Flow<Location> = callbackFlow {
+    val cb = LocationCallback { trySend(it) }
+    manager.register(cb)
+    // Missing awaitClose!
+}
+
+// callbackFlow with awaitClose ensures listener cleanup
+fun locationFlow(): Flow<Location> = callbackFlow {
+    val cb = LocationCallback { trySend(it) }
+    manager.register(cb)
+    awaitClose { manager.unregister(cb) }
+}
+```
+
+Tool support: Compiler Plugin, Detekt, IntelliJ — rule `CallbackFlowWithoutAwaitClose`.
+
+---
+
+## 11. Kotlin Multiplatform
+
+### 11.1 KMP_001 — Dispatchers.IO in commonMain
+
+|                  | Description                                                                                                                                                                                                                                                                                      |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Bad Practice** | Using `Dispatchers.IO` in `commonMain` source sets. `Dispatchers.IO` does not exist on Kotlin/Native (iOS, macOS) or Kotlin/JS. Code that uses it in shared sources crashes at runtime with `IllegalStateException: Dispatchers.IO is not supported` on those targets.                          |
+| **Recommended**  | Option A: Inject the dispatcher as a constructor parameter (default to `Dispatchers.Default` in common, `Dispatchers.IO` in JVM/Android). Option B: Use `expect`/`actual` declarations to provide the correct dispatcher per platform. Either approach keeps `commonMain` code platform-neutral. |
+
+**Example:**
+
+```kotlin
+// [KMP_001] Dispatchers.IO in commonMain — crash on iOS/JS
+// File: commonMain/src/.../Repository.kt
+suspend fun fetchData(): Data = withContext(Dispatchers.IO) {
+    httpClient.get(url)
+}
+
+// Option A: inject dispatcher (testable and KMP-safe)
+class Repository(private val ioDispatcher: CoroutineDispatcher = Dispatchers.Default) {
+    suspend fun fetchData(): Data = withContext(ioDispatcher) {
+        httpClient.get(url)
+    }
+}
+
+// Option B: expect/actual per platform
+// In commonMain:
+expect val ioDispatcher: CoroutineDispatcher
+// In jvmMain/androidMain:
+actual val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+// In iosMain:
+actual val ioDispatcher: CoroutineDispatcher = Dispatchers.Default
+```
+
+**Dispatcher availability by platform (kotlinx-coroutines 1.10.2):**
+
+| Platform                 | Dispatchers.Main            | Dispatchers.IO     | Dispatchers.Default |
+|--------------------------|:---------------------------:|:------------------:|:-------------------:|
+| JVM / Android            | yes (coroutines-android)    | yes                | yes                 |
+| iOS / macOS (Native)     | yes (main thread)           | **does not exist** | yes                 |
+| JS / WASM                | yes (microtask queue)       | **does not exist** | yes                 |
+| Linux / Windows (Native) | requires impl               | **does not exist** | yes                 |
+
+Tool support: Detekt, Android Lint — rule `DispatchersIOInCommonMain`.
 
 ---
 

--- a/docs/GRADUAL_ADOPTION.md
+++ b/docs/GRADUAL_ADOPTION.md
@@ -1,18 +1,32 @@
 # Gradual adoption guide
 
-This guide helps you adopt the Structured Coroutines plugin in an existing codebase without breaking the build. It covers **profiles** (relaxed → gradual → strict), **excluding** source sets or projects, and **suppression** best practices.
+This guide helps you adopt the Structured Coroutines plugin in an existing codebase without breaking
+the build. It covers **profiles** (relaxed → gradual → strict), **excluding** source sets or
+projects, and **suppression** best practices.
 
-**Related:** [gradle-plugin README](../gradle-plugin/README.md) (configuration), [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md) (suppression IDs).
+**Related:** [gradle-plugin README](../gradle-plugin/README.md) (
+configuration), [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md) (suppression IDs).
 
 ---
 
-## 1. Step-by-step path: Relaxed → Gradual → Strict
+## 1. Step-by-step path: Relaxed → Gradual → Strict → Platform Profile
 
-| Step | Profile | Goal |
-|------|---------|------|
-| **1. Relaxed / Gradual** | `useGradualProfile()` or `useRelaxedProfile()` | Enable the plugin with **all rules as warnings**. Build succeeds; you see findings in IDE and CI. |
-| **2. Fix and suppress** | Same | Fix violations where possible; use `@Suppress` for justified exceptions (see [Suppression best practices](#3-suppression-best-practices)). |
-| **3. Strict** | `useStrictProfile()` | Once the codebase is clean (or only documented exceptions remain), switch to strict so new violations fail the build. |
+| Step                                 | Profile                                                 | Goal                                                                                                                                       |
+|--------------------------------------|---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| **1. Relaxed / Gradual**             | `useGradualProfile()` or `useRelaxedProfile()`          | Enable the plugin with **all rules as warnings**. Build succeeds; you see findings in IDE and CI.                                          |
+| **2. Fix and suppress**              | Same                                                    | Fix violations where possible; use `@Suppress` for justified exceptions (see [Suppression best practices](#3-suppression-best-practices)). |
+| **3. Strict**                        | `useStrictProfile()`                                    | Once the codebase is clean (or only documented exceptions remain), switch to strict so new violations fail the build.                      |
+| **4. Platform profile** _(optional)_ | `useAndroidComposeProfile()` or `useKmpCommonProfile()` | Add interop-safety rules on top of strict for Android/Compose or KMP codebases.                                                            |
+
+**Available profiles:**
+
+| Profile                      | Use case          | Core rules         | INTEROP rules |
+|------------------------------|-------------------|--------------------|---------------|
+| `useGradualProfile()`        | Legacy migration  | all → warning      | warning       |
+| `useRelaxedProfile()`        | Same as gradual   | all → warning      | warning       |
+| `useStrictProfile()`         | Greenfield        | 7 error, 5 warning | error         |
+| `useAndroidComposeProfile()` | Android / Compose | strict             | error         |
+| `useKmpCommonProfile()`      | KMP common code   | strict             | error         |
 
 **Example: enable without breaking the build**
 
@@ -32,7 +46,15 @@ structuredCoroutines {
 
 ```kotlin
 structuredCoroutines {
-    useStrictProfile()   // 7 rules error, 4 warning; violations block the build
+    useStrictProfile()   // 7 rules error, 5 warning; violations block the build
+}
+```
+
+**Example: Android / Compose project (strict + interop)**
+
+```kotlin
+structuredCoroutines {
+    useAndroidComposeProfile()  // Strict + suspendCoroutine/callbackFlow rules as errors
 }
 ```
 
@@ -40,7 +62,8 @@ structuredCoroutines {
 
 ## 2. Excluding legacy code
 
-Use exclusions when you cannot fix or suppress in a given area yet, so the plugin does not run there.
+Use exclusions when you cannot fix or suppress in a given area yet, so the plugin does not run
+there.
 
 ### Exclude source sets
 
@@ -70,20 +93,24 @@ Use Gradle project paths (e.g. `:subproject`, `:app:feature`).
 
 ### When to exclude
 
-- **Temporary:** Legacy module that you will refactor later; exclude until you can run the plugin there.
-- **Permanent:** Optional; prefer fixing or suppressing so the whole codebase is under the same rules. Document why a module is excluded (e.g. in README or ADR).
+- **Temporary:** Legacy module that you will refactor later; exclude until you can run the plugin
+  there.
+- **Permanent:** Optional; prefer fixing or suppressing so the whole codebase is under the same
+  rules. Document why a module is excluded (e.g. in README or ADR).
 
 ---
 
 ## 3. Suppression best practices
 
-When you have a **justified exception** (e.g. deliberate `GlobalScope` for a process that must outlive the app), suppress the rule locally instead of disabling it globally.
+When you have a **justified exception** (e.g. deliberate `GlobalScope` for a process that must
+outlive the app), suppress the rule locally instead of disabling it globally.
 
 ### Do
 
 - **Suppress at the narrowest scope:** function or file, not whole module.
 - **Document why:** add a short comment next to `@Suppress` explaining the exception.
-- **Use the correct ID per tool:** see [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md) (Compiler vs Detekt vs Lint use different names for the same rule).
+- **Use the correct ID per tool:** see [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md) (Compiler vs
+  Detekt vs Lint use different names for the same rule).
 
 ```kotlin
 // Deliberate: fire-and-forget analytics that must survive activity lifecycle.
@@ -95,13 +122,15 @@ fun sendAnalyticsEvent(event: AnalyticsEvent) {
 
 ### Avoid
 
-- **Blanket suppression:** e.g. `@Suppress` on a whole file or package without fixing or documenting.
+- **Blanket suppression:** e.g. `@Suppress` on a whole file or package without fixing or
+  documenting.
 - **Suppressing multiple rules "just in case":** only suppress the rule that is actually reported.
 - **Disabling the plugin for the whole project** when exclusions or suppressions would be enough.
 
 ### Reference
 
-- **Rule codes and practices:** [BEST_PRACTICES_COROUTINES.md](BEST_PRACTICES_COROUTINES.md#rule-codes-reference)
+- **Rule codes and practices:
+  ** [BEST_PRACTICES_COROUTINES.md](BEST_PRACTICES_COROUTINES.md#rule-codes-reference)
 - **Suppression IDs by tool:** [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md)
 
 ---

--- a/docs/SUPPRESSING_RULES.md
+++ b/docs/SUPPRESSING_RULES.md
@@ -28,8 +28,11 @@ list of codes and suppression IDs per tool is in [rule-codes.yml](rule-codes.yml
 | CANCEL_001   | 4.1 | `LOOP_WITHOUT_YIELD`                                      | `LoopWithoutYield`                            | `LoopWithoutYield`                           | `LoopWithoutYield`                            |
 | EXCEPT_002   | 5.2 | `CANCELLATION_EXCEPTION_SUBCLASS`                         | `CancellationExceptionSubclass`               | `CancellationExceptionSubclass`              | `CancellationExceptionSubclass`              |
 | TEST_001     | 6.1 | —                                                         | `RunBlockingWithDelayInTest`                  | `RunBlockingWithDelayInTest`                 | —                                            |
+| TEST_004     | 6.4 | —                                                         | `RunBlockingInsteadOfRunTest`                 | `RunBlockingInsteadOfRunTest`                | `RunBlockingInsteadOfRunTest`                |
 | ARCH_002     | 8.2 | —                                                         | —                                             | `LifecycleAwareScope`, `ViewModelScopeLeak`, `LifecycleAwareFlowCollection` | `LifecycleAwareFlowCollection`                |
+| COMPOSE_001  | 8.3 | —                                                         | —                                             | `CollectAsStateWithoutLifecycle`             | `CollectAsStateWithoutLifecycle`              |
 | FLOW_001     | 9.1 | —                                                         | `FlowBlockingCall`                            | `FlowBlockingCall`                           | —                                            |
+| KMP_001      | 11.1 | —                                                         | `DispatchersIOInCommonMain`                  | `DispatchersIOInCommonMain`                   | `DispatchersIOInCommonMain`                   |
 
 **Note:** “—” means the rule is not implemented in that tool. When the same practice is reported by
 more than one diagnostic (e.g. SCOPE_003), suppress each identifier that applies to the code you’re

--- a/docs/SUPPRESSING_RULES.md
+++ b/docs/SUPPRESSING_RULES.md
@@ -31,7 +31,12 @@ list of codes and suppression IDs per tool is in [rule-codes.yml](rule-codes.yml
 | TEST_004     | 6.4 | —                                                         | `RunBlockingInsteadOfRunTest`                 | `RunBlockingInsteadOfRunTest`                | `RunBlockingInsteadOfRunTest`                |
 | ARCH_002     | 8.2 | —                                                         | —                                             | `LifecycleAwareScope`, `ViewModelScopeLeak`, `LifecycleAwareFlowCollection` | `LifecycleAwareFlowCollection`                |
 | COMPOSE_001  | 8.3 | —                                                         | —                                             | `CollectAsStateWithoutLifecycle`             | `CollectAsStateWithoutLifecycle`              |
-| FLOW_001     | 9.1 | —                                                         | `FlowBlockingCall`                            | `FlowBlockingCall`                           | —                                            |
+| FLOW_001     | 9.1  | —                                                         | `FlowBlockingCall`                            | `FlowBlockingCall`                           | —                                            |
+| FLOW_005     | 9.6  | —                                                         | `MissingCatchInFlow`                          | `MissingCatchInFlow`                         | `MissingCatchInFlow`                         |
+| FLOW_010     | 9.5  | —                                                         | `MutableFlowExposed`                          | —                                            | `MutableFlowExposed`                         |
+| CONCUR_003   | 1.5  | —                                                         | `SequentialAsyncAwait`                        | —                                            | `SequentialAsyncAwait`                       |
+| INTEROP_001  | 10.1 | `SUSPEND_COROUTINE_WITHOUT_CANCELLATION` (Compiler only; cannot suppress FIR this way — use Detekt/IDE instead) | `SuspendCoroutineWithoutCancellation` | —        | `SuspendCoroutineWithoutCancellation`        |
+| INTEROP_002  | 10.2 | `CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE` (Compiler only; cannot suppress FIR this way — use Detekt/IDE instead)     | `CallbackFlowWithoutAwaitClose`       | —        | `CallbackFlowWithoutAwaitClose`              |
 | KMP_001      | 11.1 | —                                                         | `DispatchersIOInCommonMain`                  | `DispatchersIOInCommonMain`                   | `DispatchersIOInCommonMain`                   |
 
 **Note:** “—” means the rule is not implemented in that tool. When the same practice is reported by

--- a/docs/rule-codes.yml
+++ b/docs/rule-codes.yml
@@ -186,7 +186,7 @@ rules:
     compiler: [SUSPEND_COROUTINE_WITHOUT_CANCELLATION]
     detekt: [SuspendCoroutineWithoutCancellation]
     lint: []
-    intellij: []
+    intellij: [SuspendCoroutineWithoutCancellation]
     default_severity: error
 
   - code: INTEROP_002
@@ -196,7 +196,7 @@ rules:
     compiler: [CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE]
     detekt: [CallbackFlowWithoutAwaitClose]
     lint: []
-    intellij: []
+    intellij: [CallbackFlowWithoutAwaitClose]
     default_severity: error
 
   - code: FLOW_005
@@ -206,7 +206,7 @@ rules:
     compiler: []
     detekt: [MissingCatchInFlow]
     lint: [MissingCatchInFlow]
-    intellij: []
+    intellij: [MissingCatchInFlow]
     default_severity: warning
 
   - code: FLOW_010
@@ -216,7 +216,7 @@ rules:
     compiler: []
     detekt: [MutableFlowExposed]
     lint: []
-    intellij: []
+    intellij: [MutableFlowExposed]
     default_severity: warning
 
   - code: CONCUR_003
@@ -226,7 +226,7 @@ rules:
     compiler: []
     detekt: [SequentialAsyncAwait]
     lint: []
-    intellij: []
+    intellij: [SequentialAsyncAwait]
     default_severity: warning
 
   - code: TEST_004

--- a/docs/rule-codes.yml
+++ b/docs/rule-codes.yml
@@ -178,3 +178,83 @@ rules:
     intellij: []
     default_severity: warning
     notes: "Android-only; not implemented in Detekt or Compiler."
+
+  - code: INTEROP_001
+    section: "10.1"
+    title: "Wrapping Callbacks Without Cancellation Support"
+    doc_anchor: "101-interop_001--wrapping-callbacks-without-cancellation-support"
+    compiler: [SUSPEND_COROUTINE_WITHOUT_CANCELLATION]
+    detekt: [SuspendCoroutineWithoutCancellation]
+    lint: []
+    intellij: []
+    default_severity: error
+
+  - code: INTEROP_002
+    section: "10.2"
+    title: "callbackFlow Without awaitClose"
+    doc_anchor: "102-interop_002--callbackflow-without-awaitclose"
+    compiler: [CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE]
+    detekt: [CallbackFlowWithoutAwaitClose]
+    lint: []
+    intellij: []
+    default_severity: error
+
+  - code: FLOW_005
+    section: "9.6"
+    title: "Missing catch in Flow Chain"
+    doc_anchor: "96-flow_005--missing-catch-in-flow-chain"
+    compiler: []
+    detekt: [MissingCatchInFlow]
+    lint: [MissingCatchInFlow]
+    intellij: []
+    default_severity: warning
+
+  - code: FLOW_010
+    section: "9.5"
+    title: "MutableStateFlow/MutableSharedFlow Exposed as Public"
+    doc_anchor: "95-flow_010--mutablestateflow-exposed"
+    compiler: []
+    detekt: [MutableFlowExposed]
+    lint: []
+    intellij: []
+    default_severity: warning
+
+  - code: CONCUR_003
+    section: "1.5"
+    title: "Sequential async/await (wasted parallelism)"
+    doc_anchor: "15-concur_003--sequential-asyncawait"
+    compiler: []
+    detekt: [SequentialAsyncAwait]
+    lint: []
+    intellij: []
+    default_severity: warning
+
+  - code: TEST_004
+    section: "6.4"
+    title: "runBlocking Instead of runTest"
+    doc_anchor: "64-test_004--runblocking-instead-of-runtest"
+    compiler: []
+    detekt: [RunBlockingInsteadOfRunTest]
+    lint: [RunBlockingInsteadOfRunTest]
+    intellij: [RunBlockingInsteadOfRunTest]
+    default_severity: warning
+
+  - code: KMP_001
+    section: "11.1"
+    title: "Dispatchers.IO in commonMain"
+    doc_anchor: "111-kmp_001--dispatchersio-in-commonmain"
+    compiler: []
+    detekt: [DispatchersIOInCommonMain]
+    lint: [DispatchersIOInCommonMain]
+    intellij: [DispatchersIOInCommonMain]
+    default_severity: error
+
+  - code: COMPOSE_001
+    section: "8.3"
+    title: "collectAsState Without Lifecycle Awareness"
+    doc_anchor: "83-compose_001--collectasstate-without-lifecycle-awareness"
+    compiler: []
+    detekt: []
+    lint: [CollectAsStateWithoutLifecycle]
+    intellij: [CollectAsStateWithoutLifecycle]
+    default_severity: warning

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -104,6 +104,11 @@ structuredCoroutines {
     suspendInFinally.set("warning")                    // Default: "warning"
     cancellationExceptionSwallowed.set("warning")      // Default: "warning"
     redundantLaunchInCoroutineScope.set("warning")     // Default: "warning"
+    loopWithoutYield.set("warning")                    // Default: "warning"
+
+    // Interop rules — v0.8.0 (enforcement active in Phase 2; configurable now)
+    suspendCoroutineWithoutCancellation.set("error")   // Default: "error"
+    callbackFlowWithoutAwaitClose.set("error")         // Default: "error"
 }
 ```
 
@@ -120,33 +125,42 @@ You can apply a preset instead of configuring each rule:
 
 ```kotlin
 structuredCoroutines {
-    useStrictProfile()   // Default: 7 error, 4 warning (greenfield)
-    // useGradualProfile()  // All rules warning (migration)
-    // useRelaxedProfile()   // Same as gradual
+    useStrictProfile()           // Default: 7 error, 5 warning (greenfield)
+    // useGradualProfile()       // All rules warning (migration)
+    // useRelaxedProfile()       // Same as gradual
+    // useAndroidComposeProfile()// Strict + INTEROP rules as errors (Android / Compose)
+    // useKmpCommonProfile()     // Same as AndroidCompose (KMP common code)
 }
 ```
 
-| Profile   | When to use | Effect |
-|-----------|--------------|--------|
-| **Strict**  | New projects or when you want the build to fail on violations | 7 rules → error, 4 rules → warning (defaults) |
-| **Gradual** | Migrating legacy code; build must not fail while you fix issues | All 11 rules → **warning** |
-| **Relaxed** | Same as gradual; see findings without blocking the build | All 11 rules → **warning** |
+| Profile              | When to use | Effect |
+|----------------------|-------------|--------|
+| **Strict**           | Greenfield projects; fail the build on any violation | 7 rules → error, 5 rules → warning |
+| **Gradual**          | Migrating legacy code; build must not fail while you fix issues | All 12 rules → **warning** |
+| **Relaxed**          | Same as Gradual | All 12 rules → **warning** |
+| **AndroidCompose**   | Android / Jetpack Compose projects; adds INTEROP rules as errors | Strict + INTEROP_001/002 → error |
+| **KmpCommon**        | KMP common-code modules | Same as AndroidCompose |
 
 **Severity per rule by profile:**
 
-| Rule                              | Strict | Gradual / Relaxed |
-|-----------------------------------|--------|-------------------|
-| `globalScopeUsage`                | error  | warning           |
-| `inlineCoroutineScope`            | error  | warning           |
-| `unstructuredLaunch`              | error  | warning           |
-| `runBlockingInSuspend`            | error  | warning           |
-| `jobInBuilderContext`             | error  | warning           |
-| `cancellationExceptionSubclass`   | error  | warning           |
-| `unusedDeferred`                  | error  | warning           |
-| `dispatchersUnconfined`           | warning| warning           |
-| `suspendInFinally`                | warning| warning           |
-| `cancellationExceptionSwallowed`  | warning| warning           |
-| `redundantLaunchInCoroutineScope` | warning| warning           |
+| Rule                                    | Strict  | Gradual / Relaxed | AndroidCompose / KmpCommon |
+|-----------------------------------------|---------|-------------------|----------------------------|
+| `globalScopeUsage`                      | error   | warning           | error                      |
+| `inlineCoroutineScope`                  | error   | warning           | error                      |
+| `unstructuredLaunch`                    | error   | warning           | error                      |
+| `runBlockingInSuspend`                  | error   | warning           | error                      |
+| `jobInBuilderContext`                   | error   | warning           | error                      |
+| `cancellationExceptionSubclass`         | error   | warning           | error                      |
+| `unusedDeferred`                        | error   | warning           | error                      |
+| `dispatchersUnconfined`                 | warning | warning           | warning                    |
+| `suspendInFinally`                      | warning | warning           | warning                    |
+| `cancellationExceptionSwallowed`        | warning | warning           | warning                    |
+| `redundantLaunchInCoroutineScope`       | warning | warning           | warning                    |
+| `loopWithoutYield`                      | warning | warning           | warning                    |
+| `suspendCoroutineWithoutCancellation` ¹ | error   | warning           | error                      |
+| `callbackFlowWithoutAwaitClose` ¹       | error   | warning           | error                      |
+
+¹ Configuration available now; rule enforcement lands in v0.8.0 Phase 2.
 
 ### Excluding source sets and projects
 
@@ -185,27 +199,33 @@ This plugin is the **recommended single entry point** for structured-coroutines:
 
 ### Summary Table
 
-| Rule                              | Default Severity | Description                                         |
-|-----------------------------------|------------------|-----------------------------------------------------|
-| `globalScopeUsage`                | Error            | Detects `GlobalScope.launch/async`                  |
-| `inlineCoroutineScope`            | Error            | Detects `CoroutineScope(...).launch/async`          |
-| `unstructuredLaunch`              | Error            | Detects launch on non-annotated scopes              |
-| `runBlockingInSuspend`            | Error            | Detects `runBlocking` in suspend functions          |
-| `jobInBuilderContext`             | Error            | Detects `Job()`/`SupervisorJob()` in builders       |
-| `cancellationExceptionSubclass`   | Error            | Detects classes extending `CancellationException`   |
-| `unusedDeferred`                  | Error            | Detects `async` without `await()`                   |
-| `dispatchersUnconfined`           | Warning          | Detects `Dispatchers.Unconfined` usage              |
-| `suspendInFinally`                | Warning          | Detects suspend in finally without `NonCancellable` |
-| `cancellationExceptionSwallowed`  | Warning          | Detects `catch(Exception)` swallowing cancellation  |
-| `redundantLaunchInCoroutineScope` | Warning          | Detects redundant launch in `coroutineScope`        |
+| Rule                                    | Default Severity | Description                                              |
+|-----------------------------------------|------------------|----------------------------------------------------------|
+| `globalScopeUsage`                      | Error            | Detects `GlobalScope.launch/async`                       |
+| `inlineCoroutineScope`                  | Error            | Detects `CoroutineScope(...).launch/async`               |
+| `unstructuredLaunch`                    | Error            | Detects launch on non-annotated scopes                   |
+| `runBlockingInSuspend`                  | Error            | Detects `runBlocking` in suspend functions               |
+| `jobInBuilderContext`                   | Error            | Detects `Job()`/`SupervisorJob()` in builders            |
+| `cancellationExceptionSubclass`         | Error            | Detects classes extending `CancellationException`        |
+| `unusedDeferred`                        | Error            | Detects `async` without `await()`                        |
+| `dispatchersUnconfined`                 | Warning          | Detects `Dispatchers.Unconfined` usage                   |
+| `suspendInFinally`                      | Warning          | Detects suspend in `finally` without `NonCancellable`    |
+| `cancellationExceptionSwallowed`        | Warning          | Detects `catch(Exception)` swallowing cancellation       |
+| `redundantLaunchInCoroutineScope`       | Warning          | Detects redundant `launch` inside `coroutineScope`       |
+| `loopWithoutYield`                      | Warning          | Detects loops in suspend functions with no yield point   |
+| `suspendCoroutineWithoutCancellation` ¹ | Error            | Detects `suspendCoroutine` without cancellation support  |
+| `callbackFlowWithoutAwaitClose` ¹       | Error            | Detects `callbackFlow` without `awaitClose`              |
+
+¹ Configuration available now; rule enforcement lands in v0.8.0 Phase 2.
 
 ### Rules Count
 
-| Severity          | Count  |
-|-------------------|--------|
-| Error (default)   | 7      |
-| Warning (default) | 4      |
-| **Total**         | **11** |
+| Severity                          | Count  |
+|-----------------------------------|--------|
+| Error (default, active)           | 7      |
+| Warning (default, active)         | 5      |
+| Error (default, v0.8.0 Phase 2) ¹ | 2      |
+| **Total configurable**            | **14** |
 
 ---
 
@@ -231,6 +251,24 @@ structuredCoroutines {
 ```kotlin
 structuredCoroutines {
     useGradualProfile()
+}
+```
+
+**Android / Compose project:** strict defaults plus INTEROP rules (suspendCoroutine, callbackFlow)
+as errors — the right choice for Compose-heavy codebases.
+
+```kotlin
+structuredCoroutines {
+    useAndroidComposeProfile()
+}
+```
+
+**Kotlin Multiplatform (common code):** same as AndroidCompose; Compose-specific Lint checks are
+a no-op on non-Android targets so this profile is safe everywhere.
+
+```kotlin
+structuredCoroutines {
+    useKmpCommonProfile()
 }
 ```
 

--- a/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesExtension.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesExtension.kt
@@ -124,6 +124,18 @@ interface StructuredCoroutinesExtension {
     val loopWithoutYield: Property<String>
 
     /**
+     * Severity for `suspendCoroutine` without cancellation support (INTEROP_001).
+     * Default: "error"
+     */
+    val suspendCoroutineWithoutCancellation: Property<String>
+
+    /**
+     * Severity for `callbackFlow` without `awaitClose` (INTEROP_002).
+     * Default: "error"
+     */
+    val callbackFlowWithoutAwaitClose: Property<String>
+
+    /**
      * Source set (compilation) names to exclude from the compiler plugin.
      * Excluded compilations will not run the Structured Coroutines plugin.
      * Use for legacy modules or test source sets during migration.
@@ -190,6 +202,8 @@ interface StructuredCoroutinesExtension {
         cancellationExceptionSwallowed.set("warning")
         redundantLaunchInCoroutineScope.set("warning")
         loopWithoutYield.set("warning")
+        suspendCoroutineWithoutCancellation.set("error")
+        callbackFlowWithoutAwaitClose.set("error")
     }
 
     /**
@@ -209,6 +223,8 @@ interface StructuredCoroutinesExtension {
         cancellationExceptionSwallowed.set("warning")
         redundantLaunchInCoroutineScope.set("warning")
         loopWithoutYield.set("warning")
+        suspendCoroutineWithoutCancellation.set("warning")
+        callbackFlowWithoutAwaitClose.set("warning")
     }
 
     /**
@@ -217,5 +233,24 @@ interface StructuredCoroutinesExtension {
      */
     fun useRelaxedProfile() {
         useGradualProfile()
+    }
+
+    /**
+     * Android Compose–oriented profile per `docs/plan/ITERATION_PLAN_2.md` (v0.8.0 Iteración 1):
+     * strict compiler defaults plus INTEROP_001/002 as errors. Additional Detekt/Lint rules from the
+     * plan are enabled when those tasks land in later phases.
+     */
+    fun useAndroidComposeProfile() {
+        useStrictProfile()
+        suspendCoroutineWithoutCancellation.set("error")
+        callbackFlowWithoutAwaitClose.set("error")
+    }
+
+    /**
+     * Kotlin Multiplatform common-code profile per iteration plan: same baseline as
+     * [useAndroidComposeProfile] (Compose-specific Lint is a no-op on non-Android modules).
+     */
+    fun useKmpCommonProfile() {
+        useAndroidComposeProfile()
     }
 }

--- a/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesGradlePlugin.kt
@@ -59,6 +59,8 @@ class StructuredCoroutinesGradlePlugin : KotlinCompilerPluginSupportPlugin {
         extension.unusedDeferred.convention("error")
         extension.redundantLaunchInCoroutineScope.convention("warning")
         extension.loopWithoutYield.convention("warning")
+        extension.suspendCoroutineWithoutCancellation.convention("error")
+        extension.callbackFlowWithoutAwaitClose.convention("error")
         extension.excludeSourceSets.convention(emptyList())
         extension.excludeProjects.convention(emptyList())
 
@@ -88,6 +90,8 @@ class StructuredCoroutinesGradlePlugin : KotlinCompilerPluginSupportPlugin {
             task.unusedDeferred.set(extension.unusedDeferred)
             task.redundantLaunchInCoroutineScope.set(extension.redundantLaunchInCoroutineScope)
             task.loopWithoutYield.set(extension.loopWithoutYield)
+            task.suspendCoroutineWithoutCancellation.set(extension.suspendCoroutineWithoutCancellation)
+            task.callbackFlowWithoutAwaitClose.set(extension.callbackFlowWithoutAwaitClose)
 
             task.excludedSourceSets.set(extension.excludeSourceSets)
             task.excludedProjects.set(extension.excludeProjects)
@@ -139,6 +143,8 @@ class StructuredCoroutinesGradlePlugin : KotlinCompilerPluginSupportPlugin {
                 add(SubpluginOption("unusedDeferred", extension.unusedDeferred.get()))
                 add(SubpluginOption("redundantLaunchInCoroutineScope", extension.redundantLaunchInCoroutineScope.get()))
                 add(SubpluginOption("loopWithoutYield", extension.loopWithoutYield.get()))
+                add(SubpluginOption("suspendCoroutineWithoutCancellation", extension.suspendCoroutineWithoutCancellation.get()))
+                add(SubpluginOption("callbackFlowWithoutAwaitClose", extension.callbackFlowWithoutAwaitClose.get()))
             }
         }
     }

--- a/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesReportTask.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesReportTask.kt
@@ -74,6 +74,8 @@ abstract class StructuredCoroutinesReportTask : DefaultTask() {
         RuleInfo("cancellationExceptionSwallowed","CANCEL_003",   "4.3", "Swallowing CancellationException",                  "43-cancel_003--swallowing-cancellationexception"),
         RuleInfo("suspendInFinally",              "CANCEL_004",   "4.4", "Suspendable Cleanup Without NonCancellable",         "44-cancel_004--suspendable-cleanup-without-noncancellable"),
         RuleInfo("cancellationExceptionSubclass", "EXCEPT_002",   "5.2", "Extending CancellationException for Domain Errors",  "52-except_002--extending-cancellationexception-for-domain-errors"),
+        RuleInfo("suspendCoroutineWithoutCancellation", "INTEROP_001", "10.1", "Wrapping Callbacks Without Cancellation Support", "101-interop_001--wrapping-callbacks-without-cancellation-support"),
+        RuleInfo("callbackFlowWithoutAwaitClose", "INTEROP_002", "10.2", "callbackFlow Without awaitClose", "102-interop_002--callbackflow-without-awaitclose"),
     )
 
     private val docBase =
@@ -97,6 +99,8 @@ abstract class StructuredCoroutinesReportTask : DefaultTask() {
     @get:Input abstract val unusedDeferred: Property<String>
     @get:Input abstract val redundantLaunchInCoroutineScope: Property<String>
     @get:Input abstract val loopWithoutYield: Property<String>
+    @get:Input abstract val suspendCoroutineWithoutCancellation: Property<String>
+    @get:Input abstract val callbackFlowWithoutAwaitClose: Property<String>
 
     // Exclusions
     @get:Input abstract val excludedSourceSets: ListProperty<String>
@@ -129,6 +133,8 @@ abstract class StructuredCoroutinesReportTask : DefaultTask() {
             "unusedDeferred"                 to unusedDeferred.get(),
             "redundantLaunchInCoroutineScope" to redundantLaunchInCoroutineScope.get(),
             "loopWithoutYield"               to loopWithoutYield.get(),
+            "suspendCoroutineWithoutCancellation" to suspendCoroutineWithoutCancellation.get(),
+            "callbackFlowWithoutAwaitClose"  to callbackFlowWithoutAwaitClose.get(),
         )
 
         val format    = reportFormat.getOrElse("all")

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ kotlin.code.style=official
 # Single source for group/version; applied in root build.gradle.kts allprojects {}.
 # Artifact IDs are set per module via mavenPublishing.coordinates().
 PROJECT_GROUP=io.github.santimattius
-PROJECT_VERSION=0.7.1
+PROJECT_VERSION=0.8.0-ALPHA01
 # Maven Central
 mavenCentralPublishing=true
 signAllPublications=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ junit-jupiter = "5.10.2"
 junit = "4.13.2"
 assertj = "3.25.3"
 kotlinx-coroutines = "1.10.2"
+lifecycle-runtime-compose = "2.8.0"
 intellij-platform = "2.11.0"
 intellij-ide = "2026.1"
 
@@ -33,6 +34,8 @@ assertj-core = { group = "org.assertj", name = "assertj-core", version.ref = "as
 
 # Coroutines
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle-runtime-compose" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -157,7 +157,7 @@ kotlin {
 
 tasks.test {
     useJUnitPlatform()
-    val toolchains = extensions.getByType(JavaToolchainService::class.java)
+    val toolchains = project.extensions.getByType(JavaToolchainService::class.java)
     javaLauncher.set(
         toolchains.launcherFor {
             languageVersion.set(JavaLanguageVersion.of(21))

--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "io.github.santimattius"
-version = "0.7.0"
+version = "0.8.0-ALPHA01"
 
 repositories {
     mavenCentral()

--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -8,6 +8,9 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
     id("org.jetbrains.intellij.platform") version libs.versions.intellij.platform.get()
@@ -32,8 +35,24 @@ dependencies {
         testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Platform)
     }
 
-    testImplementation(libs.junit.jupiter)
+    // Jupiter 5.11+ / Platform 1.11+ — Gradle 9's JUnitPlatform worker expects newer platform APIs
+    // (e.g. CloseAction.closeAutoCloseables); pinning avoids NoSuchMethodError with mixed transitive versions.
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.4")
     testImplementation(libs.assertj.core)
+}
+
+configurations.named("testRuntimeClasspath") {
+    resolutionStrategy {
+        force(
+            "org.junit.jupiter:junit-jupiter-api:5.11.4",
+            "org.junit.jupiter:junit-jupiter-engine:5.11.4",
+            "org.junit.jupiter:junit-jupiter-params:5.11.4",
+            "org.junit.platform:junit-platform-commons:1.11.4",
+            "org.junit.platform:junit-platform-engine:1.11.4",
+            "org.junit.platform:junit-platform-launcher:1.11.4",
+        )
+    }
 }
 
 intellijPlatform {
@@ -138,6 +157,12 @@ kotlin {
 
 tasks.test {
     useJUnitPlatform()
+    val toolchains = extensions.getByType(JavaToolchainService::class.java)
+    javaLauncher.set(
+        toolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        },
+    )
 }
 
 // ──────────────────────────────────────────────

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/CallbackFlowWithoutAwaitCloseInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/CallbackFlowWithoutAwaitCloseInspection.kt
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.quickfixes.AddAwaitCloseQuickFix
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtLambdaArgument
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+
+/**
+ * [INTEROP_002] — `callbackFlow` without `awaitClose` causes `IllegalStateException` at runtime
+ * and leaks registered listeners.
+ *
+ * Detects `callbackFlow { }` lambda bodies that do not contain any `awaitClose(...)` call.
+ *
+ * Exclusion: `channelFlow` has different semantics and does not require `awaitClose`.
+ */
+class CallbackFlowWithoutAwaitCloseInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.callback.flow.without.await.close.display.name"
+    override val descriptionKey = "inspection.callback.flow.without.await.close.description"
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+                if (expression.calleeExpression?.text != "callbackFlow") return
+
+                val file = expression.containingKtFile
+                if (!CoroutinesImportFilter.fileImportsCoroutines(file)) return
+
+                // Get the trailing lambda body of callbackFlow
+                val lambdaArg = expression.lambdaArguments.firstOrNull()
+                    ?: expression.valueArguments.filterIsInstance<KtLambdaArgument>().firstOrNull()
+                    ?: return
+
+                val lambdaBody = lambdaArg.getLambdaExpression()?.bodyExpression ?: return
+
+                // Check if awaitClose is present anywhere in the lambda body
+                val hasAwaitClose = lambdaBody.collectDescendantsOfType<KtCallExpression>()
+                    .any { it.calleeExpression?.text == "awaitClose" }
+
+                if (!hasAwaitClose) {
+                    holder.registerProblem(
+                        expression,
+                        StructuredCoroutinesBundle.message("error.interop.callback.flow.without.await.close"),
+                        AddAwaitCloseQuickFix()
+                    )
+                }
+            }
+        }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/CollectAsStateWithoutLifecycleInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/CollectAsStateWithoutLifecycleInspection.kt
@@ -11,6 +11,8 @@ import com.intellij.codeInspection.ProblemsHolder
 import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
 import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
 import io.github.santimattius.structured.intellij.utils.ComposePsiUtils
+import io.github.santimattius.structured.intellij.utils.importsComposeRuntime
+import io.github.santimattius.structured.intellij.utils.importsKotlinxCoroutinesFlow
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtVisitorVoid
 
@@ -28,9 +30,9 @@ class CollectAsStateWithoutLifecycleInspection : CoroutineInspectionBase() {
                 super.visitCallExpression(expression)
                 if (expression.calleeExpression?.text != "collectAsState") return
 
-                val file = expression.containingKtFile
-                if (!ComposePsiUtils.importsComposeRuntime(file)) return
-                if (!ComposePsiUtils.importsKotlinxCoroutinesFlow(file)) return
+                val ktFile = expression.containingKtFile
+                if (!ktFile.importsComposeRuntime()) return
+                if (!ktFile.importsKotlinxCoroutinesFlow()) return
 
                 if (!ComposePsiUtils.hasComposableAncestor(expression)) return
                 if (ComposePsiUtils.hasPreviewAncestor(expression)) return

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/CollectAsStateWithoutLifecycleInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/CollectAsStateWithoutLifecycleInspection.kt
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.utils.ComposePsiUtils
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+/**
+ * [COMPOSE_001] — `Flow.collectAsState()` recomposes endlessly when inactive unless lifecycle-aware collector is used.
+ */
+class CollectAsStateWithoutLifecycleInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.collect.as.state.lifecycle.display.name"
+    override val descriptionKey = "inspection.collect.as.state.lifecycle.description"
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid {
+        return object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+                if (expression.calleeExpression?.text != "collectAsState") return
+
+                val file = expression.containingKtFile
+                if (!ComposePsiUtils.importsComposeRuntime(file)) return
+                if (!ComposePsiUtils.importsKotlinxCoroutinesFlow(file)) return
+
+                if (!ComposePsiUtils.hasComposableAncestor(expression)) return
+                if (ComposePsiUtils.hasPreviewAncestor(expression)) return
+
+                holder.registerProblem(
+                    expression,
+                    StructuredCoroutinesBundle.message("error.compose.collect.as.state"),
+                )
+            }
+        }
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/DispatchersIOInCommonMainInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/DispatchersIOInCommonMainInspection.kt
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.intellij.utils.KotlinCommonSourcePsiUtils
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+/**
+ * [KMP_001] — `Dispatchers.IO` in `commonMain` / `commonTest` sources (virtual path heuristic).
+ */
+class DispatchersIOInCommonMainInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.dispatchers.io.common.display.name"
+    override val descriptionKey = "inspection.dispatchers.io.common.description"
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+                super.visitDotQualifiedExpression(expression)
+                val file = expression.containingKtFile
+                if (!CoroutinesImportFilter.fileImportsCoroutines(file)) return
+                val path = file.virtualFilePath
+                if (!KotlinCommonSourcePsiUtils.looksLikeKotlinCommonVirtualPath(path)) return
+
+                val condensed = expression.text.replace("\\s+".toRegex(), "")
+                    .removePrefix("kotlinx.coroutines.")
+                if (condensed != "Dispatchers.IO" && !condensed.endsWith(".Dispatchers.IO")) return
+
+                holder.registerProblem(
+                    expression,
+                    StructuredCoroutinesBundle.message("error.kmp.dispatchers.io.common"),
+                )
+            }
+        }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/MissingCatchInFlowInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/MissingCatchInFlowInspection.kt
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.quickfixes.AddCatchOperatorQuickFix
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtTryExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+
+/**
+ * [FLOW_005] — Flow chain is missing a `.catch {}` operator.
+ *
+ * Detects `.collect { }`, `.collectLatest { }`, or `.launchIn(scope)` calls that are
+ * preceded by at least one intermediate operator (`.map`, `.filter`, `.flatMapLatest`, etc.)
+ * without a `.catch { }` in the chain.
+ *
+ * Exclusions:
+ * - Chains inside `try/catch(Throwable/Exception)` blocks.
+ * - Chains that already have `.catch {}` in the expression.
+ * - Test files (paths containing `/test/` or `/androidTest/`).
+ */
+class MissingCatchInFlowInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.missing.catch.in.flow.display.name"
+    override val descriptionKey = "inspection.missing.catch.in.flow.description"
+
+    private val terminalOperators = setOf("collect", "collectLatest", "launchIn")
+    private val intermediateOperators = setOf(
+        "map", "filter", "flatMapLatest", "flatMapMerge", "flatMapConcat",
+        "onEach", "transform", "mapLatest", "filterNot", "filterIsInstance",
+        "take", "drop", "debounce", "distinctUntilChanged", "combine",
+        "zip", "merge", "buffer", "conflate", "flowOn"
+    )
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+
+                val calleeName = expression.calleeExpression?.text ?: return
+                if (calleeName !in terminalOperators) return
+
+                val file = expression.containingKtFile
+                if (!CoroutinesImportFilter.fileImportsCoroutines(file)) return
+
+                // Exclusion: test files
+                val path = file.virtualFilePath.replace('\\', '/')
+                if (path.contains("/test/") || path.contains("/androidTest/") ||
+                    path.contains("/commonTest/") || path.contains("/iosTest/")) return
+
+                // The terminal operator must be a dot-qualified expression receiver
+                val dotExpr = expression.parent as? KtDotQualifiedExpression ?: return
+
+                // Walk back the dot chain to find intermediate operators and check for .catch {}
+                if (!hasIntermediateOperator(dotExpr)) return
+                if (hasCatchInChain(dotExpr)) return
+
+                // Exclusion: inside try/catch(Exception) or try/catch(Throwable)
+                if (isInsideBroadCatch(expression)) return
+
+                holder.registerProblem(
+                    expression,
+                    StructuredCoroutinesBundle.message("error.flow.missing.catch.in.flow"),
+                    AddCatchOperatorQuickFix()
+                )
+            }
+        }
+
+    /**
+     * Checks if the dot-qualified chain (ending at the terminal operator call) contains
+     * at least one intermediate Flow operator.
+     */
+    private fun hasIntermediateOperator(terminalDotExpr: KtDotQualifiedExpression): Boolean {
+        var receiver = terminalDotExpr.receiverExpression
+        while (receiver is KtDotQualifiedExpression) {
+            val selectorCall = receiver.selectorExpression as? KtCallExpression
+            val name = selectorCall?.calleeExpression?.text ?: ""
+            if (name in intermediateOperators) return true
+            receiver = receiver.receiverExpression
+        }
+        // Also check if the outermost receiver itself is an intermediate call
+        val receiverCall = receiver as? KtCallExpression
+        return receiverCall?.calleeExpression?.text in intermediateOperators
+    }
+
+    /**
+     * Checks if `.catch` appears anywhere in the dot-qualified chain.
+     */
+    private fun hasCatchInChain(dotExpr: KtDotQualifiedExpression): Boolean {
+        var receiver: Any? = dotExpr.receiverExpression
+        while (receiver is KtDotQualifiedExpression) {
+            val selectorCall = receiver.selectorExpression as? KtCallExpression
+            if (selectorCall?.calleeExpression?.text == "catch") return true
+            receiver = receiver.receiverExpression
+        }
+        return false
+    }
+
+    /**
+     * Returns true if [element] is inside a `try` block whose catch clause catches
+     * `Exception` or `Throwable` broadly.
+     */
+    private fun isInsideBroadCatch(element: KtCallExpression): Boolean {
+        val tryExpr = element.getParentOfType<KtTryExpression>(strict = true) ?: return false
+        return tryExpr.catchClauses.any { clause ->
+            val typeText = clause.catchParameter?.typeReference?.text ?: ""
+            typeText == "Exception" || typeText == "Throwable" ||
+                typeText.endsWith(".Exception") || typeText.endsWith(".Throwable")
+        }
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/MutableFlowExposedInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/MutableFlowExposedInspection.kt
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.quickfixes.ReplaceWithBackingPropertyQuickFix
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.intellij.utils.ComposePsiUtils
+import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+/**
+ * [FLOW_010] — `MutableStateFlow` or `MutableSharedFlow` exposed as a public property breaks
+ * encapsulation. Consumers should only see the read-only interface.
+ *
+ * Detects `public val` whose declared or inferred type contains `MutableStateFlow` or
+ * `MutableSharedFlow`.
+ *
+ * Exclusions:
+ * - Properties inside test objects (class names ending in `Test`/`Tests`/`Spec`).
+ * - Properties inside `@Preview` annotated composable functions.
+ */
+class MutableFlowExposedInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.mutable.flow.exposed.display.name"
+    override val descriptionKey = "inspection.mutable.flow.exposed.description"
+
+    private val mutableFlowTypes = setOf("MutableStateFlow", "MutableSharedFlow")
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitProperty(property: KtProperty) {
+                super.visitProperty(property)
+
+                // Only flag public properties
+                if (!property.isPublic()) return
+
+                val file = property.containingKtFile
+                if (!CoroutinesImportFilter.fileImportsCoroutines(file)) return
+
+                // Check declared type annotation
+                val typeRef = property.typeReference?.text ?: ""
+                val initializerText = property.initializer?.text ?: ""
+
+                val typeIsMutableFlow = mutableFlowTypes.any { mutableType ->
+                    typeRef.contains(mutableType) || initializerText.startsWith(mutableType)
+                }
+
+                if (!typeIsMutableFlow) return
+
+                // Exclusion: inside test classes
+                if (isInsideTestClass(property)) return
+
+                // Exclusion: inside @Preview composables
+                if (ComposePsiUtils.hasPreviewAncestor(property)) return
+
+                holder.registerProblem(
+                    property,
+                    StructuredCoroutinesBundle.message("error.flow.mutable.flow.exposed"),
+                    ReplaceWithBackingPropertyQuickFix()
+                )
+            }
+        }
+
+    private fun KtProperty.isPublic(): Boolean {
+        // A property is public if it has no visibility modifier (default is public)
+        // or has an explicit `public` modifier
+        val hasPrivate = hasModifier(KtTokens.PRIVATE_KEYWORD)
+        val hasProtected = hasModifier(KtTokens.PROTECTED_KEYWORD)
+        val hasInternal = hasModifier(KtTokens.INTERNAL_KEYWORD)
+        return !hasPrivate && !hasProtected && !hasInternal
+    }
+
+    private fun isInsideTestClass(property: KtProperty): Boolean {
+        var parent = property.parent
+        while (parent != null) {
+            when (parent) {
+                is KtClass -> {
+                    val name = parent.name ?: return false
+                    return name.endsWith("Test") || name.endsWith("Tests") || name.endsWith("Spec")
+                }
+                is KtObjectDeclaration -> {
+                    val name = parent.name ?: return false
+                    return name.endsWith("Test") || name.endsWith("Tests") || name.endsWith("Spec")
+                }
+            }
+            parent = parent.parent
+        }
+        return false
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/RunBlockingInsteadOfRunTestInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/RunBlockingInsteadOfRunTestInspection.kt
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.intellij.utils.CoroutinePsiUtils
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+
+/**
+ * [TEST_004] — `@Test fun … = runBlocking { … }` should prefer `runTest` from kotlinx-coroutines-test.
+ */
+class RunBlockingInsteadOfRunTestInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.runblocking.instead.runtest.display.name"
+    override val descriptionKey = "inspection.runblocking.instead.runtest.description"
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitNamedFunction(function: KtNamedFunction) {
+                super.visitNamedFunction(function)
+                val file = function.containingKtFile
+                if (!CoroutinePsiUtils.looksLikeJvmTestKotlinFile(file)) return
+                if (!CoroutinesImportFilter.fileImportsCoroutines(file)) return
+                if (!function.hasJvmTestNamedAnnotation()) return
+
+                val bodyExpr = function.bodyExpression as? KtCallExpression ?: return
+                if (bodyExpr.calleeExpression?.text != "runBlocking") return
+                if (bodyExpr.runBlockingLambdaSubtreeContainsDelay()) return
+
+                holder.registerProblem(
+                    bodyExpr,
+                    StructuredCoroutinesBundle.message("error.test.runblocking.instead.runtest"),
+                )
+            }
+        }
+
+    private fun KtNamedFunction.hasJvmTestNamedAnnotation(): Boolean =
+        annotationEntries.any { it.shortName?.asString() == "Test" }
+
+    /** If `delay(...)` sits under this `runBlocking`, defer to TEST_001 (RunBlockingWithDelayInTest). */
+    private fun KtCallExpression.runBlockingLambdaSubtreeContainsDelay(): Boolean =
+        collectDescendantsOfType<KtCallExpression>()
+            .any { it !== this && it.calleeExpression?.text == "delay" }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/SequentialAsyncAwaitInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/SequentialAsyncAwaitInspection.kt
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.quickfixes.ReplaceSequentialAsyncAwaitWithContextQuickFix
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+/**
+ * [CONCUR_003] — Sequential `async { }.await()` adds [kotlinx.coroutines.Deferred] overhead without parallelism.
+ */
+class SequentialAsyncAwaitInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.sequential.async.await.display.name"
+    override val descriptionKey = "inspection.sequential.async.await.description"
+
+    override fun getShortName(): String = "SequentialAsyncAwait"
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+                super.visitDotQualifiedExpression(expression)
+                val file = expression.containingKtFile
+                if (!CoroutinesImportFilter.fileImportsCoroutines(file)) return
+
+                val selector = expression.selectorExpression as? KtCallExpression ?: return
+                if (selector.calleeExpression?.text != "await") return
+
+                val asyncCall = expression.receiverExpression as? KtCallExpression ?: return
+                if (asyncCall.calleeExpression?.text != "async") return
+
+                holder.registerProblem(
+                    selector,
+                    StructuredCoroutinesBundle.message("error.concur.sequential.async.await"),
+                    ReplaceSequentialAsyncAwaitWithContextQuickFix()
+                )
+            }
+        }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/StructuredCoroutinesInspectionProvider.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/StructuredCoroutinesInspectionProvider.kt
@@ -38,7 +38,12 @@ class StructuredCoroutinesInspectionProvider : InspectionToolProvider {
             WithTimeoutScopeCancellationInspection::class.java,
             CollectAsStateWithoutLifecycleInspection::class.java,
             RunBlockingInsteadOfRunTestInspection::class.java,
-            DispatchersIOInCommonMainInspection::class.java
+            DispatchersIOInCommonMainInspection::class.java,
+            SuspendCoroutineWithoutCancellationInspection::class.java,
+            CallbackFlowWithoutAwaitCloseInspection::class.java,
+            MutableFlowExposedInspection::class.java,
+            MissingCatchInFlowInspection::class.java,
+            SequentialAsyncAwaitInspection::class.java
         )
     }
 }

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/StructuredCoroutinesInspectionProvider.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/StructuredCoroutinesInspectionProvider.kt
@@ -35,7 +35,10 @@ class StructuredCoroutinesInspectionProvider : InspectionToolProvider {
             DispatchersUnconfinedInspection::class.java,
             LoopWithoutYieldInspection::class.java,
             LifecycleAwareFlowCollectionInspection::class.java,
-            WithTimeoutScopeCancellationInspection::class.java
+            WithTimeoutScopeCancellationInspection::class.java,
+            CollectAsStateWithoutLifecycleInspection::class.java,
+            RunBlockingInsteadOfRunTestInspection::class.java,
+            DispatchersIOInCommonMainInspection::class.java
         )
     }
 }

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/SuspendCoroutineWithoutCancellationInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/SuspendCoroutineWithoutCancellationInspection.kt
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.quickfixes.ReplaceSuspendCoroutineQuickFix
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFinallySection
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtTryExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+
+/**
+ * [INTEROP_001] — `suspendCoroutine` does not support coroutine cancellation.
+ *
+ * Detects calls to `suspendCoroutine { }` inside suspend functions and suggests
+ * replacing them with `suspendCancellableCoroutine` to properly support cancellation.
+ *
+ * Exclusion: jvmMain code with explicit try/finally cleanup block is excluded to avoid
+ * false positives when the developer has already handled resource cleanup.
+ */
+class SuspendCoroutineWithoutCancellationInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.suspend.coroutine.without.cancellation.display.name"
+    override val descriptionKey = "inspection.suspend.coroutine.without.cancellation.description"
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+                if (expression.calleeExpression?.text != "suspendCoroutine") return
+
+                val file = expression.containingKtFile
+                if (!CoroutinesImportFilter.fileImportsCoroutines(file)) return
+
+                // Must be inside a suspend function
+                val enclosingFun = expression.getParentOfType<KtNamedFunction>(strict = true)
+                    ?: return
+                if (!enclosingFun.hasModifier(KtTokens.SUSPEND_KEYWORD)) return
+
+                // Exclusion: if inside try/finally with explicit cleanup, skip
+                if (isInsideTryFinallyCleanup(expression)) return
+
+                holder.registerProblem(
+                    expression,
+                    StructuredCoroutinesBundle.message("error.interop.suspend.coroutine.without.cancellation"),
+                    ReplaceSuspendCoroutineQuickFix()
+                )
+            }
+        }
+
+    /**
+     * Returns true if the suspendCoroutine call is inside a try block that has a
+     * finally section — indicating the developer is already managing cleanup.
+     */
+    private fun isInsideTryFinallyCleanup(expression: KtCallExpression): Boolean {
+        val tryExpr = expression.getParentOfType<KtTryExpression>(strict = true) ?: return false
+        return tryExpr.finallyBlock != null
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/AddAwaitCloseQuickFix.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/AddAwaitCloseQuickFix.kt
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.intellij.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtLambdaArgument
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+/**
+ * Appends [kotlinx.coroutines.channels.awaitClose] to a [kotlinx.coroutines.flow.callbackFlow] block.
+ */
+class AddAwaitCloseQuickFix : LocalQuickFix {
+
+    override fun getName(): String =
+        StructuredCoroutinesBundle.message("quickfix.add.await.close")
+
+    override fun getFamilyName(): String = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val call = descriptor.psiElement as? KtCallExpression ?: return
+        val factory = KtPsiFactory(project, markGenerated = false)
+        val lambdaArg = call.lambdaArguments.firstOrNull()
+            ?: call.valueArguments.filterIsInstance<KtLambdaArgument>().firstOrNull()
+            ?: return
+        val lambda = lambdaArg.getLambdaExpression() ?: return
+        val body = lambda.bodyExpression ?: return
+
+        val awaitCloseLine = "awaitClose { }"
+        val inner = when (body) {
+            is KtBlockExpression -> body.statements.joinToString("\n") { it.text }
+            else -> body.text
+        }
+        body.replace(factory.createBlock("$inner\n$awaitCloseLine"))
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/AddCatchOperatorQuickFix.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/AddCatchOperatorQuickFix.kt
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.intellij.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+/**
+ * Inserts a [kotlinx.coroutines.flow.catch] before the terminal Flow operator.
+ */
+class AddCatchOperatorQuickFix : LocalQuickFix {
+
+    override fun getName(): String =
+        StructuredCoroutinesBundle.message("quickfix.add.catch.operator")
+
+    override fun getFamilyName(): String = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val terminal = descriptor.psiElement as? KtCallExpression ?: return
+        val dot = terminal.parent as? KtDotQualifiedExpression ?: return
+        val receiver = dot.receiverExpression
+        val selector = dot.selectorExpression ?: return
+        val factory = KtPsiFactory(project, markGenerated = false)
+        val replacement = factory.createExpression(
+            "${receiver.text}.catch { e -> throw e }.${selector.text}"
+        )
+        dot.replace(replacement)
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceSequentialAsyncAwaitWithContextQuickFix.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceSequentialAsyncAwaitWithContextQuickFix.kt
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.intellij.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtLambdaArgument
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+/**
+ * Replaces `async { }.await()` with `withContext(coroutineContext) { }` for sequential work.
+ */
+class ReplaceSequentialAsyncAwaitWithContextQuickFix : LocalQuickFix {
+
+    override fun getName(): String =
+        StructuredCoroutinesBundle.message("quickfix.replace.async.await.with.with.context")
+
+    override fun getFamilyName(): String = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val awaitCall = descriptor.psiElement as? KtCallExpression ?: return
+        val dot = awaitCall.parent as? KtDotQualifiedExpression ?: return
+        val asyncCall = dot.receiverExpression as? KtCallExpression ?: return
+        val factory = KtPsiFactory(project, markGenerated = false)
+        val lambdaArg = asyncCall.lambdaArguments.firstOrNull()
+            ?: asyncCall.valueArguments.filterIsInstance<KtLambdaArgument>().firstOrNull()
+            ?: return
+        val lambdaBody = lambdaArg.getLambdaExpression()?.bodyExpression ?: return
+        val inner = when (lambdaBody) {
+            is KtBlockExpression -> lambdaBody.statements.joinToString("\n") { it.text }
+            else -> lambdaBody.text
+        }
+        val replacement = factory.createExpression("withContext(coroutineContext) {\n$inner\n}")
+        dot.replace(replacement)
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceSuspendCoroutineQuickFix.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceSuspendCoroutineQuickFix.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.intellij.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+/**
+ * Replaces [kotlinx.coroutines.suspendCoroutine] with [kotlinx.coroutines.suspendCancellableCoroutine].
+ */
+class ReplaceSuspendCoroutineQuickFix : LocalQuickFix {
+
+    override fun getName(): String =
+        StructuredCoroutinesBundle.message("quickfix.replace.suspend.coroutine.with.cancellable")
+
+    override fun getFamilyName(): String = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val call = descriptor.psiElement as? KtCallExpression ?: return
+        val factory = KtPsiFactory(project, markGenerated = false)
+        val text = call.text.replaceFirst("suspendCoroutine", "suspendCancellableCoroutine")
+        call.replace(factory.createExpression(text))
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceWithBackingPropertyQuickFix.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceWithBackingPropertyQuickFix.kt
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.intellij.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+/**
+ * Splits a public [kotlinx.coroutines.flow.MutableStateFlow] / [MutableSharedFlow] property into
+ * a private mutable backing field and a read-only [kotlinx.coroutines.flow.StateFlow] / [SharedFlow].
+ */
+class ReplaceWithBackingPropertyQuickFix : LocalQuickFix {
+
+    override fun getName(): String =
+        StructuredCoroutinesBundle.message("quickfix.replace.with.backing.property")
+
+    override fun getFamilyName(): String = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val prop = descriptor.psiElement as? KtProperty ?: return
+        val name = prop.name ?: return
+        val initializer = prop.initializer?.text ?: return
+        val factory = KtPsiFactory(project, markGenerated = false)
+        val backing = "_$name"
+        val readOnly =
+            if (initializer.contains("MutableSharedFlow")) "asSharedFlow()"
+            else "asStateFlow()"
+        val privateProp = factory.createProperty("private val $backing = $initializer")
+        val publicProp = factory.createProperty("val $name = $backing.$readOnly")
+        prop.replace(privateProp)
+        privateProp.parent?.addAfter(publicProp, privateProp)
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/ComposePsiUtils.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/ComposePsiUtils.kt
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.intellij.utils
+
+import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+/**
+ * Kotlin PSI helpers for Jetpack Compose ([COMPOSE_001]).
+ * Keep aligned with `lint-rules/.../ComposePsiUtils.kt`.
+ */
+object ComposePsiUtils {
+
+    fun KtFile.importsComposeRuntime(): Boolean =
+        importDirectives.any {
+            val fq = it.importedFqName?.asString().orEmpty()
+            fq.startsWith("androidx.compose.runtime")
+        }
+
+    fun KtFile.importsKotlinxCoroutinesFlow(): Boolean =
+        importDirectives.any {
+            val fq = it.importedFqName?.asString().orEmpty()
+            fq.startsWith("kotlinx.coroutines.flow")
+        }
+
+    fun hasPreviewAncestor(element: KtElement): Boolean =
+        enclosingAnnotatedElements(element).any { annotated ->
+            annotated.annotationEntries.any { entry ->
+                when (entry.shortName?.asString()) {
+                    "Preview", "MultiPreview" -> true
+                    else -> false
+                }
+            }
+        }
+
+    fun hasComposableAncestor(element: KtElement): Boolean =
+        enclosingAnnotatedElements(element).any { annotated ->
+            annotated.annotationEntries.any { it.shortName?.asString() == "Composable" }
+        }
+
+    private fun enclosingAnnotatedElements(element: KtElement): List<KtAnnotated> {
+        val result = mutableListOf<KtAnnotated>()
+        var p: KtElement? = element.parent as? KtElement
+        while (p != null) {
+            when (p) {
+                is KtNamedFunction -> result += p
+                is KtLambdaExpression -> result += p.functionLiteral
+                else -> { }
+            }
+            p = p.parent as? KtElement
+        }
+        return result
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/ComposePsiUtils.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/ComposePsiUtils.kt
@@ -33,19 +33,38 @@ fun KtFile.importsKotlinxCoroutinesFlow(): Boolean =
  */
 object ComposePsiUtils {
 
-    fun hasPreviewAncestor(element: KtElement): Boolean =
-        enclosingAnnotatedElements(element).any { annotated ->
-            annotated.annotationEntries.any { entry ->
-                when (entry.shortName?.asString()) {
-                    "Preview", "MultiPreview" -> true
-                    else -> false
-                }
-            }
-        }
+    private const val COMPOSABLE_FQN = "androidx.compose.runtime.Composable"
+    private const val PREVIEW_FQN = "androidx.compose.ui.tooling.preview.Preview"
+    private const val MULTI_PREVIEW_FQN = "androidx.compose.ui.tooling.preview.MultiPreview"
 
-    fun hasComposableAncestor(element: KtElement): Boolean =
-        enclosingAnnotatedElements(element).any { annotated ->
-            annotated.annotationEntries.any { it.shortName?.asString() == "Composable" }
+    fun hasPreviewAncestor(element: KtElement): Boolean {
+        val ktFile = element.containingFile as? KtFile ?: return false
+        val previewNames = buildSet {
+            add("Preview")
+            add("MultiPreview")
+            addAll(ktFile.aliasNamesFor(PREVIEW_FQN))
+            addAll(ktFile.aliasNamesFor(MULTI_PREVIEW_FQN))
+        }
+        return enclosingAnnotatedElements(element).any { annotated ->
+            annotated.annotationEntries.any { it.shortName?.asString() in previewNames }
+        }
+    }
+
+    fun hasComposableAncestor(element: KtElement): Boolean {
+        val ktFile = element.containingFile as? KtFile ?: return false
+        val composableNames = buildSet {
+            add("Composable")
+            addAll(ktFile.aliasNamesFor(COMPOSABLE_FQN))
+        }
+        return enclosingAnnotatedElements(element).any { annotated ->
+            annotated.annotationEntries.any { it.shortName?.asString() in composableNames }
+        }
+    }
+
+    private fun KtFile.aliasNamesFor(fqName: String): List<String> =
+        importDirectives.mapNotNull { directive ->
+            if (directive.importedFqName?.asString() != fqName) return@mapNotNull null
+            directive.alias?.name
         }
 
     private fun enclosingAnnotatedElements(element: KtElement): List<KtAnnotated> {

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/ComposePsiUtils.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/ComposePsiUtils.kt
@@ -13,23 +13,25 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+fun KtFile.importsComposeRuntime(): Boolean =
+    importDirectives.any {
+        val fq = it.importedFqName?.asString().orEmpty()
+        fq.startsWith("androidx.compose.runtime")
+    }
+
+fun KtFile.importsKotlinxCoroutinesFlow(): Boolean =
+    importDirectives.any {
+        val fq = it.importedFqName?.asString().orEmpty()
+        fq.startsWith("kotlinx.coroutines.flow")
+    }
+
 /**
  * Kotlin PSI helpers for Jetpack Compose ([COMPOSE_001]).
  * Keep aligned with `lint-rules/.../ComposePsiUtils.kt`.
+ *
+ * Import checks live as top-level [KtFile] extensions so callers use `file.importsComposeRuntime()`.
  */
 object ComposePsiUtils {
-
-    fun KtFile.importsComposeRuntime(): Boolean =
-        importDirectives.any {
-            val fq = it.importedFqName?.asString().orEmpty()
-            fq.startsWith("androidx.compose.runtime")
-        }
-
-    fun KtFile.importsKotlinxCoroutinesFlow(): Boolean =
-        importDirectives.any {
-            val fq = it.importedFqName?.asString().orEmpty()
-            fq.startsWith("kotlinx.coroutines.flow")
-        }
 
     fun hasPreviewAncestor(element: KtElement): Boolean =
         enclosingAnnotatedElements(element).any { annotated ->

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/CoroutinePsiUtils.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/CoroutinePsiUtils.kt
@@ -517,4 +517,16 @@ object CoroutinePsiUtils {
         })
         return result
     }
+
+    /**
+     * Gradle/JVM test-ish source heuristic (JUnit-style names or files under conventional test dirs).
+     */
+    fun looksLikeJvmTestKotlinFile(file: KtFile): Boolean {
+        val path = file.virtualFilePath.replace('\\', '/')
+        return file.name.endsWith("Test.kt") ||
+            file.name.endsWith("Tests.kt") ||
+            file.name.endsWith("Spec.kt") ||
+            path.contains("/test/") ||
+            path.contains("/androidTest/")
+    }
 }

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/KotlinCommonSourcePsiUtils.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/KotlinCommonSourcePsiUtils.kt
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.intellij.utils
+
+/**
+ * KMP-aware virtual paths aligned with Lint [io.github.santimattius.structured.lint.utils.KotlinCommonSourceLintUtils].
+ */
+object KotlinCommonSourcePsiUtils {
+
+    fun looksLikeKotlinCommonVirtualPath(virtualPath: String): Boolean {
+        val normalized = virtualPath.replace('\\', '/')
+        return normalized.contains("/commonMain/") || normalized.contains("/commonTest/")
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/view/InspectionGuideRegistry.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/view/InspectionGuideRegistry.kt
@@ -10,8 +10,11 @@
 package io.github.santimattius.structured.intellij.view
 
 import io.github.santimattius.structured.intellij.inspections.AsyncWithoutAwaitInspection
+import io.github.santimattius.structured.intellij.inspections.CallbackFlowWithoutAwaitCloseInspection
 import io.github.santimattius.structured.intellij.inspections.CancellationExceptionSubclassInspection
 import io.github.santimattius.structured.intellij.inspections.CancellationExceptionSwallowedInspection
+import io.github.santimattius.structured.intellij.inspections.CollectAsStateWithoutLifecycleInspection
+import io.github.santimattius.structured.intellij.inspections.DispatchersIOInCommonMainInspection
 import io.github.santimattius.structured.intellij.inspections.DispatchersUnconfinedInspection
 import io.github.santimattius.structured.intellij.inspections.GlobalScopeInspection
 import io.github.santimattius.structured.intellij.inspections.InlineCoroutineScopeInspection
@@ -19,8 +22,13 @@ import io.github.santimattius.structured.intellij.inspections.JobInBuilderContex
 import io.github.santimattius.structured.intellij.inspections.LifecycleAwareFlowCollectionInspection
 import io.github.santimattius.structured.intellij.inspections.LoopWithoutYieldInspection
 import io.github.santimattius.structured.intellij.inspections.MainDispatcherMisuseInspection
+import io.github.santimattius.structured.intellij.inspections.MissingCatchInFlowInspection
+import io.github.santimattius.structured.intellij.inspections.MutableFlowExposedInspection
 import io.github.santimattius.structured.intellij.inspections.RunBlockingInSuspendInspection
+import io.github.santimattius.structured.intellij.inspections.RunBlockingInsteadOfRunTestInspection
 import io.github.santimattius.structured.intellij.inspections.ScopeReuseAfterCancelInspection
+import io.github.santimattius.structured.intellij.inspections.SequentialAsyncAwaitInspection
+import io.github.santimattius.structured.intellij.inspections.SuspendCoroutineWithoutCancellationInspection
 import io.github.santimattius.structured.intellij.inspections.SuspendInFinallyInspection
 import io.github.santimattius.structured.intellij.inspections.UnstructuredLaunchInspection
 import io.github.santimattius.structured.intellij.inspections.WithTimeoutScopeCancellationInspection
@@ -105,6 +113,38 @@ object InspectionGuideRegistry {
         WithTimeoutScopeCancellationInspection::class.java to GuideEntry(
             whatToDo = "Replace withTimeout with withTimeoutOrNull to get null on timeout without cancelling the parent scope. Or catch TimeoutCancellationException explicitly.",
             guideUrl = "$BASE_URL#46-cancel_006--withtimeout-and-scope-cancellation"
+        ),
+        CollectAsStateWithoutLifecycleInspection::class.java to GuideEntry(
+            whatToDo = "Use collectAsStateWithLifecycle() from lifecycle-runtime-compose so collection pauses when the lifecycle is not at least STARTED.",
+            guideUrl = "$BASE_URL#83-compose_001--collectasstate-without-lifecycle-awareness"
+        ),
+        RunBlockingInsteadOfRunTestInspection::class.java to GuideEntry(
+            whatToDo = "Replace runBlocking with runTest from kotlinx-coroutines-test for virtual time and structured TestScope.",
+            guideUrl = "$BASE_URL#64-test_004--runblocking-instead-of-runtest"
+        ),
+        DispatchersIOInCommonMainInspection::class.java to GuideEntry(
+            whatToDo = "Inject CoroutineDispatcher from platform code or use expect/actual — Dispatchers.IO is not available in Kotlin/Common on Native/JS.",
+            guideUrl = "$BASE_URL#111-kmp_001--dispatchersio-in-commonmain"
+        ),
+        SuspendCoroutineWithoutCancellationInspection::class.java to GuideEntry(
+            whatToDo = "Replace suspendCoroutine with suspendCancellableCoroutine and use invokeOnCancellation for cleanup.",
+            guideUrl = "$BASE_URL#101-interop_001--wrapping-callbacks-without-cancellation-support"
+        ),
+        CallbackFlowWithoutAwaitCloseInspection::class.java to GuideEntry(
+            whatToDo = "Add awaitClose { } inside callbackFlow to unregister listeners when the collector leaves.",
+            guideUrl = "$BASE_URL#102-interop_002--callbackflow-without-awaitclose"
+        ),
+        MutableFlowExposedInspection::class.java to GuideEntry(
+            whatToDo = "Use a private MutableStateFlow/MutableSharedFlow with a public read-only asStateFlow()/asSharedFlow() property.",
+            guideUrl = "$BASE_URL#95-flow_010--mutablestateflow-exposed"
+        ),
+        MissingCatchInFlowInspection::class.java to GuideEntry(
+            whatToDo = "Add .catch { } before collect/collectLatest/launchIn so upstream operator failures are handled.",
+            guideUrl = "$BASE_URL#96-flow_005--missing-catch-in-flow-chain"
+        ),
+        SequentialAsyncAwaitInspection::class.java to GuideEntry(
+            whatToDo = "Use withContext(coroutineContext) { } for sequential work, or start multiple async calls without awaiting between them.",
+            guideUrl = "$BASE_URL#15-concur_003--sequential-asyncawait"
         )
     )
 

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/view/StructuredCoroutinesInspectionRunner.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/view/StructuredCoroutinesInspectionRunner.kt
@@ -60,14 +60,16 @@ object StructuredCoroutinesInspectionRunner {
      *
      * This method is intended to be called from a background thread
      * (e.g. inside a [com.intellij.openapi.progress.Task.Backgroundable]).
-     * PSI access is wrapped in [ReadAction.compute] automatically by [runOnFile];
-     * file collection here runs inside a single read action for efficiency.
+     * File collection uses [ReadAction.compute] for read-lock sections (older IDEs lack
+     * [ReadAction.computeBlocking]; the Plugin Verifier treats that as a compatibility error).
+     * Per-file work is done in [runOnFile].
      *
      * @param project The project to scan.
      * @param indicator Optional progress indicator — updated with fraction and current file name.
      *                  The scan stops early if the indicator is cancelled.
      * @return Aggregated findings across all Kotlin source files, sorted by file path then line.
      */
+    @Suppress("DEPRECATION")
     fun runOnProject(project: Project, indicator: ProgressIndicator? = null): List<Finding> {
         val ktFiles: Collection<VirtualFile> = ReadAction.compute<Collection<VirtualFile>, Throwable> {
             FileTypeIndex.getFiles(KotlinFileType.INSTANCE, GlobalSearchScope.projectScope(project))

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/view/StructuredCoroutinesToolWindowFactory.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/view/StructuredCoroutinesToolWindowFactory.kt
@@ -25,6 +25,12 @@ import java.util.WeakHashMap
  */
 class StructuredCoroutinesToolWindowFactory : ToolWindowFactory, DumbAware {
 
+    /**
+     * Avoids the default [ToolWindowFactory.isApplicableAsync] implementation, which delegates
+     * to deprecated [ToolWindowFactory.isApplicable] and is flagged by the Plugin Verifier.
+     */
+    override suspend fun isApplicableAsync(project: Project): Boolean = true
+
     companion object {
         const val TOOL_WINDOW_ID = "StructuredCoroutines"
 

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -399,7 +399,8 @@
             id="StructuredCoroutines"
             factoryClass="io.github.santimattius.structured.intellij.view.StructuredCoroutinesToolWindowFactory"
             anchor="bottom"
-            secondary="false"/>
+            secondary="false"
+            doNotActivateOnStart="false"/>
     </extensions>
 
     <actions>

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,11 @@
             <li>collectAsState without lifecycle-aware collection (Compose)</li>
             <li>runBlocking instead of runTest in JUnit bodies (TEST_004)</li>
             <li>Dispatchers.IO in Kotlin common sources (KMP)</li>
+            <li>suspendCoroutine without cancellation (INTEROP_001)</li>
+            <li>callbackFlow without awaitClose (INTEROP_002)</li>
+            <li>MutableStateFlow/MutableSharedFlow exposed publicly (FLOW_010)</li>
+            <li>Flow chains missing .catch before collect (FLOW_005)</li>
+            <li>Sequential async/await (CONCUR_003)</li>
         </ul>
     ]]></description>
 
@@ -262,6 +267,66 @@
             enabledByDefault="true"
             level="ERROR"
             implementationClass="io.github.santimattius.structured.intellij.inspections.DispatchersIOInCommonMainInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="SuspendCoroutineWithoutCancellation"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.suspend.coroutine.without.cancellation.display.name"
+            enabledByDefault="true"
+            level="ERROR"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.SuspendCoroutineWithoutCancellationInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="CallbackFlowWithoutAwaitClose"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.callback.flow.without.await.close.display.name"
+            enabledByDefault="true"
+            level="ERROR"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.CallbackFlowWithoutAwaitCloseInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="MutableFlowExposed"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.mutable.flow.exposed.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.MutableFlowExposedInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="MissingCatchInFlow"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.missing.catch.in.flow.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.MissingCatchInFlowInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="SequentialAsyncAwait"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.sequential.async.await.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.SequentialAsyncAwaitInspection"/>
 
         <localInspection
             language="kotlin"

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -38,6 +38,9 @@
             <li>CancellationException swallowed</li>
             <li>CancellationException subclass (domain error)</li>
             <li>Dispatchers.Unconfined usage</li>
+            <li>collectAsState without lifecycle-aware collection (Compose)</li>
+            <li>runBlocking instead of runTest in JUnit bodies (TEST_004)</li>
+            <li>Dispatchers.IO in Kotlin common sources (KMP)</li>
         </ul>
     ]]></description>
 
@@ -223,6 +226,42 @@
             enabledByDefault="true"
             level="WARNING"
             implementationClass="io.github.santimattius.structured.intellij.inspections.LifecycleAwareFlowCollectionInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="CollectAsStateWithoutLifecycle"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.collect.as.state.lifecycle.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.CollectAsStateWithoutLifecycleInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="RunBlockingInsteadOfRunTest"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.runblocking.instead.runtest.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.RunBlockingInsteadOfRunTestInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="DispatchersIOInCommonMain"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.dispatchers.io.common.display.name"
+            enabledByDefault="true"
+            level="ERROR"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.DispatchersIOInCommonMainInspection"/>
 
         <localInspection
             language="kotlin"

--- a/intellij-plugin/src/main/resources/messages/StructuredCoroutinesBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/StructuredCoroutinesBundle.properties
@@ -57,6 +57,21 @@ inspection.runblocking.instead.runtest.description=<html>Using <code>@Test fun �
 inspection.dispatchers.io.common.display.name=Dispatchers.IO in common Kotlin sources
 inspection.dispatchers.io.common.description=<html><code>Dispatchers.IO</code> is not available from Kotlin/Common code targeting Native or JS.<br/><br/><b>KMP_001</b>. Inject <code>CoroutineDispatcher</code> from platform code or provide an <code>expect</code>/<code>actual</code>.<br/><a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#111-kmp_001--dispatchersio-in-commonmain">Learn more</a></html>
 
+inspection.suspend.coroutine.without.cancellation.display.name=suspendCoroutine without cancellation support
+inspection.suspend.coroutine.without.cancellation.description=<html><code>suspendCoroutine</code> does not support coroutine cancellation. Use <code>suspendCancellableCoroutine</code> and call <code>invokeOnCancellation</code> to release resources.<br/><br/><b>INTEROP_001</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#101-interop_001">Learn more</a></html>
+
+inspection.callback.flow.without.await.close.display.name=callbackFlow without awaitClose
+inspection.callback.flow.without.await.close.description=<html><code>callbackFlow</code> without <code>awaitClose</code> causes <code>IllegalStateException</code> at runtime and leaks listeners. Add <code>awaitClose { }</code> to properly clean up.<br/><br/><b>INTEROP_002</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#102-interop_002">Learn more</a></html>
+
+inspection.mutable.flow.exposed.display.name=MutableStateFlow/MutableSharedFlow exposed as public
+inspection.mutable.flow.exposed.description=<html>Exposing <code>MutableStateFlow</code> or <code>MutableSharedFlow</code> as a public property breaks encapsulation. Use a backing property with <code>asStateFlow()</code>/<code>asSharedFlow()</code>.<br/><br/><b>FLOW_010</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md">Learn more</a></html>
+
+inspection.missing.catch.in.flow.display.name=Flow chain missing catch operator
+inspection.missing.catch.in.flow.description=<html>Flow chain is missing a <code>.catch {}</code> operator. Unhandled exceptions will propagate to the parent scope.<br/><br/><b>FLOW_005</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md">Learn more</a></html>
+
+inspection.sequential.async.await.display.name=Sequential async-await (use withContext instead)
+inspection.sequential.async.await.description=<html><code>async { }.await()</code> is equivalent to <code>withContext</code> but creates an unnecessary <code>Deferred</code>. Use <code>withContext(coroutineContext) { }</code> or launch multiple <code>async</code> blocks in parallel.<br/><br/><b>CONCUR_003</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md">Learn more</a></html>
+
 # Quick Fix Names
 quickfix.replace.global.scope=Replace with {0}
 quickfix.replace.global.scope.viewmodel=Replace GlobalScope with viewModelScope
@@ -77,6 +92,11 @@ quickfix.add.delay.in.loop=Add delay(0) in loop
 quickfix.add.cooperation.point.in.loop.family=Add cooperation point in loop
 quickfix.change.superclass.to.exception=Change superclass to Exception
 quickfix.replace.with.timeout.or.null=Replace withTimeout with withTimeoutOrNull
+quickfix.replace.suspend.coroutine.with.cancellable=Replace suspendCoroutine with suspendCancellableCoroutine
+quickfix.add.await.close=Add awaitClose { } to callbackFlow
+quickfix.replace.with.backing.property=Convert to backing property with asStateFlow()/asSharedFlow()
+quickfix.add.catch.operator=Add .catch { e -> } operator
+quickfix.replace.async.await.with.with.context=Replace async { }.await() with withContext(coroutineContext) { }
 
 # Intention Names
 intention.category=Structured Coroutines
@@ -125,6 +145,11 @@ error.with.timeout.scope.cancellation=[CANCEL_006] withTimeout may cancel the pa
 error.compose.collect.as.state=[COMPOSE_001] collectAsState() is not lifecycle-aware. Prefer collectAsStateWithLifecycle() on Android screens. See: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#83-compose_001--collectasstate-without-lifecycle-awareness
 error.test.runblocking.instead.runtest=[TEST_004] Prefer runTest instead of runBlocking as the direct @Test body. See: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#64-test_004--runblocking-instead-of-runtest
 error.kmp.dispatchers.io.common=[KMP_001] Dispatchers.IO in commonMain/commonTest – use injected dispatcher or expect/actual. See: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#111-kmp_001--dispatchersio-in-commonmain
+error.interop.suspend.coroutine.without.cancellation=[INTEROP_001] 'suspendCoroutine' does not support cancellation. Use 'suspendCancellableCoroutine' and call 'invokeOnCancellation' to release resources. See BEST_PRACTICES §10.1
+error.interop.callback.flow.without.await.close=[INTEROP_002] 'callbackFlow' without 'awaitClose' causes 'IllegalStateException' at runtime and leaks listeners. Add 'awaitClose { }' to properly clean up.
+error.flow.mutable.flow.exposed=[FLOW_010] 'MutableStateFlow'/'MutableSharedFlow' should not be exposed as public. Use a backing property with 'asStateFlow()'/'asSharedFlow()'.
+error.flow.missing.catch.in.flow=[FLOW_005] Flow chain is missing a '.catch {}' operator. Unhandled exceptions will propagate to the parent scope. Add '.catch { e -> }' before the terminal operator.
+error.concur.sequential.async.await=[CONCUR_003] 'async { }.await()' is equivalent to 'withContext' but creates an unnecessary 'Deferred'. Use 'withContext(coroutineContext) { }' or launch multiple 'async' blocks in parallel.
 
 # Action - Scan Project
 action.scan.project.text=Scan Project for Coroutine Issues

--- a/intellij-plugin/src/main/resources/messages/StructuredCoroutinesBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/StructuredCoroutinesBundle.properties
@@ -29,6 +29,7 @@ inspection.dispatchers.unconfined.display.name=Dispatchers.Unconfined usage
 inspection.lifecycle.flow.collection.display.name=Flow collection without repeatOnLifecycle
 inspection.loop.without.yield.display.name=Loop without cooperation point
 inspection.with.timeout.scope.cancellation.display.name=withTimeout without TimeoutCancellationException handling
+inspection.collect.as.state.lifecycle.display.name=collectAsState without lifecycle-aware collection
 
 # Inspection Descriptions (include rule code and Learn more link; HTML supported in inspection description pane)
 inspection.doc.base.url=https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md
@@ -48,6 +49,13 @@ inspection.dispatchers.unconfined.description=<html>Dispatchers.Unconfined can l
 inspection.lifecycle.flow.collection.description=<html>Collecting a Flow in lifecycleScope without repeatOnLifecycle or flowWithLifecycle keeps the flow running when the UI goes to background. Use repeatOnLifecycle(Lifecycle.State.STARTED) or flowWithLifecycle.<br/><br/><b>ARCH_002</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#82-lifecycle-aware-flow-collection-android">Learn more</a></html>
 inspection.loop.without.yield.description=<html>Loops in suspend functions without cooperation points cannot be cancelled until the loop completes. In suspend functions use currentCoroutineContext().ensureActive(), or yield(), or delay() inside the loop.<br/><br/><b>CANCEL_001</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#41-cancel_001--ignoring-cancellation-in-intensive-loops">Learn more</a></html>
 inspection.with.timeout.scope.cancellation.description=<html>withTimeout throws TimeoutCancellationException when the timeout expires. If uncaught, it cancels the <b>parent scope</b>, potentially killing sibling coroutines.<br/><br/>Prefer <b>withTimeoutOrNull</b> to receive null on timeout without affecting the scope. If you must use withTimeout, catch TimeoutCancellationException explicitly.<br/><br/><b>CANCEL_006</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#46-cancel_006--withtimeout-and-scope-cancellation">Learn more</a></html>
+inspection.collect.as.state.lifecycle.description=<html>The default <code>Flow.collectAsState()</code> API keeps subscribing while Composition is deactivated. On Android, prefer <code>collectAsStateWithLifecycle()</code> from lifecycle-runtime-compose (add the dependency first). Desktop-only Compose may deliberately keep collecting; suppress if justified.<br/><br/><b>COMPOSE_001</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#83-compose_001--collectasstate-without-lifecycle-awareness">Learn more</a></html>
+
+inspection.runblocking.instead.runtest.display.name=runBlocking instead of runTest (JUnit expression body)
+inspection.runblocking.instead.runtest.description=<html>Using <code>@Test fun … = runBlocking { }</code> misses the structured <code>TestScope</code> and virtual time from <code>runTest</code> in kotlinx-coroutines-test.<br/><br/><b>TEST_004</b>. When the lambda uses <code>delay</code>, the separate &quot;slow tests&quot; inspection ([TEST_001]) applies instead.<br/><a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#64-test_004--runblocking-instead-of-runtest">Learn more</a></html>
+
+inspection.dispatchers.io.common.display.name=Dispatchers.IO in common Kotlin sources
+inspection.dispatchers.io.common.description=<html><code>Dispatchers.IO</code> is not available from Kotlin/Common code targeting Native or JS.<br/><br/><b>KMP_001</b>. Inject <code>CoroutineDispatcher</code> from platform code or provide an <code>expect</code>/<code>actual</code>.<br/><a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#111-kmp_001--dispatchersio-in-commonmain">Learn more</a></html>
 
 # Quick Fix Names
 quickfix.replace.global.scope=Replace with {0}
@@ -114,6 +122,9 @@ error.dispatchers.unconfined=[DISPATCH_003] Dispatchers.Unconfined should be avo
 error.lifecycle.flow.collection=[ARCH_002] Flow collection in lifecycleScope without repeatOnLifecycle. Use repeatOnLifecycle(Lifecycle.State.STARTED) or flowWithLifecycle so collection stops when UI is in background. See: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#82-lifecycle-aware-flow-collection-android
 error.loop.without.yield=[CANCEL_001] Loop in suspend function without cooperation point. Add ensureActive() or yield() to allow cancellation. See: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#41-cancel_001--ignoring-cancellation-in-intensive-loops
 error.with.timeout.scope.cancellation=[CANCEL_006] withTimeout may cancel the parent scope if TimeoutCancellationException propagates. Use withTimeoutOrNull or catch TimeoutCancellationException. See: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#46-cancel_006--withtimeout-and-scope-cancellation
+error.compose.collect.as.state=[COMPOSE_001] collectAsState() is not lifecycle-aware. Prefer collectAsStateWithLifecycle() on Android screens. See: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#83-compose_001--collectasstate-without-lifecycle-awareness
+error.test.runblocking.instead.runtest=[TEST_004] Prefer runTest instead of runBlocking as the direct @Test body. See: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#64-test_004--runblocking-instead-of-runtest
+error.kmp.dispatchers.io.common=[KMP_001] Dispatchers.IO in commonMain/commonTest – use injected dispatcher or expect/actual. See: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#111-kmp_001--dispatchersio-in-commonmain
 
 # Action - Scan Project
 action.scan.project.text=Scan Project for Coroutine Issues

--- a/intellij-plugin/src/main/resources/messages/StructuredCoroutinesBundle_es.properties
+++ b/intellij-plugin/src/main/resources/messages/StructuredCoroutinesBundle_es.properties
@@ -24,6 +24,7 @@ inspection.dispatchers.unconfined.display.name=Uso de Dispatchers.Unconfined
 inspection.lifecycle.flow.collection.display.name=Collect de Flow sin repeatOnLifecycle
 inspection.loop.without.yield.display.name=Bucle sin punto de cooperaci\u00f3n
 inspection.with.timeout.scope.cancellation.display.name=withTimeout sin manejo de TimeoutCancellationException
+inspection.collect.as.state.lifecycle.display.name=collectAsState sin recolecci\u00f3n consciente del ciclo de vida
 
 # Inspection Descriptions (c\u00f3digo de regla + enlace Learn more)
 inspection.doc.base.url=https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md
@@ -43,6 +44,13 @@ inspection.dispatchers.unconfined.description=<html>Dispatchers.Unconfined puede
 inspection.lifecycle.flow.collection.description=<html>Recolectar un Flow en lifecycleScope sin repeatOnLifecycle o flowWithLifecycle mantiene el flow activo en segundo plano. Use repeatOnLifecycle(Lifecycle.State.STARTED) o flowWithLifecycle.<br/><br/><b>ARCH_002</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#82-lifecycle-aware-flow-collection-android">M\u00e1s informaci\u00f3n</a></html>
 inspection.loop.without.yield.description=<html>Bucles en funciones suspend sin puntos de cooperaci\u00f3n no pueden cancelarse hasta que terminen. En funciones suspend use currentCoroutineContext().ensureActive(), o yield(), o delay() dentro del bucle.<br/><br/><b>CANCEL_001</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#41-cancel_001--ignoring-cancellation-in-intensive-loops">M\u00e1s informaci\u00f3n</a></html>
 inspection.with.timeout.scope.cancellation.description=<html>withTimeout lanza TimeoutCancellationException cuando se agota el tiempo. Si no se captura, cancela el <b>scope padre</b>, lo que puede matar corrutinas hermanas inesperadamente.<br/><br/>Prefiera <b>withTimeoutOrNull</b> para obtener null en caso de timeout sin afectar al scope. Si debe usar withTimeout, capture TimeoutCancellationException expl\u00edcitamente.<br/><br/><b>CANCEL_006</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#46-cancel_006--withtimeout-and-scope-cancellation">M\u00e1s informaci\u00f3n</a></html>
+inspection.collect.as.state.lifecycle.description=<html>Por defecto <code>Flow.collectAsState()</code> sigue recolectando aunque la Composition est\u00e9 desactivada. En Android prefiera <code>collectAsStateWithLifecycle()</code> de lifecycle-runtime-compose (a\u00f1ada antes la dependencia). En Compose Desktop puede ser intencional; suprimir si corresponde.<br/><br/><b>COMPOSE_001</b>. <a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#83-compose_001--collectasstate-without-lifecycle-awareness">M\u00e1s informaci\u00f3n</a></html>
+
+inspection.runblocking.instead.runtest.display.name=runBlocking en lugar de runTest (cuerpo de @Test como expresi\u00f3n)
+inspection.runblocking.instead.runtest.description=<html>Usar <code>@Test fun \u2026 = runBlocking { }</code> pierde el <code>TestScope</code> y el tiempo virtual de <code>runTest</code> en kotlinx-coroutines-test.<br/><br/><b>TEST_004</b>. Si el lambda usa <code>delay</code>, aplique la inspecci\u00f3n de tests lentos ([TEST_001]).<br/><a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#64-test_004--runblocking-instead-of-runtest">M\u00e1s informaci\u00f3n</a></html>
+
+inspection.dispatchers.io.common.display.name=Dispatchers.IO en c\u00f3digo com\u00fan de Kotlin
+inspection.dispatchers.io.common.description=<html><code>Dispatchers.IO</code> no est\u00e1 disponible en Kotlin/Common destinado a Native o JS.<br/><br/><b>KMP_001</b>. Inyecte <code>CoroutineDispatcher</code> desde la plataforma o use expect/actual.<br/><a href="https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#111-kmp_001--dispatchersio-in-commonmain">M\u00e1s informaci\u00f3n</a></html>
 
 # Quick Fix Names
 quickfix.replace.global.scope=Reemplazar con {0}
@@ -108,6 +116,9 @@ error.dispatchers.unconfined=[DISPATCH_003] Debe evitarse Dispatchers.Unconfined
 error.lifecycle.flow.collection=[ARCH_002] Recolecci\u00f3n de Flow en lifecycleScope sin repeatOnLifecycle. Use repeatOnLifecycle(Lifecycle.State.STARTED) o flowWithLifecycle para que la recolecci\u00f3n se detenga en segundo plano. Ver: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#82-lifecycle-aware-flow-collection-android
 error.loop.without.yield=[CANCEL_001] Bucle en funci\u00f3n suspend sin punto de cooperaci\u00f3n. A\u00f1ada ensureActive() o yield() para permitir cancelaci\u00f3n. Ver: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#41-cancel_001--ignoring-cancellation-in-intensive-loops
 error.with.timeout.scope.cancellation=[CANCEL_006] withTimeout puede cancelar el scope padre si TimeoutCancellationException se propaga. Use withTimeoutOrNull o capture TimeoutCancellationException. Ver: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#46-cancel_006--withtimeout-and-scope-cancellation
+error.compose.collect.as.state=[COMPOSE_001] collectAsState() no est\u00e1 alineado con el ciclo de vida de la pantalla; prefiera collectAsStateWithLifecycle() en pantallas Android. Ver: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#83-compose_001--collectasstate-without-lifecycle-awareness
+error.test.runblocking.instead.runtest=[TEST_004] Prefiera runTest en lugar de runBlocking como cuerpo directo de @Test. Ver: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#64-test_004--runblocking-instead-of-runtest
+error.kmp.dispatchers.io.common=[KMP_001] Dispatchers.IO en commonMain/commonTest: use dispatcher inyectado o expect/actual. Ver: https://github.com/santimattius/structured-coroutines/blob/main/docs/BEST_PRACTICES_COROUTINES.md#111-kmp_001--dispatchersio-in-commonmain
 
 # Action - Scan Project
 action.scan.project.text=Escanear Proyecto por Problemas de Coroutines

--- a/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/CallbackFlowWithoutAwaitCloseInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/CallbackFlowWithoutAwaitCloseInspectionTest.kt
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [CallbackFlowWithoutAwaitCloseInspection].
+ *
+ * TDD Evidence: RED — tests written before implementation exists.
+ * GREEN — tests pass once CallbackFlowWithoutAwaitCloseInspection is implemented.
+ */
+class CallbackFlowWithoutAwaitCloseInspectionTest {
+
+    @Test
+    fun `inspection can be instantiated`() {
+        val inspection = CallbackFlowWithoutAwaitCloseInspection()
+        assertThat(inspection).isNotNull()
+    }
+
+    @Test
+    fun `inspection is enabled by default`() {
+        val inspection = CallbackFlowWithoutAwaitCloseInspection()
+        assertThat(inspection.isEnabledByDefault).isTrue()
+    }
+
+    @Test
+    fun `inspection display name key is set`() {
+        val inspection = CallbackFlowWithoutAwaitCloseInspection()
+        assertThat(inspection.displayNameKey).isEqualTo("inspection.callback.flow.without.await.close.display.name")
+    }
+
+    @Test
+    fun `inspection description key is set`() {
+        val inspection = CallbackFlowWithoutAwaitCloseInspection()
+        assertThat(inspection.descriptionKey).isEqualTo("inspection.callback.flow.without.await.close.description")
+    }
+}

--- a/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/MissingCatchInFlowInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/MissingCatchInFlowInspectionTest.kt
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [MissingCatchInFlowInspection].
+ *
+ * TDD Evidence: RED — tests written before implementation exists.
+ * GREEN — tests pass once MissingCatchInFlowInspection is implemented.
+ */
+class MissingCatchInFlowInspectionTest {
+
+    @Test
+    fun `inspection can be instantiated`() {
+        val inspection = MissingCatchInFlowInspection()
+        assertThat(inspection).isNotNull()
+    }
+
+    @Test
+    fun `inspection is enabled by default`() {
+        val inspection = MissingCatchInFlowInspection()
+        assertThat(inspection.isEnabledByDefault).isTrue()
+    }
+
+    @Test
+    fun `inspection display name key is set`() {
+        val inspection = MissingCatchInFlowInspection()
+        assertThat(inspection.displayNameKey).isEqualTo("inspection.missing.catch.in.flow.display.name")
+    }
+
+    @Test
+    fun `inspection description key is set`() {
+        val inspection = MissingCatchInFlowInspection()
+        assertThat(inspection.descriptionKey).isEqualTo("inspection.missing.catch.in.flow.description")
+    }
+}

--- a/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/MutableFlowExposedInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/MutableFlowExposedInspectionTest.kt
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [MutableFlowExposedInspection].
+ *
+ * TDD Evidence: RED — tests written before implementation exists.
+ * GREEN — tests pass once MutableFlowExposedInspection is implemented.
+ */
+class MutableFlowExposedInspectionTest {
+
+    @Test
+    fun `inspection can be instantiated`() {
+        val inspection = MutableFlowExposedInspection()
+        assertThat(inspection).isNotNull()
+    }
+
+    @Test
+    fun `inspection is enabled by default`() {
+        val inspection = MutableFlowExposedInspection()
+        assertThat(inspection.isEnabledByDefault).isTrue()
+    }
+
+    @Test
+    fun `inspection display name key is set`() {
+        val inspection = MutableFlowExposedInspection()
+        assertThat(inspection.displayNameKey).isEqualTo("inspection.mutable.flow.exposed.display.name")
+    }
+
+    @Test
+    fun `inspection description key is set`() {
+        val inspection = MutableFlowExposedInspection()
+        assertThat(inspection.descriptionKey).isEqualTo("inspection.mutable.flow.exposed.description")
+    }
+}

--- a/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/SequentialAsyncAwaitInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/SequentialAsyncAwaitInspectionTest.kt
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [SequentialAsyncAwaitInspection].
+ *
+ * TDD Evidence: RED — tests written before implementation exists.
+ * GREEN — tests pass once SequentialAsyncAwaitInspection is implemented.
+ */
+class SequentialAsyncAwaitInspectionTest {
+
+    @Test
+    fun `inspection can be instantiated`() {
+        val inspection = SequentialAsyncAwaitInspection()
+        assertThat(inspection).isNotNull()
+    }
+
+    @Test
+    fun `inspection is enabled by default`() {
+        val inspection = SequentialAsyncAwaitInspection()
+        assertThat(inspection.isEnabledByDefault).isTrue()
+    }
+
+    @Test
+    fun `inspection display name key is set`() {
+        val inspection = SequentialAsyncAwaitInspection()
+        assertThat(inspection.displayNameKey).isEqualTo("inspection.sequential.async.await.display.name")
+    }
+
+    @Test
+    fun `inspection description key is set`() {
+        val inspection = SequentialAsyncAwaitInspection()
+        assertThat(inspection.descriptionKey).isEqualTo("inspection.sequential.async.await.description")
+    }
+}

--- a/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/SuspendCoroutineWithoutCancellationInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/SuspendCoroutineWithoutCancellationInspectionTest.kt
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [SuspendCoroutineWithoutCancellationInspection].
+ *
+ * IntelliJ Platform integration tests require a running IDE environment with JDK 21.
+ * These tests verify the inspection's metadata and registration properties, which
+ * can be validated without a running IDE.
+ *
+ * TDD Evidence: RED — these tests are written before the implementation class exists.
+ * GREEN — tests pass once SuspendCoroutineWithoutCancellationInspection is implemented.
+ */
+class SuspendCoroutineWithoutCancellationInspectionTest {
+
+    @Test
+    fun `inspection can be instantiated`() {
+        val inspection = SuspendCoroutineWithoutCancellationInspection()
+        assertThat(inspection).isNotNull()
+    }
+
+    @Test
+    fun `inspection is enabled by default`() {
+        val inspection = SuspendCoroutineWithoutCancellationInspection()
+        assertThat(inspection.isEnabledByDefault).isTrue()
+    }
+
+    @Test
+    fun `inspection display name key is set`() {
+        val inspection = SuspendCoroutineWithoutCancellationInspection()
+        assertThat(inspection.displayNameKey).isNotBlank()
+        assertThat(inspection.displayNameKey).isEqualTo("inspection.suspend.coroutine.without.cancellation.display.name")
+    }
+
+    @Test
+    fun `inspection description key is set`() {
+        val inspection = SuspendCoroutineWithoutCancellationInspection()
+        assertThat(inspection.descriptionKey).isNotBlank()
+        assertThat(inspection.descriptionKey).isEqualTo("inspection.suspend.coroutine.without.cancellation.description")
+    }
+}

--- a/lint-rules/README.md
+++ b/lint-rules/README.md
@@ -118,6 +118,10 @@ Configure Android Lint rules in `lint.xml`:
     <issue id="ChannelNotClosed" severity="warning" />
     <issue id="ConsumeEachMultipleConsumers" severity="warning" />
     <issue id="FlowBlockingCall" severity="warning" />
+    <issue id="MissingCatchInFlow" severity="warning" />
+    <issue id="CollectAsStateWithoutLifecycle" severity="warning" />
+    <issue id="RunBlockingInsteadOfRunTest" severity="warning" />
+    <issue id="DispatchersIOInCommonMain" severity="error" />
 </lint>
 ```
 
@@ -145,6 +149,8 @@ Configure Android Lint rules in `lint.xml`:
 | `UnstructuredLaunch` | Additional | Error | Detects launch without structured scope |
 | `RedundantLaunchInCoroutineScope` | Additional | Warning | Detects redundant launch in `coroutineScope` |
 | `RunBlockingWithDelayInTest` | Additional | Warning | Detects `runBlocking` + `delay` in tests |
+| `RunBlockingInsteadOfRunTest` | Additional | Warning | Detects `@Test … = runBlocking { }` (prefer `runTest`) |
+| `DispatchersIOInCommonMain` | Additional | Error | Detects `Dispatchers.IO` in `commonMain` / `commonTest` |
 | `LoopWithoutYield` | Additional | Warning | Detects loops without cooperation points |
 | `ScopeReuseAfterCancel` | Additional | Warning | Detects cancelled scope reuse |
 | `ChannelNotClosed` | Additional | Warning | Detects manual Channel() without close() in same function |
@@ -157,8 +163,8 @@ Configure Android Lint rules in `lint.xml`:
 |----------|-------|
 | Compiler Plugin Rules | 9 |
 | Android-Specific Rules | 4 |
-| Additional Rules | 8 |
-| **Total** | **19** |
+| Additional Rules | 10 |
+| **Total** | **23** |
 
 ---
 

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/StructuredCoroutinesIssueRegistry.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/StructuredCoroutinesIssueRegistry.kt
@@ -51,6 +51,10 @@ class StructuredCoroutinesIssueRegistry : IssueRegistry() {
             ChannelNotClosedDetector.ISSUE,
             ConsumeEachMultipleConsumersDetector.ISSUE,
             FlowBlockingCallDetector.ISSUE,
+            MissingCatchInFlowDetector.ISSUE,
+            CollectAsStateWithoutLifecycleDetector.ISSUE,
+            RunBlockingInsteadOfRunTestDetector.ISSUE,
+            DispatchersIOInCommonMainDetector.ISSUE,
         )
     
     override val api: Int = CURRENT_API

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CollectAsStateWithoutLifecycleDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CollectAsStateWithoutLifecycleDetector.kt
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import io.github.santimattius.structured.lint.utils.AndroidLintUtils
+import io.github.santimattius.structured.lint.utils.ComposePsiUtils
+import io.github.santimattius.structured.lint.utils.LintDocUrl
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.uast.UCallExpression
+
+/**
+ * [COMPOSE_001] — `Flow.collectAsState()` in Compose keeps emitting while the Composition is deactivated.
+ * Prefer `collectAsStateWithLifecycle()` from lifecycle-runtime-compose for Android shells.
+ */
+class CollectAsStateWithoutLifecycleDetector : Detector(), SourceCodeScanner {
+
+    companion object {
+        val ISSUE = Issue.create(
+            id = "CollectAsStateWithoutLifecycle",
+            briefDescription = "collectAsState without lifecycle awareness",
+            explanation = """
+                [COMPOSE_001] Plain `collectAsState()` continues collecting Flow emissions even when the
+                screen or window is inactive. On Android screens, prefer
+                `collectAsStateWithLifecycle()` (lifecycle-runtime-compose) so collection aligns with lifecycle.
+
+                See: ${LintDocUrl.buildDocLink("83-compose_001--collectasstate-without-lifecycle-awareness")}
+            """.trimIndent(),
+            category = Category.PERFORMANCE,
+            priority = 6,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                CollectAsStateWithoutLifecycleDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            ),
+        )
+    }
+
+    override fun getApplicableMethodNames(): List<String> = listOf("collectAsState")
+
+    override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: com.intellij.psi.PsiMethod) {
+        if (AndroidLintUtils.isTestFile(context, node)) return
+
+        val ktCall = node.sourcePsi as? KtCallExpression ?: return
+        val ktFile = ktCall.containingKtFile
+
+        if (!ComposePsiUtils.importsComposeRuntime(ktFile)) return
+        if (!ComposePsiUtils.importsKotlinxCoroutinesFlow(ktFile)) return
+
+        if (!ComposePsiUtils.hasComposableAncestor(ktCall)) return
+        if (ComposePsiUtils.hasPreviewAncestor(ktCall)) return
+
+        context.report(
+            ISSUE,
+            node,
+            context.getLocation(node),
+            "[COMPOSE_001] Prefer `collectAsStateWithLifecycle()` for lifecycle-aware Flow collection in Compose UI. " +
+                "See: ${LintDocUrl.buildDocLink("83-compose_001--collectasstate-without-lifecycle-awareness")}",
+        )
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CollectAsStateWithoutLifecycleDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CollectAsStateWithoutLifecycleDetector.kt
@@ -18,6 +18,8 @@ import com.android.tools.lint.detector.api.SourceCodeScanner
 import io.github.santimattius.structured.lint.utils.AndroidLintUtils
 import io.github.santimattius.structured.lint.utils.ComposePsiUtils
 import io.github.santimattius.structured.lint.utils.LintDocUrl
+import io.github.santimattius.structured.lint.utils.importsComposeRuntime
+import io.github.santimattius.structured.lint.utils.importsKotlinxCoroutinesFlow
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.uast.UCallExpression
 
@@ -56,8 +58,8 @@ class CollectAsStateWithoutLifecycleDetector : Detector(), SourceCodeScanner {
         val ktCall = node.sourcePsi as? KtCallExpression ?: return
         val ktFile = ktCall.containingKtFile
 
-        if (!ComposePsiUtils.importsComposeRuntime(ktFile)) return
-        if (!ComposePsiUtils.importsKotlinxCoroutinesFlow(ktFile)) return
+        if (!ktFile.importsComposeRuntime()) return
+        if (!ktFile.importsKotlinxCoroutinesFlow()) return
 
         if (!ComposePsiUtils.hasComposableAncestor(ktCall)) return
         if (ComposePsiUtils.hasPreviewAncestor(ktCall)) return

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/DispatchersIOInCommonMainDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/DispatchersIOInCommonMainDetector.kt
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import io.github.santimattius.structured.lint.utils.KotlinCommonSourceLintUtils
+import io.github.santimattius.structured.lint.utils.LintDocUrl
+import io.github.santimattius.structured.lint.utils.importsKotlinxCoroutines
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UQualifiedReferenceExpression
+
+/**
+ * [KMP_001] — references to `Dispatchers.IO` under `commonMain` / `commonTest` are invalid on Native/JS.
+ */
+class DispatchersIOInCommonMainDetector : Detector(), SourceCodeScanner {
+
+    companion object {
+        val ISSUE = Issue.create(
+            id = "DispatchersIOInCommonMain",
+            briefDescription = "Dispatchers.IO in Kotlin common source",
+            explanation = """
+                [KMP_001] `Dispatchers.IO` is not available in Kotlin/Native or Kotlin/JS. Use an injected
+                `CoroutineDispatcher`, or `expect`/`actual` to provide a platform-backed I/O dispatcher.
+
+                See: ${LintDocUrl.buildDocLink("111-kmp_001--dispatchersio-in-commonmain")}
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 10,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                DispatchersIOInCommonMainDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            ),
+        )
+
+        internal fun isDispatchersIOAccess(text: String): Boolean {
+            val t = text.removePrefix("kotlinx.coroutines.")
+            return t == "Dispatchers.IO" ||
+                t.endsWith(".Dispatchers.IO")
+        }
+    }
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> =
+        listOf(UQualifiedReferenceExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitQualifiedReferenceExpression(node: UQualifiedReferenceExpression) {
+                val path = context.file.path.replace('\\', '/')
+                if (!KotlinCommonSourceLintUtils.absolutePathLooksLikeKotlinCommonLikeSource(path)) return
+
+                val ktFile = node.sourcePsi?.containingFile as? KtFile ?: return
+                if (!ktFile.importsKotlinxCoroutines()) return
+
+                val source = node.asSourceString()
+                if (!isDispatchersIOAccess(source)) return
+
+                context.report(
+                    ISSUE,
+                    node,
+                    context.getLocation(node),
+                    "[KMP_001] `Dispatchers.IO` in common Kotlin source sets will fail on iOS / JS targets. Inject a dispatcher or use expect/actual. " +
+                        "See: ${LintDocUrl.buildDocLink("111-kmp_001--dispatchersio-in-commonmain")}",
+                )
+            }
+        }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/MissingCatchInFlowDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/MissingCatchInFlowDetector.kt
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import io.github.santimattius.structured.lint.utils.AndroidLintUtils
+import io.github.santimattius.structured.lint.utils.LintDocUrl
+import io.github.santimattius.structured.lint.utils.MissingCatchInFlowHeuristic
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.uast.UCallExpression
+/**
+ * [FLOW_005] — Android Lint facade over the same heuristic as Detekt (`MissingCatchInFlow`).
+ */
+class MissingCatchInFlowDetector : Detector(), SourceCodeScanner {
+
+    companion object {
+        val ISSUE = Issue.create(
+            id = "MissingCatchInFlow",
+            briefDescription = "Flow collector without upstream catch operator",
+            explanation = """
+                [FLOW_005] Long chains that transform or filter Flow emissions rarely surface errors safely.
+                Prefer `.catch { }` (or deliberate error propagation) upstream of `.collect` / `.launchIn`
+                unless the whole collector is guarded by `try/catch(Throwable)`.
+
+                See: ${LintDocUrl.buildDocLink("96-flow_005--missing-catch-in-flow-chain")}
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 6,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                MissingCatchInFlowDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            ),
+        )
+
+        fun importsCoroutinesOrFlow(file: KtFile): Boolean =
+            file.importDirectives.any {
+                val fq = it.importedFqName?.asString().orEmpty()
+                fq.startsWith("kotlinx.coroutines")
+            }
+    }
+
+    override fun getApplicableMethodNames(): List<String> = listOf("collect", "collectLatest", "launchIn")
+
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod,
+    ) {
+        if (AndroidLintUtils.isTestFile(context, node)) return
+
+        val ktCall = node.sourcePsi as? KtCallExpression ?: return
+        val ktFile = ktCall.containingKtFile
+        if (!importsCoroutinesOrFlow(ktFile)) return
+
+        if (!MissingCatchInFlowHeuristic.shouldReportTerminalCall(ktCall)) return
+
+        context.report(
+            ISSUE,
+            node,
+            context.getLocation(node),
+            "[FLOW_005] Consider `.catch { }` before the terminal collector for transformed Flow chains. " +
+                "See: ${LintDocUrl.buildDocLink("96-flow_005--missing-catch-in-flow-chain")}",
+        )
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/RunBlockingInsteadOfRunTestDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/RunBlockingInsteadOfRunTestDetector.kt
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import io.github.santimattius.structured.lint.utils.AndroidLintUtils
+import io.github.santimattius.structured.lint.utils.LintDocUrl
+import io.github.santimattius.structured.lint.utils.hasShortNameTestAnnotation
+import io.github.santimattius.structured.lint.utils.importsKotlinxCoroutines
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+import org.jetbrains.uast.UBlockExpression
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.ULambdaExpression
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+
+/**
+ * [TEST_004] — `@Test fun x() = runBlocking { }` should use `runTest` from kotlinx-coroutines-test.
+ *
+ * When `runBlocking` contains `delay()`, [RunBlockingWithDelayInTestDetector] ([TEST_001]) reports instead.
+ */
+class RunBlockingInsteadOfRunTestDetector : Detector(), SourceCodeScanner {
+
+    companion object {
+        val ISSUE = Issue.create(
+            id = "RunBlockingInsteadOfRunTest",
+            briefDescription = "runBlocking as JUnit test body",
+            explanation = """
+                [TEST_004] Using `runBlocking { }` as the direct body of a `@Test` function misses the
+                structured test scope and virtual time provided by `runTest` from kotlinx-coroutines-test.
+
+                See: ${LintDocUrl.buildDocLink("64-test_004--runblocking-instead-of-runtest")}
+            """.trimIndent(),
+            category = Category.PERFORMANCE,
+            priority = 6,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                RunBlockingInsteadOfRunTestDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            ),
+        )
+    }
+
+    override fun getApplicableMethodNames(): List<String> = listOf("runBlocking")
+
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: com.intellij.psi.PsiMethod,
+    ) {
+        if (!AndroidLintUtils.isTestFile(context, node)) return
+
+        val ktCall = node.sourcePsi as? KtCallExpression ?: return
+        val ktFile = ktCall.containingKtFile
+        if (!ktFile.importsKotlinxCoroutines()) return
+
+        val enclosing = ktCall.getParentOfType<KtNamedFunction>(strict = false) ?: return
+        if (enclosing.bodyExpression !== ktCall) return
+        if (!enclosing.hasShortNameTestAnnotation()) return
+
+        val lambdaBody = getLambdaBody(node) ?: return
+        if (containsDelayCall(lambdaBody)) return
+
+        context.report(
+            ISSUE,
+            node,
+            context.getLocation(node),
+            "[TEST_004] Prefer `runTest { }` instead of `runBlocking { }` as the test body for coroutine-aware tests. " +
+                "See: ${LintDocUrl.buildDocLink("64-test_004--runblocking-instead-of-runtest")}",
+        )
+    }
+
+    private fun getLambdaBody(call: UCallExpression): UExpression? {
+        val arguments = call.valueArguments
+        if (arguments.isEmpty()) return null
+        val lastArg = arguments.lastOrNull() ?: return null
+        return when (lastArg) {
+            is ULambdaExpression -> lastArg.body
+            is UBlockExpression -> lastArg
+            else -> null
+        }
+    }
+
+    private fun containsDelayCall(expression: UExpression): Boolean {
+        var foundDelay = false
+        expression.accept(object : AbstractUastVisitor() {
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+                if (node.methodName == "delay") {
+                    foundDelay = true
+                    return false
+                }
+                return super.visitCallExpression(node)
+            }
+        })
+        return foundDelay
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/ComposePsiUtils.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/ComposePsiUtils.kt
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.utils
+
+import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+/**
+ * Kotlin PSI helpers for Jetpack Compose ([COMPOSE_001]).
+ * Keep aligned with IntelliJ `ComposePsiUtils`.
+ */
+object ComposePsiUtils {
+
+    fun KtFile.importsComposeRuntime(): Boolean =
+        importDirectives.any {
+            val fq = it.importedFqName?.asString().orEmpty()
+            fq.startsWith("androidx.compose.runtime")
+        }
+
+    fun KtFile.importsKotlinxCoroutinesFlow(): Boolean =
+        importDirectives.any {
+            val fq = it.importedFqName?.asString().orEmpty()
+            fq.startsWith("kotlinx.coroutines.flow")
+        }
+
+    /** True if `@Preview` / `@MultiPreview` is on an enclosing composable declaration/lambda. */
+    fun hasPreviewAncestor(element: KtElement): Boolean =
+        enclosingAnnotatedElements(element).any { annotated ->
+            annotated.annotationEntries.any { entry ->
+                when (entry.shortName?.asString()) {
+                    "Preview", "MultiPreview" -> true
+                    else -> false
+                }
+            }
+        }
+
+    /** True when an enclosing declaration/lambda carries `@Composable`. */
+    fun hasComposableAncestor(element: KtElement): Boolean =
+        enclosingAnnotatedElements(element).any { annotated ->
+            annotated.annotationEntries.any { it.shortName?.asString() == "Composable" }
+        }
+
+    private fun enclosingAnnotatedElements(element: KtElement): List<KtAnnotated> {
+        val result = mutableListOf<KtAnnotated>()
+        var p: KtElement? = element.parent as? KtElement
+        while (p != null) {
+            when (p) {
+                is KtNamedFunction -> result += p
+                is KtLambdaExpression -> result += p.functionLiteral
+                else -> { }
+            }
+            p = p.parent as? KtElement
+        }
+        return result
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/ComposePsiUtils.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/ComposePsiUtils.kt
@@ -33,21 +33,40 @@ fun KtFile.importsKotlinxCoroutinesFlow(): Boolean =
  */
 object ComposePsiUtils {
 
+    private const val COMPOSABLE_FQN = "androidx.compose.runtime.Composable"
+    private const val PREVIEW_FQN = "androidx.compose.ui.tooling.preview.Preview"
+    private const val MULTI_PREVIEW_FQN = "androidx.compose.ui.tooling.preview.MultiPreview"
+
     /** True if `@Preview` / `@MultiPreview` is on an enclosing composable declaration/lambda. */
-    fun hasPreviewAncestor(element: KtElement): Boolean =
-        enclosingAnnotatedElements(element).any { annotated ->
-            annotated.annotationEntries.any { entry ->
-                when (entry.shortName?.asString()) {
-                    "Preview", "MultiPreview" -> true
-                    else -> false
-                }
-            }
+    fun hasPreviewAncestor(element: KtElement): Boolean {
+        val ktFile = element.containingFile as? KtFile ?: return false
+        val previewNames = buildSet {
+            add("Preview")
+            add("MultiPreview")
+            addAll(ktFile.aliasNamesFor(PREVIEW_FQN))
+            addAll(ktFile.aliasNamesFor(MULTI_PREVIEW_FQN))
         }
+        return enclosingAnnotatedElements(element).any { annotated ->
+            annotated.annotationEntries.any { it.shortName?.asString() in previewNames }
+        }
+    }
 
     /** True when an enclosing declaration/lambda carries `@Composable`. */
-    fun hasComposableAncestor(element: KtElement): Boolean =
-        enclosingAnnotatedElements(element).any { annotated ->
-            annotated.annotationEntries.any { it.shortName?.asString() == "Composable" }
+    fun hasComposableAncestor(element: KtElement): Boolean {
+        val ktFile = element.containingFile as? KtFile ?: return false
+        val composableNames = buildSet {
+            add("Composable")
+            addAll(ktFile.aliasNamesFor(COMPOSABLE_FQN))
+        }
+        return enclosingAnnotatedElements(element).any { annotated ->
+            annotated.annotationEntries.any { it.shortName?.asString() in composableNames }
+        }
+    }
+
+    private fun KtFile.aliasNamesFor(fqName: String): List<String> =
+        importDirectives.mapNotNull { directive ->
+            if (directive.importedFqName?.asString() != fqName) return@mapNotNull null
+            directive.alias?.name
         }
 
     private fun enclosingAnnotatedElements(element: KtElement): List<KtAnnotated> {

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/ComposePsiUtils.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/ComposePsiUtils.kt
@@ -13,23 +13,25 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
+fun KtFile.importsComposeRuntime(): Boolean =
+    importDirectives.any {
+        val fq = it.importedFqName?.asString().orEmpty()
+        fq.startsWith("androidx.compose.runtime")
+    }
+
+fun KtFile.importsKotlinxCoroutinesFlow(): Boolean =
+    importDirectives.any {
+        val fq = it.importedFqName?.asString().orEmpty()
+        fq.startsWith("kotlinx.coroutines.flow")
+    }
+
 /**
  * Kotlin PSI helpers for Jetpack Compose ([COMPOSE_001]).
  * Keep aligned with IntelliJ `ComposePsiUtils`.
+ *
+ * Import checks are top-level extensions so detectors use `ktFile.importsComposeRuntime()` (same style as `KotlinPsiLintUtils`).
  */
 object ComposePsiUtils {
-
-    fun KtFile.importsComposeRuntime(): Boolean =
-        importDirectives.any {
-            val fq = it.importedFqName?.asString().orEmpty()
-            fq.startsWith("androidx.compose.runtime")
-        }
-
-    fun KtFile.importsKotlinxCoroutinesFlow(): Boolean =
-        importDirectives.any {
-            val fq = it.importedFqName?.asString().orEmpty()
-            fq.startsWith("kotlinx.coroutines.flow")
-        }
 
     /** True if `@Preview` / `@MultiPreview` is on an enclosing composable declaration/lambda. */
     fun hasPreviewAncestor(element: KtElement): Boolean =

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/KotlinCommonSourceLintUtils.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/KotlinCommonSourceLintUtils.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.utils
+
+/**
+ * Mirrors Detekt [`CoroutineDetektUtils.isKotlinCommonLikeSourceVirtualPath`]: KMP folders where
+ * [kotlinx.coroutines.Dispatchers.IO] is unsupported on Kotlin/Native/JS.
+ */
+object KotlinCommonSourceLintUtils {
+
+    fun absolutePathLooksLikeKotlinCommonLikeSource(filePath: String): Boolean {
+        val normalized = filePath.replace('\\', '/')
+        return normalized.contains("/commonMain/") || normalized.contains("/commonTest/")
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/KotlinPsiLintUtils.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/KotlinPsiLintUtils.kt
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.utils
+
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+fun KtFile.importsKotlinxCoroutines(): Boolean =
+    importDirectives.any {
+        it.importedFqName?.asString()?.startsWith("kotlinx.coroutines") == true
+    }
+
+fun KtNamedFunction.hasShortNameTestAnnotation(): Boolean =
+    annotationEntries.any { it.shortName?.asString() == "Test" }

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/MissingCatchInFlowHeuristic.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/MissingCatchInFlowHeuristic.kt
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.utils
+
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtPsiUtil
+import org.jetbrains.kotlin.psi.KtTryExpression
+
+/**
+ * Mirrors `detekt-rules` [io.github.santimattius.structured.detekt.utils.MissingCatchInFlowHeuristic]
+ * ([FLOW_005]). Keep implementations in sync when the heuristic changes.
+ */
+object MissingCatchInFlowHeuristic {
+
+    private val FLOW_TERMINALS = setOf("collect", "collectLatest", "launchIn")
+
+    private val FLOW_INTERMEDIATES = setOf(
+        "map",
+        "mapLatest",
+        "filter",
+        "filterNot",
+        "transform",
+        "flatMapConcat",
+        "flatMapLatest",
+        "flatMapMerge",
+        "distinctUntilChanged",
+        "debounce",
+        "sample",
+        "take",
+        "drop",
+        "onStart",
+        "onEmpty",
+        "onCompletion",
+        "retry",
+        "retryWhen",
+        "runningFold",
+        "runningReduce",
+    )
+
+    fun shouldReportTerminalCall(terminalFlowCall: KtCallExpression): Boolean {
+        val callee = terminalFlowCall.calleeExpression?.text ?: return false
+        if (callee !in FLOW_TERMINALS) return false
+
+        val receiverChainCalls = callersInReceiverChainBeforeTerminal(terminalFlowCall)
+
+        if (receiverChainCalls.any { it.calleeExpression?.text == "catch" }) return false
+
+        val hasTrackedIntermediate = receiverChainCalls.any {
+            val n = it.calleeExpression?.text ?: return@any false
+            n in FLOW_INTERMEDIATES
+        }
+        if (!hasTrackedIntermediate) return false
+
+        if (isInsideCatchAllThrowableOrException(terminalFlowCall)) return false
+
+        return true
+    }
+
+    fun callersInReceiverChainBeforeTerminal(terminalFlowCall: KtCallExpression): List<KtCallExpression> {
+        val dot = terminalFlowCall.parent as? KtDotQualifiedExpression ?: return emptyList()
+        if (dot.selectorExpression != terminalFlowCall) return emptyList()
+        return extractQualifiedChainCalls(dot.receiverExpression)
+    }
+
+    private fun extractQualifiedChainCalls(receiver: KtExpression?): List<KtCallExpression> {
+        if (receiver == null) return emptyList()
+        return when (receiver) {
+            is KtDotQualifiedExpression -> {
+                val selector = receiver.selectorExpression
+                val suffix = if (selector is KtCallExpression) listOf(selector) else emptyList()
+                extractQualifiedChainCalls(receiver.receiverExpression) + suffix
+            }
+            is KtCallExpression -> listOf(receiver)
+            else -> emptyList()
+        }
+    }
+
+    private fun isInsideCatchAllThrowableOrException(element: KtElement): Boolean {
+        var tryExpr: KtTryExpression? =
+            KtPsiUtil.getParentOfType(element, KtTryExpression::class.java, strict = false) ?: return false
+
+        while (tryExpr != null) {
+            val inCatch = tryExpr.catchClauses.any { clause ->
+                val body = clause.catchBody
+                body != null && KtPsiUtil.isAncestor(body, element, false)
+            }
+            if (inCatch) {
+                tryExpr =
+                    KtPsiUtil.getParentOfType(
+                        tryExpr.parent as KtElement,
+                        KtTryExpression::class.java,
+                        strict = false,
+                    )
+                continue
+            }
+
+            val tryBlock = tryExpr.tryBlock
+            if (tryBlock != null && KtPsiUtil.isAncestor(tryBlock, element, false) &&
+                catchesThrowableOrGenericException(tryExpr)
+            ) {
+                return true
+            }
+
+            tryExpr = KtPsiUtil.getParentOfType(
+                tryExpr.parent as KtElement,
+                KtTryExpression::class.java,
+                strict = false,
+            )
+        }
+        return false
+    }
+
+    private fun catchesThrowableOrGenericException(tryExpr: KtTryExpression): Boolean =
+        tryExpr.catchClauses.any { clause ->
+            val names = clause.catchParameter?.typeReference?.text ?: return@any false
+            val normalized = names.trim()
+            normalized == "Throwable" ||
+                normalized == "java.lang.Throwable" ||
+                normalized.endsWith(".Throwable") ||
+                normalized == "Exception" ||
+                normalized == "java.lang.Exception" ||
+                normalized.endsWith(".Exception")
+        }
+}

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/MissingCatchInFlowHeuristic.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/utils/MissingCatchInFlowHeuristic.kt
@@ -7,12 +7,13 @@
 
 package io.github.santimattius.structured.lint.utils
 
+import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtPsiUtil
 import org.jetbrains.kotlin.psi.KtTryExpression
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 /**
  * Mirrors `detekt-rules` [io.github.santimattius.structured.detekt.utils.MissingCatchInFlowHeuristic]
@@ -85,35 +86,28 @@ object MissingCatchInFlowHeuristic {
 
     private fun isInsideCatchAllThrowableOrException(element: KtElement): Boolean {
         var tryExpr: KtTryExpression? =
-            KtPsiUtil.getParentOfType(element, KtTryExpression::class.java, strict = false) ?: return false
+            element.getParentOfType<KtTryExpression>(strict = false) ?: return false
 
         while (tryExpr != null) {
             val inCatch = tryExpr.catchClauses.any { clause ->
                 val body = clause.catchBody
-                body != null && KtPsiUtil.isAncestor(body, element, false)
+                body != null && PsiTreeUtil.isAncestor(body, element, false)
             }
             if (inCatch) {
                 tryExpr =
-                    KtPsiUtil.getParentOfType(
-                        tryExpr.parent as KtElement,
-                        KtTryExpression::class.java,
-                        strict = false,
-                    )
+                    (tryExpr.parent as? KtElement)?.getParentOfType<KtTryExpression>(strict = false)
                 continue
             }
 
             val tryBlock = tryExpr.tryBlock
-            if (tryBlock != null && KtPsiUtil.isAncestor(tryBlock, element, false) &&
+            if (tryBlock != null && PsiTreeUtil.isAncestor(tryBlock, element, false) &&
                 catchesThrowableOrGenericException(tryExpr)
             ) {
                 return true
             }
 
-            tryExpr = KtPsiUtil.getParentOfType(
-                tryExpr.parent as KtElement,
-                KtTryExpression::class.java,
-                strict = false,
-            )
+            tryExpr =
+                (tryExpr.parent as? KtElement)?.getParentOfType<KtTryExpression>(strict = false)
         }
         return false
     }

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/LintTestStubs.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/LintTestStubs.kt
@@ -39,9 +39,23 @@ object LintTestStubs {
 
     val kotlinxCoroutinesFlow = """
         package kotlinx.coroutines.flow
+        import kotlinx.coroutines.CoroutineScope
+        import kotlinx.coroutines.Job
+
         interface Flow<out T>
+        interface StateFlow<out T> : Flow<T>
         interface FlowCollector<in T>
+
         fun <T> flow(block: suspend FlowCollector<T>.() -> Unit): Flow<T> = error("stub")
+
+        fun <T, R> Flow<T>.map(transform: suspend (value: T) -> R): Flow<R> = error("stub")
+        fun <T> Flow<T>.catch(
+            handler: suspend FlowCollector<T>.(cause: Throwable) -> Unit
+        ): Flow<T> = error("stub")
+
+        suspend fun <T> Flow<T>.collect(action: suspend (value: T) -> Unit): Unit = error("stub")
+        suspend fun <T> Flow<T>.collectLatest(action: suspend (value: T) -> Unit): Unit = error("stub")
+        fun <T> Flow<T>.launchIn(scope: CoroutineScope): Job = error("stub")
     """.trimIndent()
 
     val androidxLifecycle = """
@@ -56,6 +70,41 @@ object LintTestStubs {
         import kotlinx.coroutines.CoroutineScope
         fun rememberCoroutineScope(): CoroutineScope = error("stub")
     """.trimIndent()
+
+    /** Composable stubs + Flow.collectAsState extensions for Compose ([COMPOSE_001]) tests */
+    val androidxComposeRuntimeCollect = """
+        package androidx.compose.runtime
+
+        import kotlinx.coroutines.flow.Flow
+        import kotlinx.coroutines.flow.StateFlow
+
+        annotation class Composable
+
+        interface State<out T> {
+            val value: T
+        }
+
+        @Composable
+        fun <T> Flow<T>.collectAsState(initial: T): State<T> = error("stub")
+
+        /** Preferred overload used by `@Composable val x by uiState.collectAsState()` — StateFlow is Flow. */
+        @Composable
+        fun <T : Any> StateFlow<T>.collectAsState(): State<T> = error("stub")
+    """.trimIndent()
+
+    val androidxComposeUiPreview = """
+        package androidx.compose.ui.tooling.preview
+
+        annotation class Preview
+        annotation class MultiPreview
+    """.trimIndent()
+
+    fun composeRuntimeCollectAndFlow(): List<TestFile> = listOf(
+        TestFiles.kotlin(kotlinxCoroutines).indented(),
+        TestFiles.kotlin(kotlinxCoroutinesFlow).indented(),
+        TestFiles.kotlin(androidxComposeRuntimeCollect).indented(),
+        TestFiles.kotlin(androidxComposeUiPreview).indented(),
+    )
 
     fun all() = listOf(
         TestFiles.kotlin(kotlinxCoroutines).indented(),

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/LintTestStubs.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/LintTestStubs.kt
@@ -45,9 +45,13 @@ object LintTestStubs {
 
         interface Flow<out T>
         interface StateFlow<out T> : Flow<T>
-        interface FlowCollector<in T>
+        interface FlowCollector<in T> {
+            suspend fun emit(value: T)
+        }
 
         fun <T> flow(block: suspend FlowCollector<T>.() -> Unit): Flow<T> = error("stub")
+        fun <T> flowOf(value: T): Flow<T> = error("stub")
+        fun <T> flowOf(vararg values: T): Flow<T> = error("stub")
 
         fun <T, R> Flow<T>.map(transform: suspend (value: T) -> R): Flow<R> = error("stub")
         fun <T> Flow<T>.catch(

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/LintTestStubs.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/LintTestStubs.kt
@@ -4,6 +4,7 @@
  */
 package io.github.santimattius.structured.lint
 
+import com.android.tools.lint.checks.infrastructure.TestFile
 import com.android.tools.lint.checks.infrastructure.TestFiles
 
 object LintTestStubs {

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/CollectAsStateWithoutLifecycleDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/CollectAsStateWithoutLifecycleDetectorTest.kt
@@ -76,4 +76,42 @@ class CollectAsStateWithoutLifecycleDetectorTest {
             .run()
             .expectClean()
     }
+
+    @Test
+    fun cleanWhenSuppressLintAnnotationPresent() {
+        val code =
+            """
+            package test
+
+            import android.annotation.SuppressLint
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.collectAsState
+            import kotlinx.coroutines.flow.StateFlow
+
+            class Vm(val ui: StateFlow<Int>)
+
+            @SuppressLint("CollectAsStateWithoutLifecycle")
+            @Composable
+            fun Screen(vm: Vm) {
+                val s by vm.ui.collectAsState()
+            }
+            """.trimIndent()
+
+        val androidAnnotation = """
+            package android.annotation
+            annotation class SuppressLint(vararg val value: String)
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.composeRuntimeCollectAndFlow().toTypedArray(),
+                TestFiles.kotlin(androidAnnotation).indented(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(CollectAsStateWithoutLifecycleDetector.ISSUE)
+            .allowMissingSdk()
+            .skipTestModes(TestMode.PARENTHESIZED)
+            .run()
+            .expectClean()
+    }
 }

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/CollectAsStateWithoutLifecycleDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/CollectAsStateWithoutLifecycleDetectorTest.kt
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.android.tools.lint.checks.infrastructure.TestMode
+import io.github.santimattius.structured.lint.LintTestStubs
+import org.junit.Test
+
+class CollectAsStateWithoutLifecycleDetectorTest {
+
+    @Test
+    fun warnsOnComposableFlowCollectAsState() {
+        val code =
+            """
+            package test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.collectAsState
+            import kotlinx.coroutines.flow.StateFlow
+
+            class Vm(val ui: StateFlow<Int>)
+
+            @Composable
+            fun Screen(vm: Vm) {
+                val s by vm.ui.collectAsState()
+            }
+            """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.composeRuntimeCollectAndFlow().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(CollectAsStateWithoutLifecycleDetector.ISSUE)
+            .allowMissingSdk()
+            .skipTestModes(TestMode.PARENTHESIZED)
+            .run()
+            .expectWarningCount(1)
+            .expectContains("[COMPOSE_001]")
+    }
+
+    @Test
+    fun cleanWhenSameComposableIsPreview() {
+        val code =
+            """
+            package test
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.collectAsState
+            import androidx.compose.ui.tooling.preview.Preview
+            import kotlinx.coroutines.flow.StateFlow
+
+            class Vm(val ui: StateFlow<Int>)
+
+            @Preview
+            @Composable
+            fun PreviewPane(vm: Vm) {
+                val s by vm.ui.collectAsState()
+            }
+            """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.composeRuntimeCollectAndFlow().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(CollectAsStateWithoutLifecycleDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/DispatchersIOInCommonMainDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/DispatchersIOInCommonMainDetectorTest.kt
@@ -39,4 +39,60 @@ class DispatchersIOInCommonMainDetectorTest {
             .run()
             .expectClean()
     }
+
+    @JUnitTest
+    fun noReportInAndroidMainSourceLayout() {
+        // FP guard: Dispatchers.IO in androidMain is legitimate
+        // Lint's synthetic test tree does not embed /androidMain/ in the path,
+        // so this verifies the rule does not fire in a standard Android source tree.
+        val code =
+            """
+            package test
+
+            import kotlinx.coroutines.*
+
+            suspend fun readDb() = withContext(Dispatchers.IO) { 42 }
+            """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(DispatchersIOInCommonMainDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @JUnitTest
+    fun noReportWhenSuppressLintPresent() {
+        // Suppression guard: @SuppressLint("DispatchersIOInCommonMain") silences the issue
+        val code =
+            """
+            package test
+
+            import android.annotation.SuppressLint
+            import kotlinx.coroutines.*
+
+            @SuppressLint("DispatchersIOInCommonMain")
+            suspend fun readDb() = withContext(Dispatchers.IO) { 42 }
+            """.trimIndent()
+
+        val androidAnnotation = """
+            package android.annotation
+            annotation class SuppressLint(vararg val value: String)
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(androidAnnotation).indented(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(DispatchersIOInCommonMainDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
 }

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/DispatchersIOInCommonMainDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/DispatchersIOInCommonMainDetectorTest.kt
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import io.github.santimattius.structured.lint.LintTestStubs
+import org.junit.Test as JUnitTest
+
+/**
+ * Regression: Lint paths default to synthetic test trees without `commonMain/`; KMP-positive cases
+ * are covered by JVM unit tests over [KotlinCommonSourceLintUtils] and heuristic helpers.
+ */
+class DispatchersIOInCommonMainDetectorTest {
+
+    @JUnitTest
+    fun noReportOutsideCommonSourceLayout() {
+        val code =
+            """
+            package test
+
+            import kotlinx.coroutines.*
+
+            val io = Dispatchers.IO
+            """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(DispatchersIOInCommonMainDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/MissingCatchInFlowDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/MissingCatchInFlowDetectorTest.kt
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.android.tools.lint.checks.infrastructure.TestMode
+import io.github.santimattius.structured.lint.LintTestStubs
+import org.junit.Test
+
+class MissingCatchInFlowDetectorTest {
+
+    @Test
+    fun warnsOnMapCollectWithoutCatch() {
+        val code = """
+            package test
+            import kotlinx.coroutines.flow.flow
+            import kotlinx.coroutines.runBlocking
+
+            fun demo() {
+                runBlocking {
+                    flow { emit(1) }
+                        .map { it }
+                        .collect { }
+                }
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesAndFlow().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(MissingCatchInFlowDetector.ISSUE)
+            .allowMissingSdk()
+            .skipTestModes(TestMode.PARENTHESIZED)
+            .run()
+            .expectWarningCount(1)
+            .expectContains("[FLOW_005]")
+    }
+
+    @Test
+    fun cleanWhenCatchPresent() {
+        val code = """
+            package test
+            import kotlinx.coroutines.flow.flow
+            import kotlinx.coroutines.runBlocking
+
+            fun demo() {
+                runBlocking {
+                    flow { emit(1) }
+                        .map { it }
+                        .catch { _: Throwable ->
+                        }
+                        .collect { }
+                }
+            }
+        """.trimIndent()
+
+        val issues = TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesAndFlow().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(MissingCatchInFlowDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+
+        issues.expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/MissingCatchInFlowDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/MissingCatchInFlowDetectorTest.kt
@@ -19,12 +19,14 @@ class MissingCatchInFlowDetectorTest {
     fun warnsOnMapCollectWithoutCatch() {
         val code = """
             package test
-            import kotlinx.coroutines.flow.flow
+            import kotlinx.coroutines.flow.flowOf
+            import kotlinx.coroutines.flow.map
+            import kotlinx.coroutines.flow.collect
             import kotlinx.coroutines.runBlocking
 
             fun demo() {
                 runBlocking {
-                    flow { emit(1) }
+                    flowOf(1)
                         .map { it }
                         .collect { }
                 }
@@ -48,12 +50,15 @@ class MissingCatchInFlowDetectorTest {
     fun cleanWhenCatchPresent() {
         val code = """
             package test
-            import kotlinx.coroutines.flow.flow
+            import kotlinx.coroutines.flow.flowOf
+            import kotlinx.coroutines.flow.map
+            import kotlinx.coroutines.flow.catch
+            import kotlinx.coroutines.flow.collect
             import kotlinx.coroutines.runBlocking
 
             fun demo() {
                 runBlocking {
-                    flow { emit(1) }
+                    flowOf(1)
                         .map { it }
                         .catch { _: Throwable ->
                         }

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/MissingCatchInFlowDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/MissingCatchInFlowDetectorTest.kt
@@ -78,4 +78,36 @@ class MissingCatchInFlowDetectorTest {
 
         issues.expectClean()
     }
+
+    @Test
+    fun cleanWhenCatchPresentBeforeCollectLatest() {
+        // FP guard: Flow chain with .catch {} already present before collectLatest
+        val code = """
+            package test
+            import kotlinx.coroutines.flow.flowOf
+            import kotlinx.coroutines.flow.map
+            import kotlinx.coroutines.flow.catch
+            import kotlinx.coroutines.flow.collectLatest
+            import kotlinx.coroutines.runBlocking
+
+            fun demo() {
+                runBlocking {
+                    flowOf(1)
+                        .map { it * 2 }
+                        .catch { _: Throwable -> }
+                        .collectLatest { }
+                }
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesAndFlow().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(MissingCatchInFlowDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
 }

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/RunBlockingInsteadOfRunTestDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/RunBlockingInsteadOfRunTestDetectorTest.kt
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.android.tools.lint.checks.infrastructure.TestMode
+import io.github.santimattius.structured.lint.LintTestStubs
+import org.junit.Test as JUnitTest
+
+class RunBlockingInsteadOfRunTestDetectorTest {
+
+    @JUnitTest
+    fun warnsOnTestAnnotationWithRunBlockingBody() {
+        val code =
+            """
+            package test
+
+            import kotlinx.coroutines.*
+
+            annotation class Test
+
+            @Test
+            fun smoke() = runBlocking {
+                println(1)
+            }
+            """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(RunBlockingInsteadOfRunTestDetector.ISSUE)
+            .allowMissingSdk()
+            .skipTestModes(TestMode.PARENTHESIZED)
+            .run()
+            .expectWarningCount(1)
+            .expectContains("[TEST_004]")
+    }
+
+    @JUnitTest
+    fun skipsWhenLambdaUsesDelayLeavingTest001Rule() {
+        val code =
+            """
+            package test
+
+            import kotlinx.coroutines.*
+
+            annotation class Test
+
+            @Test
+            fun slow() = runBlocking {
+                delay(1)
+                println(2)
+            }
+            """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(RunBlockingInsteadOfRunTestDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @JUnitTest
+    fun noWarningWithoutTestAnnotationOnFunction() {
+        val code =
+            """
+            package test
+
+            import kotlinx.coroutines.*
+
+            fun helper() = runBlocking {
+                println(1)
+            }
+            """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(RunBlockingInsteadOfRunTestDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/utils/KotlinCommonSourceLintUtilsTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/utils/KotlinCommonSourceLintUtilsTest.kt
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package io.github.santimattius.structured.lint.utils
+
+import io.github.santimattius.structured.lint.detectors.DispatchersIOInCommonMainDetector
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class KotlinCommonSourceLintUtilsTest {
+
+    @Test
+    fun `recognizes unix commonMain`() {
+        assertThat(
+            KotlinCommonSourceLintUtils.absolutePathLooksLikeKotlinCommonLikeSource("/p/shared/src/commonMain/kotlin/A.kt"),
+        ).isTrue()
+    }
+
+    @Test
+    fun `recognizes windows commonTest`() {
+        assertThat(
+            KotlinCommonSourceLintUtils.absolutePathLooksLikeKotlinCommonLikeSource("C:\\m\\src\\commonTest\\kotlin\\A.kt"),
+        ).isTrue()
+    }
+
+    @Test
+    fun `jvm main is excluded`() {
+        assertThat(
+            KotlinCommonSourceLintUtils.absolutePathLooksLikeKotlinCommonLikeSource("/p/app/src/main/java/A.kt"),
+        ).isFalse()
+    }
+
+    @Test
+    fun `dispatchers io access strings`() {
+        assertThat(DispatchersIOInCommonMainDetector.isDispatchersIOAccess("Dispatchers.IO")).isTrue()
+        assertThat(DispatchersIOInCommonMainDetector.isDispatchersIOAccess("kotlinx.coroutines.Dispatchers.IO")).isTrue()
+        assertThat(DispatchersIOInCommonMainDetector.isDispatchersIOAccess("Dispatchers.Default")).isFalse()
+    }
+}

--- a/sample-detekt/build.gradle.kts
+++ b/sample-detekt/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
     // Test source set used for RunBlockingWithDelayInTest rule example
     testImplementation(libs.kotlin.test)
     testImplementation(libs.junit.jupiter)
+    // Test source set used for RunBlockingInsteadOfRunTest rule example (TEST_004)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 kotlin {

--- a/sample-detekt/detekt.yml
+++ b/sample-detekt/detekt.yml
@@ -55,3 +55,15 @@ structured-coroutines:
     active: true
   FlowBlockingCall:
     active: true
+  SuspendCoroutineWithoutCancellation:
+    active: true
+  CallbackFlowWithoutAwaitClose:
+    active: true
+  MutableFlowExposed:
+    active: true
+  MissingCatchInFlow:
+    active: true
+  SequentialAsyncAwait:
+    active: true
+  RunBlockingInsteadOfRunTest:
+    active: true

--- a/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/CallbackFlowWithoutAwaitCloseSample.kt
+++ b/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/CallbackFlowWithoutAwaitCloseSample.kt
@@ -1,0 +1,37 @@
+package io.github.santimattius.structured.sample.detekt
+
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * Demonstrates INTEROP_002: callbackFlow without awaitClose.
+ * Used to validate that :detekt-rules report callbackFlow missing awaitClose.
+ *
+ * BAD: callbackFlow without awaitClose causes IllegalStateException at runtime
+ * (kotlinx-coroutines >= 1.6) and leaks registered listeners.
+ */
+
+interface LocationManager {
+    fun register(cb: (String) -> Unit)
+    fun unregister(cb: (String) -> Unit)
+}
+
+val locationManager = object : LocationManager {
+    override fun register(cb: (String) -> Unit) {}
+    override fun unregister(cb: (String) -> Unit) {}
+}
+
+// BAD: no awaitClose — IllegalStateException at runtime + listener leak
+fun badLocationFlow(): Flow<String> = callbackFlow {
+    val cb: (String) -> Unit = { trySend(it) }
+    locationManager.register(cb)
+    // Missing awaitClose!
+}
+
+// GOOD: awaitClose ensures listener cleanup
+fun goodLocationFlow(): Flow<String> = callbackFlow {
+    val cb: (String) -> Unit = { trySend(it) }
+    locationManager.register(cb)
+    awaitClose { locationManager.unregister(cb) }
+}

--- a/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/DispatchersIOInCommonMainSample.kt
+++ b/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/DispatchersIOInCommonMainSample.kt
@@ -1,0 +1,37 @@
+package io.github.santimattius.structured.sample.detekt
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Demonstrates KMP_001: Dispatchers.IO in commonMain.
+ * Used to validate that :detekt-rules report Dispatchers.IO in shared source sets.
+ *
+ * NOTE: This rule applies to files under commonMain source sets in KMP modules.
+ * This sample is placed under the JVM main source set because sample-detekt uses the
+ * kotlin.jvm plugin. In a real KMP project, the violation occurs in commonMain where
+ * Dispatchers.IO does not exist on iOS/JS targets, causing IllegalStateException at runtime.
+ *
+ * BAD: Dispatchers.IO crashes on iOS and JS (commonMain code)
+ */
+
+// BAD: Dispatchers.IO — would crash on iOS and JS if this were commonMain
+suspend fun badFetchDataKmp(): String = withContext(Dispatchers.IO) {
+    "data"
+}
+
+// GOOD option A: inject dispatcher (testable and KMP-safe)
+class GoodRepository(private val ioDispatcher: CoroutineDispatcher = Dispatchers.Default) {
+    suspend fun fetchData(): String = withContext(ioDispatcher) {
+        "data"
+    }
+}
+
+// GOOD option B: expect/actual per platform
+// In commonMain:
+//   expect val ioDispatcher: CoroutineDispatcher
+// In androidMain/jvmMain:
+//   actual val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+// In iosMain:
+//   actual val ioDispatcher: CoroutineDispatcher = Dispatchers.Default

--- a/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/MissingCatchInFlowSample.kt
+++ b/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/MissingCatchInFlowSample.kt
@@ -1,0 +1,43 @@
+package io.github.santimattius.structured.sample.detekt
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * Demonstrates FLOW_005: Missing catch operator in Flow chain.
+ * Used to validate that :detekt-rules report Flow chains without .catch before terminal operator.
+ *
+ * BAD: no catch — exceptions from intermediate operators propagate to the
+ * containing scope and cancel it.
+ */
+
+val scope = CoroutineScope(Dispatchers.Default)
+val _state = MutableStateFlow<String?>(null)
+val _error = MutableStateFlow<String?>(null)
+
+fun getItems() = flow { emit("item") }
+
+// BAD: no catch — exceptions propagate to scope and cancel it
+fun badCollect() {
+    scope.launch {
+        getItems()
+            .map { it.uppercase() }
+            .collect { _state.value = it }
+    }
+}
+
+// GOOD: catch before collect
+fun goodCollect() {
+    scope.launch {
+        getItems()
+            .map { it.uppercase() }
+            .catch { e -> _error.value = e.message }
+            .collect { _state.value = it }
+    }
+}

--- a/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/MutableFlowExposedSample.kt
+++ b/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/MutableFlowExposedSample.kt
@@ -1,0 +1,31 @@
+package io.github.santimattius.structured.sample.detekt
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Demonstrates FLOW_010: MutableStateFlow/MutableSharedFlow exposed as public.
+ * Used to validate that :detekt-rules report public mutable flow properties.
+ *
+ * BAD: mutable flows are public — any caller can emit values, breaking
+ * Unidirectional Data Flow (UDF).
+ */
+
+// BAD: mutable flows are public — any caller can emit values
+class BadViewModel {
+    val uiState = MutableStateFlow<String>("loading")
+    val events = MutableSharedFlow<String>()
+}
+
+// GOOD: backing properties with read-only public exposure
+class GoodViewModel {
+    private val _uiState = MutableStateFlow<String>("loading")
+    val uiState: StateFlow<String> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<String>()
+    val events: SharedFlow<String> = _events.asSharedFlow()
+}

--- a/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/SequentialAsyncAwaitSample.kt
+++ b/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/SequentialAsyncAwaitSample.kt
@@ -1,0 +1,32 @@
+package io.github.santimattius.structured.sample.detekt
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * Demonstrates CONCUR_003: Sequential async/await (wasted parallelism).
+ * Used to validate that :detekt-rules report async { }.await() inline patterns
+ * that provide no parallelism benefit.
+ *
+ * BAD: async { }.await() in sequence is semantically equivalent to withContext { }
+ * but creates unnecessary Deferred overhead without achieving parallelism.
+ */
+
+data class Dashboard(val user: String, val metrics: String)
+
+suspend fun fetchUser(): String = "user"
+suspend fun fetchMetrics(): String = "metrics"
+
+// BAD: sequential — no parallelism benefit
+suspend fun badLoadDashboard(): Dashboard = coroutineScope {
+    val user = async { fetchUser() }.await()
+    val metrics = async { fetchMetrics() }.await()
+    Dashboard(user, metrics)
+}
+
+// GOOD: parallel async
+suspend fun goodLoadDashboard(): Dashboard = coroutineScope {
+    val userDeferred = async { fetchUser() }
+    val metricsDeferred = async { fetchMetrics() }
+    Dashboard(userDeferred.await(), metricsDeferred.await())
+}

--- a/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/SuspendCoroutineWithoutCancellationSample.kt
+++ b/sample-detekt/src/main/kotlin/io/github/santimattius/structured/sample/detekt/SuspendCoroutineWithoutCancellationSample.kt
@@ -1,0 +1,27 @@
+package io.github.santimattius.structured.sample.detekt
+
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * Demonstrates INTEROP_001: suspendCoroutine without cancellation support.
+ * Used to validate that :detekt-rules report suspendCoroutine usage in suspend functions.
+ *
+ * BAD: suspendCoroutine does not propagate cancellation from the parent coroutine.
+ * When the parent cancels, the callback remains registered, leaking memory and resuming
+ * a dead continuation.
+ */
+
+// BAD: suspendCoroutine does not support cancellation
+suspend fun badFetchData(): String = suspendCoroutine { cont ->
+    // Simulated async callback — if parent coroutine cancels, callback is never unregistered
+    Thread { cont.resume("data") }.start()
+}
+
+// GOOD: suspendCancellableCoroutine with cleanup
+suspend fun goodFetchData(): String = suspendCancellableCoroutine { cont ->
+    val thread = Thread { cont.resume("data") }
+    thread.start()
+    cont.invokeOnCancellation { thread.interrupt() }
+}

--- a/sample-detekt/src/test/kotlin/io/github/santimattius/structured/sample/detekt/RunBlockingInsteadOfRunTestSampleTest.kt
+++ b/sample-detekt/src/test/kotlin/io/github/santimattius/structured/sample/detekt/RunBlockingInsteadOfRunTestSampleTest.kt
@@ -1,0 +1,30 @@
+package io.github.santimattius.structured.sample.detekt
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Demonstrates TEST_004: runBlocking instead of runTest.
+ * Used to validate that :detekt-rules report runBlocking in @Test functions.
+ *
+ * BAD: delay(5000) waits 5 real seconds, making the test slow.
+ * GOOD: runTest uses virtual time — delay(5000) executes in microseconds.
+ */
+class RunBlockingInsteadOfRunTestSampleTest {
+
+    // BAD: delay(5000) waits 5 real seconds
+    @Test
+    fun badSlowTest() = runBlocking {
+        delay(5_000)
+        // assertion
+    }
+
+    // GOOD: runTest uses virtual time — delay is instant
+    @Test
+    fun goodFastTest() = runTest {
+        delay(5_000) // executes in microseconds
+        // assertion
+    }
+}


### PR DESCRIPTION
## Description
- dispatcher qualifiers and INTEROP gradle options
- Add @IoDispatcher, @MainDispatcher, @DefaultDispatcher in :annotations
- Extend PluginConfiguration and Gradle extension with INTEROP_001/002 severity keys
- Wire SubpluginOptions and structuredCoroutinesReport for new rules
- Add kotlinx-coroutines-test and lifecycle-runtime-compose to version catalog
- Add PluginConfigurationInteropOptionsTest for defaults and overrides
- Add useAndroidComposeProfile / useKmpCommonProfile presets
