### PR TITLE
Support meta-annotated StructuredScope qualifiers

### DIFF
--- a/annotations/README.md
+++ b/annotations/README.md
@@ -178,9 +178,30 @@ available at runtime reflection.
 | Windows | `annotations-mingwx64` |
 | WASM | `annotations-wasmjs`, `annotations-wasmwasi` |
 
+## Meta-annotations (DI qualifiers)
+
+Mark your own scope qualifier once with `@StructuredScope` so injection sites do not need the annotation repeated:
+
+```kotlin
+import io.github.santimattius.structured.annotations.StructuredScope
+
+@StructuredScope
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.PROPERTY)
+annotation class AppCoroutineScope
+
+class UserRepository(@AppCoroutineScope private val scope: CoroutineScope) {
+    fun load() {
+        scope.launch { fetch() }  // recognized as structured
+    }
+}
+```
+
+The compiler plugin and IntelliJ inspection resolve `@AppCoroutineScope` to its annotation class and treat it like a direct `@StructuredScope` on the parameter or property.
+
 ## Recognition by compiler and IDE
 
-The **Structured Coroutines compiler plugin** and **IntelliJ plugin** both recognize `@StructuredScope` on function parameters and class properties. For example, `fun foo(@StructuredScope scope: CoroutineScope) { scope.launch { } }` is not reported as an unstructured launch. The IDE resolves the scope name to the parameter or property declaration and checks for the annotation.
+The **Structured Coroutines compiler plugin** and **IntelliJ plugin** both recognize `@StructuredScope` on function parameters, class properties, and **annotation types** (meta-annotations). For example, `fun foo(@StructuredScope scope: CoroutineScope) { scope.launch { } }` is not reported as an unstructured launch. The IDE resolves the scope name to the parameter or property declaration and checks for the annotation (direct or via a meta-annotated qualifier).
 
 ## Framework Scopes (Auto-recognized)
 

--- a/annotations/src/commonMain/kotlin/io/github/santimattius/structured/annotations/StructuredScope.kt
+++ b/annotations/src/commonMain/kotlin/io/github/santimattius/structured/annotations/StructuredScope.kt
@@ -3,7 +3,8 @@ package io.github.santimattius.structured.annotations
 @Target(
     AnnotationTarget.VALUE_PARAMETER,
     AnnotationTarget.PROPERTY,
-    AnnotationTarget.FIELD
+    AnnotationTarget.FIELD,
+    AnnotationTarget.ANNOTATION_CLASS,
 )
 @Retention(AnnotationRetention.BINARY)
 annotation class StructuredScope

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredScopeAnnotation.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredScopeAnnotation.kt
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassIdSafe
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassLikeSymbol
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+internal val STRUCTURED_SCOPE_ANNOTATION_CLASS_ID = ClassId(
+    FqName("io.github.santimattius.structured.annotations"),
+    Name.identifier("StructuredScope"),
+)
+
+@OptIn(SymbolInternals::class)
+internal fun FirValueParameterSymbol.hasStructuredScope(session: FirSession): Boolean =
+    hasStructuredScope(session, hasAnnotation(STRUCTURED_SCOPE_ANNOTATION_CLASS_ID, session), fir.annotations)
+
+@OptIn(SymbolInternals::class)
+internal fun FirPropertySymbol.hasStructuredScope(session: FirSession): Boolean =
+    hasStructuredScope(session, hasAnnotation(STRUCTURED_SCOPE_ANNOTATION_CLASS_ID, session), fir.annotations)
+
+/**
+ * Returns true when [hasDirect] is true, or any [annotations] type is meta-marked with @StructuredScope.
+ */
+private fun hasStructuredScope(
+    session: FirSession,
+    hasDirect: Boolean,
+    annotations: List<FirAnnotation>,
+): Boolean {
+    if (hasDirect) return true
+    return annotations.any { it.isMetaStructuredScope(session) }
+}
+
+private fun FirAnnotation.isMetaStructuredScope(session: FirSession): Boolean {
+    val annotationClass = resolveAnnotationClassSymbol(session) ?: return false
+    return annotationClass.hasAnnotation(STRUCTURED_SCOPE_ANNOTATION_CLASS_ID, session)
+}
+
+private fun FirAnnotation.resolveAnnotationClassSymbol(session: FirSession): FirRegularClassSymbol? {
+    toAnnotationClassLikeSymbol(session)?.let { symbol ->
+        return symbol as? FirRegularClassSymbol
+    }
+    val classId = toAnnotationClassId(session) ?: toAnnotationClassIdSafe(session) ?: return null
+    return session.symbolProvider.getClassLikeSymbolByClassId(classId) as? FirRegularClassSymbol
+}

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/UnstructuredLaunchChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/UnstructuredLaunchChecker.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
-import org.jetbrains.kotlin.fir.declarations.hasAnnotation
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
@@ -26,7 +25,6 @@ import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.name.CallableId
@@ -156,14 +154,6 @@ class UnstructuredLaunchChecker : FirFunctionCallChecker(MppCheckerKind.Common) 
         private val GLOBAL_SCOPE_CLASS_ID = ClassId(
             FqName("kotlinx.coroutines"),
             Name.identifier("GlobalScope")
-        )
-
-        /**
-         * ClassId for the @StructuredScope annotation.
-         */
-        private val STRUCTURED_SCOPE_ANNOTATION_CLASS_ID = ClassId(
-            FqName("io.github.santimattius.structured.annotations"),
-            Name.identifier("StructuredScope")
         )
 
         /**
@@ -380,14 +370,14 @@ class UnstructuredLaunchChecker : FirFunctionCallChecker(MppCheckerKind.Common) 
             // Check if it's a value parameter (function parameter)
             val parameterSymbol = calleeReference.toResolvedValueParameterSymbol()
             if (parameterSymbol != null) {
-                return hasStructuredScopeAnnotation(parameterSymbol, context)
+                return parameterSymbol.hasStructuredScope(context.session)
             }
 
             // Check if it's a property (including properties from constructor parameters)
             val propertySymbol = calleeReference.toResolvedPropertySymbol()
             if (propertySymbol != null) {
                 // Check annotation on the property itself
-                if (hasStructuredScopeAnnotation(propertySymbol, context)) return true
+                if (propertySymbol.hasStructuredScope(context.session)) return true
                 // Check if the property is initialized from a framework scope function.
                 // Handles: val scope = rememberCoroutineScope(); scope.launch { }
                 val initializer = propertySymbol.fir.initializer
@@ -504,31 +494,4 @@ class UnstructuredLaunchChecker : FirFunctionCallChecker(MppCheckerKind.Common) 
         }
     }
 
-    /**
-     * Checks if a value parameter symbol has @StructuredScope annotation.
-     *
-     * @param symbol The value parameter symbol to check
-     * @param context The checker context for session access
-     * @return true if the parameter has the annotation
-     */
-    private fun hasStructuredScopeAnnotation(
-        symbol: FirValueParameterSymbol,
-        context: CheckerContext
-    ): Boolean {
-        return symbol.hasAnnotation(STRUCTURED_SCOPE_ANNOTATION_CLASS_ID, context.session)
-    }
-
-    /**
-     * Checks if a property symbol has @StructuredScope annotation.
-     *
-     * @param symbol The property symbol to check
-     * @param context The checker context for session access
-     * @return true if the property has the annotation
-     */
-    private fun hasStructuredScopeAnnotation(
-        symbol: FirPropertySymbol,
-        context: CheckerContext
-    ): Boolean {
-        return symbol.hasAnnotation(STRUCTURED_SCOPE_ANNOTATION_CLASS_ID, context.session)
-    }
 }

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -144,6 +144,55 @@ class StructuredCoroutinesPluginFunctionalTest {
     }
 
     @Test
+    fun `meta-annotated DI qualifier on scope compiles successfully`() {
+        val sourceCode = """
+            import kotlinx.coroutines.CoroutineScope
+            import kotlinx.coroutines.launch
+            import io.github.santimattius.structured.annotations.StructuredScope
+
+            @StructuredScope
+            @Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.PROPERTY)
+            annotation class TestAppScope
+
+            class Service(@property:TestAppScope private val scope: CoroutineScope) {
+                fun run() {
+                    scope.launch { println("Running") }
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue("BUILD SUCCESSFUL" in output || "compileKotlin" in output, "Expected success:\n$output")
+    }
+
+    @Test
+    fun `DI qualifier without meta StructuredScope fails compilation`() {
+        val sourceCode = """
+            import kotlinx.coroutines.CoroutineScope
+            import kotlinx.coroutines.launch
+
+            @Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.PROPERTY)
+            annotation class TestAppScope
+
+            class Service(@property:TestAppScope private val scope: CoroutineScope) {
+                fun run() {
+                    scope.launch { println("Running") }
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = false)
+
+        assertTrue(
+            "UNSTRUCTURED_COROUTINE_LAUNCH" in output || "SCOPE_003" in output,
+            "Expected SCOPE_003 error but got:\n$output",
+        )
+    }
+
+    @Test
     fun `supervisorScope usage compiles successfully`() {
         val sourceCode = """
             import kotlinx.coroutines.launch

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/ScopeAnalyzer.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/ScopeAnalyzer.kt
@@ -285,23 +285,39 @@ object ScopeAnalyzer {
         return false
     }
 
+    private const val STRUCTURED_SCOPE_FQ_NAME =
+        "io.github.santimattius.structured.annotations.StructuredScope"
+
     /**
-     * Checks if a scope has the @StructuredScope annotation.
+     * Checks if a scope has @StructuredScope directly, or a meta-annotated qualifier
+     * (e.g. @AppCoroutineScope on an annotation type also marked with @StructuredScope).
      */
     fun hasStructuredScopeAnnotation(element: PsiElement): Boolean {
         return when (element) {
-            is KtParameter -> {
-                element.annotationEntries.any {
-                    it.shortName?.asString() == "StructuredScope"
-                }
-            }
-            is KtProperty -> {
-                element.annotationEntries.any {
-                    it.shortName?.asString() == "StructuredScope"
-                }
-            }
+            is KtParameter -> element.annotationEntries.any { annotationEntryIsStructuredScope(it) }
+            is KtProperty -> element.annotationEntries.any { annotationEntryIsStructuredScope(it) }
             else -> false
         }
+    }
+
+    private fun annotationEntryIsStructuredScope(entry: KtAnnotationEntry): Boolean {
+        if (entry.isStructuredScopeAnnotation()) return true
+        val annotationClass = entry.resolveAnnotationClass() ?: return false
+        return annotationClass.annotationEntries.any { it.isStructuredScopeAnnotation() }
+    }
+
+    private fun KtAnnotationEntry.isStructuredScopeAnnotation(): Boolean {
+        val shortName = shortName?.asString()
+        if (shortName == "StructuredScope") return true
+        return resolveAnnotationClass()?.fqName?.asString() == STRUCTURED_SCOPE_FQ_NAME
+    }
+
+    private fun KtAnnotationEntry.resolveAnnotationClass(): KtClass? {
+        val refExpr = (typeReference as? KtUserType)?.referenceExpression
+        val resolved = refExpr?.references?.firstOrNull()?.resolve()
+        if (resolved is KtClass) return resolved
+        val name = shortName?.asString() ?: return null
+        return containingKtFile.declarations.filterIsInstance<KtClass>().find { it.name == name }
     }
 
     /**


### PR DESCRIPTION
Recognize annotation types annotated with @StructuredScope as valid scope qualifiers. Adds AnnotationTarget.ANNOTATION_CLASS to the StructuredScope annotation and documents usage in the annotations README. Introduces compiler helper (StructuredScopeAnnotation.kt) to detect direct or meta-annotated StructuredScope on parameters and properties, and refactors UnstructuredLaunchChecker to use these helpers. Updates the IntelliJ ScopeAnalyzer to resolve annotation classes and check for meta-annotations. Adds functional tests verifying compilation success for a meta-annotated qualifier and failure when the qualifier is not meta-annotated.

ISSUE: #47 