### PR TITLE
Handle Compose, Decompose & MVIKotlin scopes; gate launch/async by package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ---
 
+## [Unreleased]
+
+### Fixed — Compiler
+
+- **`UnstructuredLaunchChecker`** — multiple false-positive cases for `[SCOPE_003]`:
+  - `kotlinx.coroutines` package gating: `launch` / `async` are now matched only when resolved to `kotlinx.coroutines.launch` / `kotlinx.coroutines.async`. Other functions named `launch` (e.g. `androidx.activity.result.ActivityResultLauncher.launch`) are no longer flagged.
+  - **Compose UI** `androidx.compose.ui.Modifier.Node.coroutineScope` is now recognized as a structured scope. Launches inside `onAttach()` / other node callbacks no longer trigger `[SCOPE_003]`.
+  - **Decompose / Essenty** `com.arkivanov.essenty.lifecycle.coroutines.coroutineScope()` (extension on `LifecycleOwner`) is now treated like `rememberCoroutineScope()` — both as a direct call and when stored in a local `val`.
+  - **MVIKotlin** `CoroutineBootstrapper.scope` and `CoroutineExecutor.scope` are now recognized. The checker walks the dispatch-receiver type's super-type chain so inherited (fake-override) accesses from user subclasses are also detected.
+
+---
+
 ## [0.7.0] — 2026-04-07
 
 ### Changed — Compiler

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/UnstructuredLaunchChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/UnstructuredLaunchChecker.kt
@@ -18,11 +18,14 @@ import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.expressions.FirResolvedQualifier
+import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.references.toResolvedPropertySymbol
 import org.jetbrains.kotlin.fir.references.toResolvedValueParameterSymbol
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.resolvedType
@@ -116,6 +119,13 @@ import org.jetbrains.kotlin.name.Name
  *         Text("Click")
  *     }
  * }
+ *
+ * // ✅ GOOD: Compose Modifier.Node coroutineScope (tied to node attach/detach lifecycle)
+ * private class MyNode : Modifier.Node(), DrawModifierNode {
+ *     override fun onAttach() {
+ *         coroutineScope.launch { collectInteractions() }
+ *     }
+ * }
  * ```
  *
  * ## Detection Logic
@@ -170,6 +180,34 @@ class UnstructuredLaunchChecker : FirFunctionCallChecker(MppCheckerKind.Common) 
             CallableId(FqName("androidx.lifecycle"), Name.identifier("lifecycleScope")),
             // org.koin.androidx.viewmodel (KMP Koin)
             CallableId(FqName("org.koin.androidx.viewmodel"), Name.identifier("viewModelScope")),
+            // androidx.compose.ui.Modifier.Node.coroutineScope
+            // Member property of Modifier.Node; tied to node attach/detach lifecycle.
+            CallableId(
+                ClassId(
+                    FqName("androidx.compose.ui"),
+                    FqName("Modifier.Node"),
+                    false,
+                ),
+                Name.identifier("coroutineScope"),
+            ),
+            // com.arkivanov.mvikotlin.extensions.coroutines.CoroutineBootstrapper.scope
+            // Member property of MVIKotlin's CoroutineBootstrapper; cancelled on dispose().
+            CallableId(
+                ClassId(
+                    FqName("com.arkivanov.mvikotlin.extensions.coroutines"),
+                    Name.identifier("CoroutineBootstrapper"),
+                ),
+                Name.identifier("scope"),
+            ),
+            // com.arkivanov.mvikotlin.extensions.coroutines.CoroutineExecutor.scope
+            // Member property of MVIKotlin's CoroutineExecutor; cancelled on dispose().
+            CallableId(
+                ClassId(
+                    FqName("com.arkivanov.mvikotlin.extensions.coroutines"),
+                    Name.identifier("CoroutineExecutor"),
+                ),
+                Name.identifier("scope"),
+            ),
         )
 
         /**
@@ -180,6 +218,12 @@ class UnstructuredLaunchChecker : FirFunctionCallChecker(MppCheckerKind.Common) 
             CallableId(FqName("androidx.compose.runtime"), Name.identifier("rememberCoroutineScope")),
             // Compose Multiplatform (same package in most cases)
             CallableId(FqName("androidx.compose.runtime"), Name.identifier("rememberCoroutineScope")),
+            // Decompose / Essenty: extension on LifecycleOwner returning a CoroutineScope
+            // tied to the component lifecycle (cancelled in onDestroy).
+            CallableId(
+                FqName("com.arkivanov.essenty.lifecycle.coroutines"),
+                Name.identifier("coroutineScope"),
+            ),
         )
 
         /**
@@ -191,6 +235,22 @@ class UnstructuredLaunchChecker : FirFunctionCallChecker(MppCheckerKind.Common) 
             Name.identifier("viewModelScope"),
             Name.identifier("lifecycleScope"),
             Name.identifier("rememberCoroutineScope"),
+        )
+
+        /**
+         * ClassIds whose `scope` member property exposes a structured CoroutineScope.
+         * Used by the inheritance fallback to recognize `scope` access via implicit `this`
+         * in subclasses where FIR resolves the symbol against the subclass (fake override).
+         */
+        private val FRAMEWORK_SCOPE_HOLDER_CLASS_IDS: Set<ClassId> = setOf(
+            ClassId(
+                FqName("com.arkivanov.mvikotlin.extensions.coroutines"),
+                Name.identifier("CoroutineBootstrapper"),
+            ),
+            ClassId(
+                FqName("com.arkivanov.mvikotlin.extensions.coroutines"),
+                Name.identifier("CoroutineExecutor"),
+            ),
         )
     }
 
@@ -221,15 +281,19 @@ class UnstructuredLaunchChecker : FirFunctionCallChecker(MppCheckerKind.Common) 
     }
 
     /**
-     * Checks if the function call is to `launch` or `async`.
+     * Checks if the function call is to `kotlinx.coroutines.launch` or `kotlinx.coroutines.async`.
+     *
+     * Other functions named `launch` (e.g. `ActivityResultLauncher.launch`,
+     * `Intent.launch`) are intentionally **not** matched.
      *
      * @param call The function call to check
-     * @return true if this is a coroutine builder call
+     * @return true if this is a kotlinx.coroutines builder call
      */
     private fun isCoroutineBuilderCall(call: FirFunctionCall): Boolean {
         val calleeReference = call.calleeReference
-        val name = calleeReference.name
-        return name in COROUTINE_BUILDER_NAMES
+        if (calleeReference.name !in COROUTINE_BUILDER_NAMES) return false
+        val callableId = calleeReference.toResolvedCallableSymbol()?.callableId ?: return false
+        return callableId.packageName.asString() == "kotlinx.coroutines"
     }
 
     /**
@@ -309,7 +373,7 @@ class UnstructuredLaunchChecker : FirFunctionCallChecker(MppCheckerKind.Common) 
             val calleeReference = receiver.calleeReference
 
             // Try to verify the property is from a known framework package
-            if (isFrameworkScopeProperty(receiver)) {
+            if (isFrameworkScopeProperty(receiver, context.session)) {
                 return true
             }
 
@@ -369,7 +433,10 @@ class UnstructuredLaunchChecker : FirFunctionCallChecker(MppCheckerKind.Common) 
      * @param propertyAccess The property access expression
      * @return true if it's a verified framework scope property
      */
-    private fun isFrameworkScopeProperty(propertyAccess: FirPropertyAccessExpression): Boolean {
+    private fun isFrameworkScopeProperty(
+        propertyAccess: FirPropertyAccessExpression,
+        session: FirSession,
+    ): Boolean {
         val symbol = propertyAccess.calleeReference.toResolvedCallableSymbol() ?: return false
         val callableId = symbol.callableId ?: return false
 
@@ -392,7 +459,49 @@ class UnstructuredLaunchChecker : FirFunctionCallChecker(MppCheckerKind.Common) 
             return true
         }
 
+        // MVIKotlin coroutine extensions: CoroutineBootstrapper.scope and CoroutineExecutor.scope.
+        // The exposed `scope` is cancelled in dispose(), so launches on it are structured.
+        if (packageName.startsWith("com.arkivanov.mvikotlin.extensions.coroutines") &&
+            callableName == Name.identifier("scope")
+        ) {
+            return true
+        }
+
+        // Inheritance fallback: when a member property is accessed via implicit `this` in a
+        // subclass (e.g., `class BootstrapperImpl : CoroutineBootstrapper<Action>()` accessing
+        // `scope`), FIR resolves the symbol against the subclass (fake override). Walk the
+        // dispatch receiver's super-type chain to detect inheritance from a known framework
+        // scope holder.
+        if (callableName == Name.identifier("scope")) {
+            val dispatchType = symbol.dispatchReceiverType as? ConeClassLikeType
+            if (dispatchType != null &&
+                inheritsFromAny(dispatchType, FRAMEWORK_SCOPE_HOLDER_CLASS_IDS, session)
+            ) {
+                return true
+            }
+        }
+
         return false
+    }
+
+    /**
+     * Recursively checks whether [type] (or any of its super-types) is one of [targetClassIds].
+     */
+    private fun inheritsFromAny(
+        type: ConeClassLikeType,
+        targetClassIds: Set<ClassId>,
+        session: FirSession,
+        visited: MutableSet<ClassId> = mutableSetOf(),
+    ): Boolean {
+        val classId = type.lookupTag.classId
+        if (classId in targetClassIds) return true
+        if (!visited.add(classId)) return false
+        val classSymbol = session.symbolProvider.getClassLikeSymbolByClassId(classId)
+            as? FirRegularClassSymbol ?: return false
+        return classSymbol.resolvedSuperTypes.any { superType ->
+            superType is ConeClassLikeType &&
+                inheritsFromAny(superType, targetClassIds, session, visited)
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Reduce false positives in `UnstructuredLaunchChecker` (`[SCOPE_003]`) by recognising more framework-provided structured scopes and by gating `launch`/`async` matching to the `kotlinx.coroutines` package.

## Motivation

Hit while integrating the plugin into an Android project that mixes Jetpack Compose UI, [Decompose](https://github.com/arkivanov/Decompose) / [Essenty](https://github.com/arkivanov/Essenty) for navigation and [MVIKotlin](https://github.com/arkivanov/MVIKotlin) for state. The build was blocked by ~50 `SCOPE_003` errors that all fell into one of four false-positive patterns:

1. `ActivityResultLauncher.launch(...)` — flagged purely because the function name is `launch`.
2. `coroutineScope.launch { ... }` inside a Compose `Modifier.Node.onAttach()` — the `coroutineScope` is the inherited `androidx.compose.ui.Modifier.Node.coroutineScope`, which is cancelled in `onDetach`.
3. `coroutineScope().launch { ... }` (and the local-`val` variant) inside Decompose components — Essenty's `LifecycleOwner.coroutineScope()` extension.
4. `scope.launch { ... }` inside subclasses of MVIKotlin's `CoroutineBootstrapper` / `CoroutineExecutor` — both expose a structured `scope` that is cancelled in `dispose()`.

## Changes

- **Gate `launch`/`async` by callable package.** Only `kotlinx.coroutines.launch` and `kotlinx.coroutines.async` are matched. Functions that share the name from other packages (e.g. `androidx.activity.result.ActivityResultLauncher.launch`) are no longer flagged.
- **Compose UI** — register `androidx.compose.ui.Modifier.Node.coroutineScope` as a known framework scope.
- **Decompose / Essenty** — register `com.arkivanov.essenty.lifecycle.coroutines.coroutineScope()` (extension on `LifecycleOwner`) as a framework scope function. Both direct calls and locals initialised from it are accepted via the existing initializer-tracing path.
- **MVIKotlin** — register `CoroutineBootstrapper.scope` and `CoroutineExecutor.scope`. Because user subclasses access these via implicit `this`, FIR resolves the symbol against the most-derived class (fake override). The checker now walks the dispatch-receiver type's super-type chain via `FirSession.symbolProvider` to recognise the inherited member regardless of the user's subclass name.
- Add an `Unreleased` entry to `CHANGELOG.md`.

## Notes

- Tests are not included in this PR — happy to add them in a follow-up if helpful; the existing test setup uses functional tests that compile a sample with the plugin applied, and the reproduction scaffolding for Compose UI / Decompose / MVIKotlin would need a few stub libraries on the classpath.
- The MVIKotlin inheritance walk is bounded by a `visited` set and only triggers when the property name is `scope`, so it does not add measurable cost for unrelated property accesses.