### PR TITLE
Add new IDE inspections, quickfixes and tools

### DIFF
--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -39,6 +39,8 @@ dependencies {
     // (e.g. CloseAction.closeAutoCloseables); pinning avoids NoSuchMethodError with mixed transitive versions.
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.4")
+    // IntelliJ Platform testFramework still loads JUnit5TestSessionListener (needs JUnit 4 TestCase).
+    testRuntimeOnly("junit:junit:4.13.2")
     testImplementation(libs.assertj.core)
 }
 

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/BlockingFutureGetInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/BlockingFutureGetInspection.kt
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.quickfixes.ReplaceGetWithAwaitQuickFix
+import io.github.santimattius.structured.intellij.utils.CoroutinePsiUtils
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+
+/** [INTEROP_004] — blocking [java.util.concurrent.Future.get] inside coroutines. */
+class BlockingFutureGetInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.blocking.future.get.display.name"
+    override val descriptionKey = "inspection.blocking.future.get.description"
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+                if (!CoroutinesImportFilter.fileImportsCoroutines(expression.containingKtFile)) return
+                if (expression.calleeExpression?.text != "get") return
+
+                val parent = expression.parent as? KtDotQualifiedExpression ?: return
+                val receiverText = parent.receiverExpression.text
+                if (!receiverText.contains("Future", ignoreCase = true)) return
+                if (!isInsideCoroutine(expression)) return
+
+                holder.registerProblem(
+                    expression,
+                    StructuredCoroutinesBundle.message("error.interop.blocking.future.get"),
+                    ReplaceGetWithAwaitQuickFix(),
+                )
+            }
+        }
+
+    private fun isInsideCoroutine(element: KtCallExpression): Boolean {
+        val fn = element.getParentOfType<KtNamedFunction>(strict = true)
+        if (fn?.hasModifier(KtTokens.SUSPEND_KEYWORD) == true) return true
+        return CoroutinePsiUtils.isInsideCoroutineContext(element)
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/ChannelFlowVsCallbackFlowInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/ChannelFlowVsCallbackFlowInspection.kt
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+
+/** [INTEROP_003] — choose [callbackFlow] vs [channelFlow] correctly. */
+class ChannelFlowVsCallbackFlowInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.channelflow.vs.callbackflow.display.name"
+    override val descriptionKey = "inspection.channelflow.vs.callbackflow.description"
+
+    private val externalCallbackCalleePattern = Regex(
+        """(?i)(register|unregister|addListener|removeListener|subscribe|unsubscribe|setCallback|observe|enqueue)""",
+    )
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+                if (!CoroutinesImportFilter.fileImportsCoroutines(expression.containingKtFile)) return
+
+                val calleeName = expression.calleeExpression?.text ?: return
+                val lambdaExpr = extractTrailingLambda(expression) ?: return
+
+                when (calleeName) {
+                    "channelFlow" -> {
+                        if (lambdaBodyContainsAwaitClose(lambdaExpr)) return
+                        register(
+                            holder,
+                            expression,
+                            "error.interop.channelflow.external.callback",
+                        )
+                    }
+                    "callbackFlow" -> {
+                        if (!lambdaBodyContainsAwaitClose(lambdaExpr)) return
+                        if (lambdaHasExternalCallbackRegistration(lambdaExpr)) return
+                        register(
+                            holder,
+                            expression,
+                            "error.interop.callbackflow.internal.emission",
+                        )
+                    }
+                }
+            }
+        }
+
+    private fun register(holder: ProblemsHolder, expression: KtCallExpression, messageKey: String) {
+        holder.registerProblem(
+            expression,
+            StructuredCoroutinesBundle.message(messageKey),
+        )
+    }
+
+    private fun extractTrailingLambda(expression: KtCallExpression): KtLambdaExpression? {
+        expression.lambdaArguments.lastOrNull()?.getArgumentExpression()?.let { arg ->
+            if (arg is KtLambdaExpression) return arg
+        }
+        return null
+    }
+
+    private fun lambdaBodyContainsAwaitClose(lambda: KtLambdaExpression): Boolean =
+        lambda.bodyExpression?.anyDescendantOfType<KtCallExpression> { call ->
+            call.calleeExpression?.text == "awaitClose"
+        } ?: false
+
+    private fun lambdaHasExternalCallbackRegistration(lambda: KtLambdaExpression): Boolean =
+        lambda.bodyExpression?.anyDescendantOfType<KtCallExpression> { call ->
+            externalCallbackCalleePattern.containsMatchIn(call.calleeExpression?.text.orEmpty())
+        } ?: false
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/CoroutineNotCompletedInTestInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/CoroutineNotCompletedInTestInspection.kt
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import io.github.santimattius.structured.intellij.utils.CoroutinePsiUtils
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+
+/** [TEST_006] — assertion in [runTest] without [advanceUntilIdle] after work that may launch coroutines. */
+class CoroutineNotCompletedInTestInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.coroutine.not.completed.in.test.display.name"
+    override val descriptionKey = "inspection.coroutine.not.completed.in.test.description"
+
+    private val assertionPrefixes = setOf("assert", "verify", "expect")
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+                if (!isAssertionCall(expression)) return
+                val runTestCall = findEnclosingRunTest(expression) ?: return
+                if (hasAdvanceBeforeAssertion(runTestCall, expression)) return
+
+                holder.registerProblem(
+                    expression,
+                    StructuredCoroutinesBundle.message("error.test.coroutine.not.completed"),
+                )
+            }
+        }
+
+    private fun isAssertionCall(call: KtCallExpression): Boolean {
+        val name = call.calleeExpression?.text ?: return false
+        return assertionPrefixes.any { name.startsWith(it, ignoreCase = true) }
+    }
+
+    private fun findEnclosingRunTest(element: KtElement): KtCallExpression? {
+        val file = element.containingKtFile
+        if (!CoroutinesImportFilter.fileImportsCoroutines(file)) return null
+        if (!CoroutinePsiUtils.looksLikeJvmTestKotlinFile(file)) return null
+        var current: KtElement? = element
+        while (current != null) {
+            if (current is KtCallExpression && current.calleeExpression?.text == "runTest") {
+                return current
+            }
+            current = current.parent as? KtElement
+        }
+        return null
+    }
+
+    private fun hasAdvanceBeforeAssertion(runTestCall: KtCallExpression, assertion: KtCallExpression): Boolean {
+        val body = runTestCall.lambdaArguments.firstOrNull()?.getLambdaExpression()?.bodyExpression
+            ?: return false
+        val descendants = body.collectDescendantsOfType<KtCallExpression>()
+        val assertionIndex = descendants.indexOf(assertion)
+        if (assertionIndex <= 0) return false
+        return descendants.subList(0, assertionIndex).any { call ->
+            val name = call.calleeExpression?.text
+            name == "advanceUntilIdle" || name == "advanceTimeBy"
+        }
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/FlatMapOperatorChoiceInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/FlatMapOperatorChoiceInspection.kt
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+/** [FLOW_009] — contextual guidance for flatMap operator choice (Info). */
+class FlatMapOperatorChoiceInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.flatmap.operator.choice.display.name"
+    override val descriptionKey = "inspection.flatmap.operator.choice.description"
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+                if (!CoroutinesImportFilter.fileImportsCoroutines(expression.containingKtFile)) return
+
+                val callee = expression.calleeExpression?.text ?: return
+                val context = expression.parentsWithSelf().joinToString(" ") { it.text }
+
+                when {
+                    callee == "flatMapLatest" && looksLikeDownloadContext(context) -> {
+                        holder.registerProblem(
+                            expression,
+                            StructuredCoroutinesBundle.message("error.flow.flatmap.latest.download"),
+                        )
+                    }
+                    callee == "flatMapConcat" && looksLikeSearchContext(context) -> {
+                        holder.registerProblem(
+                            expression,
+                            StructuredCoroutinesBundle.message("error.flow.flatmap.concat.search"),
+                        )
+                    }
+                }
+            }
+        }
+
+    private fun org.jetbrains.kotlin.psi.KtElement.parentsWithSelf(): Sequence<org.jetbrains.kotlin.psi.KtElement> =
+        generateSequence(this as org.jetbrains.kotlin.psi.KtElement?) { it.parent as? org.jetbrains.kotlin.psi.KtElement }
+
+    private fun looksLikeDownloadContext(text: String): Boolean =
+        listOf("download", "Download", "upload", "Upload", "file").any { text.contains(it) }
+
+    private fun looksLikeSearchContext(text: String): Boolean =
+        listOf("searchQuery", "searchText", "query", "Query", "search").any { text.contains(it) }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/HardcodedDispatcherInClassInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/HardcodedDispatcherInClassInspection.kt
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.utils.CoroutinePsiUtils
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.isAncestor
+
+/** [TEST_005] — hardcoded [Dispatchers.IO]/[Dispatchers.Main] in production classes. */
+class HardcodedDispatcherInClassInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.hardcoded.dispatcher.display.name"
+    override val descriptionKey = "inspection.hardcoded.dispatcher.description"
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+                super.visitDotQualifiedExpression(expression)
+                if (!CoroutinesImportFilter.fileImportsCoroutines(expression.containingKtFile)) return
+                if (CoroutinePsiUtils.looksLikeJvmTestKotlinFile(expression.containingKtFile)) return
+
+                val receiver = expression.receiverExpression.text.trim()
+                if (receiver != "Dispatchers" && !receiver.endsWith(".Dispatchers")) return
+                val selector = expression.selectorExpression?.text ?: return
+                if (selector != "IO" && selector != "Main") return
+                if (!isInsideCoroutine(expression)) return
+                if (isInDefaultParameterValue(expression)) return
+
+                val klass = expression.getParentOfType<KtClass>(strict = true) ?: return
+                if (klass.hasDispatcherQualifierParameter()) return
+
+                holder.registerProblem(
+                    expression,
+                    StructuredCoroutinesBundle.message("error.test.hardcoded.dispatcher"),
+                )
+            }
+        }
+
+    private fun isInsideCoroutine(element: KtDotQualifiedExpression): Boolean {
+        val fn = element.getParentOfType<KtNamedFunction>(strict = true)
+        if (fn?.hasModifier(KtTokens.SUSPEND_KEYWORD) == true) return true
+        var current = element.parent
+        while (current != null) {
+            val call = current as? org.jetbrains.kotlin.psi.KtCallExpression
+            if (call?.calleeExpression?.text in setOf("launch", "async", "withContext", "coroutineScope", "supervisorScope")) {
+                return true
+            }
+            current = current.parent
+        }
+        return false
+    }
+
+    private fun isInDefaultParameterValue(element: KtDotQualifiedExpression): Boolean {
+        val parameter = element.getParentOfType<KtParameter>(strict = true) ?: return false
+        val default = parameter.defaultValue ?: return false
+        return default.isAncestor(element)
+    }
+
+    private fun KtClass.hasDispatcherQualifierParameter(): Boolean {
+        val params = primaryConstructor?.valueParameters.orEmpty() +
+            secondaryConstructors.flatMap { it.valueParameters }
+        return params.any { param ->
+            param.annotationEntries.any { ann ->
+                val short = ann.shortName?.asString()
+                short == "IoDispatcher" || short == "MainDispatcher"
+            }
+        }
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/RememberScopeForInitInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/RememberScopeForInitInspection.kt
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.quickfixes.ReplaceWithLaunchedEffectQuickFix
+import io.github.santimattius.structured.intellij.utils.ComposePsiUtils
+import io.github.santimattius.structured.intellij.utils.CoroutinePsiUtils
+import io.github.santimattius.structured.intellij.utils.importsComposeRuntime
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+/** [COMPOSE_002] — [rememberCoroutineScope] used for init work in composable body. */
+class RememberScopeForInitInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.remember.scope.for.init.display.name"
+    override val descriptionKey = "inspection.remember.scope.for.init.description"
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+                if (expression.calleeExpression?.text != "launch") return
+                if (!CoroutinePsiUtils.isFrameworkScopeCall(expression)) return
+
+                val file = expression.containingKtFile
+                if (!file.importsComposeRuntime()) return
+                if (!ComposePsiUtils.hasComposableAncestor(expression)) return
+                if (ComposePsiUtils.hasPreviewAncestor(expression)) return
+                if (ComposePsiUtils.isInsideComposeEffectOrEventHandler(expression)) return
+
+                holder.registerProblem(
+                    expression,
+                    StructuredCoroutinesBundle.message("error.compose.remember.scope.for.init"),
+                    ReplaceWithLaunchedEffectQuickFix(),
+                )
+            }
+        }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/SharedFlowForOneshotEventsInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/SharedFlowForOneshotEventsInspection.kt
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.inspections.base.CoroutineInspectionBase
+import io.github.santimattius.structured.intellij.quickfixes.ReplaceSharedFlowWithChannelQuickFix
+import io.github.santimattius.structured.intellij.utils.CoroutinePsiUtils
+import io.github.santimattius.structured.intellij.utils.CoroutinesImportFilter
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+/** [FLOW_011] — [MutableSharedFlow] with default buffer for one-shot UI events. */
+class SharedFlowForOneshotEventsInspection : CoroutineInspectionBase() {
+
+    override val displayNameKey = "inspection.sharedflow.oneshot.display.name"
+    override val descriptionKey = "inspection.sharedflow.oneshot.description"
+
+    private val oneShotNamePattern = Regex("""(event|command|effect)""", RegexOption.IGNORE_CASE)
+
+    override fun buildKotlinVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): KtVisitorVoid =
+        object : KtVisitorVoid() {
+            override fun visitProperty(property: KtProperty) {
+                super.visitProperty(property)
+                val file = property.containingKtFile
+                if (!CoroutinesImportFilter.fileImportsCoroutines(file)) return
+                if (CoroutinePsiUtils.looksLikeJvmTestKotlinFile(file)) return
+
+                val propName = property.name ?: return
+                if (!oneShotNamePattern.containsMatchIn(propName)) return
+
+                val init = property.initializer as? KtCallExpression ?: return
+                val callee = init.calleeExpression?.text ?: return
+                if (callee != "MutableSharedFlow" && !callee.endsWith(".MutableSharedFlow")) return
+                if (hasNonDefaultBuffer(init.text)) return
+
+                holder.registerProblem(
+                    property,
+                    StructuredCoroutinesBundle.message("error.flow.sharedflow.oneshot"),
+                    ReplaceSharedFlowWithChannelQuickFix(),
+                )
+            }
+        }
+
+    private fun hasNonDefaultBuffer(argsText: String): Boolean {
+        val replayPositive = Regex("""replay\s*=\s*([1-9]\d*)""")
+        val extraPositive = Regex("""extraBufferCapacity\s*=\s*([1-9]\d*)""")
+        return replayPositive.containsMatchIn(argsText) || extraPositive.containsMatchIn(argsText)
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/StructuredCoroutinesInspectionProvider.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/StructuredCoroutinesInspectionProvider.kt
@@ -49,6 +49,13 @@ class StructuredCoroutinesInspectionProvider : InspectionToolProvider {
             LaunchInWithUnstructuredScopeInspection::class.java,
             RedundantWithContextInspection::class.java,
             SideEffectInMapOperatorInspection::class.java,
+            RememberScopeForInitInspection::class.java,
+            HardcodedDispatcherInClassInspection::class.java,
+            CoroutineNotCompletedInTestInspection::class.java,
+            FlatMapOperatorChoiceInspection::class.java,
+            SharedFlowForOneshotEventsInspection::class.java,
+            ChannelFlowVsCallbackFlowInspection::class.java,
+            BlockingFutureGetInspection::class.java,
         )
     }
 }

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/intentions/AnalyzeFlowChainIntention.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/intentions/AnalyzeFlowChainIntention.kt
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.intentions
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.psi.PsiElement
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import io.github.santimattius.structured.intellij.utils.FlowChainAnalyzer
+import org.jetbrains.kotlin.psi.KtElement
+
+/** [INF-001] — show Flow chain analysis for the operator under the cursor. */
+class AnalyzeFlowChainIntention : PsiElementBaseIntentionAction(), IntentionAction {
+
+    override fun getText(): String = StructuredCoroutinesBundle.message("intention.analyze.flow.chain")
+
+    override fun getFamilyName(): String = StructuredCoroutinesBundle.message("intention.category")
+
+    override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
+        val kt = element as? KtElement ?: return false
+        return FlowChainAnalyzer.findFlowDotChain(kt) != null
+    }
+
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        val kt = element as? KtElement ?: return
+        val chain = FlowChainAnalyzer.findFlowDotChain(kt) ?: return
+        val report = FlowChainAnalyzer.formatReport(FlowChainAnalyzer.analyze(chain))
+        Messages.showInfoMessage(project, report, StructuredCoroutinesBundle.message("intention.analyze.flow.chain"))
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceGetWithAwaitQuickFix.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceGetWithAwaitQuickFix.kt
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+/** Replaces `.get()` with `.await()` for [INTEROP_004]. */
+class ReplaceGetWithAwaitQuickFix : LocalQuickFix {
+
+    override fun getName(): String =
+        StructuredCoroutinesBundle.message("quickfix.replace.get.with.await")
+
+    override fun getFamilyName(): String = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val getCall = descriptor.psiElement as? KtCallExpression ?: return
+        val dotExpr = getCall.parent as? KtDotQualifiedExpression ?: return
+        val factory = KtPsiFactory(project, markGenerated = false)
+        val receiver = dotExpr.receiverExpression.text
+        val replacement = factory.createExpression("$receiver.await()")
+        dotExpr.replace(replacement)
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceSharedFlowWithChannelQuickFix.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceSharedFlowWithChannelQuickFix.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+/** Replaces default [MutableSharedFlow] with [Channel] for [FLOW_011]. */
+class ReplaceSharedFlowWithChannelQuickFix : LocalQuickFix {
+
+    override fun getName(): String =
+        StructuredCoroutinesBundle.message("quickfix.replace.sharedflow.with.channel")
+
+    override fun getFamilyName(): String = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val property = descriptor.psiElement as? KtProperty ?: return
+        val init = property.initializer as? KtCallExpression ?: return
+        val typeArgs = init.typeArguments.joinToString(", ") { it.text }
+        val channelType = if (typeArgs.isNotBlank()) "<$typeArgs>" else ""
+        val factory = KtPsiFactory(project, markGenerated = false)
+        val replacement = factory.createExpression("Channel$channelType(Channel.BUFFERED)")
+        init.replace(replacement)
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceWithLaunchedEffectQuickFix.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/quickfixes/ReplaceWithLaunchedEffectQuickFix.kt
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import io.github.santimattius.structured.intellij.StructuredCoroutinesBundle
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+/** Replaces `scope.launch { }` with `LaunchedEffect(Unit) { }` for [COMPOSE_002]. */
+class ReplaceWithLaunchedEffectQuickFix : LocalQuickFix {
+
+    override fun getName(): String =
+        StructuredCoroutinesBundle.message("quickfix.replace.with.launched.effect")
+
+    override fun getFamilyName(): String = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val launchCall = descriptor.psiElement as? KtCallExpression ?: return
+        val parent = launchCall.parent as? KtDotQualifiedExpression ?: return
+        val factory = KtPsiFactory(project, markGenerated = false)
+        val lambdaArg = launchCall.lambdaArguments.firstOrNull()?.getLambdaExpression()?.text
+            ?: launchCall.valueArguments.firstOrNull()?.text
+            ?: "{ }"
+        val replacement = factory.createExpression("LaunchedEffect(Unit) $lambdaArg")
+        parent.replace(replacement)
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/ComposePsiUtils.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/ComposePsiUtils.kt
@@ -8,10 +8,13 @@
 package io.github.santimattius.structured.intellij.utils
 
 import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 fun KtFile.importsComposeRuntime(): Boolean =
     importDirectives.any {
@@ -79,5 +82,33 @@ object ComposePsiUtils {
             p = p.parent as? KtElement
         }
         return result
+    }
+
+    private val composeEffectCalls = setOf("SideEffect", "LaunchedEffect", "DisposableEffect")
+    private val eventHandlerParamSuffixes = listOf("onClick", "onValueChange", "onDismiss", "Listener", "Handler")
+
+    fun isInsideComposeEffectOrEventHandler(element: KtElement): Boolean =
+        isInsideComposeEffectBlock(element) || isInsideEventHandlerLambda(element)
+
+    fun isInsideComposeEffectBlock(element: KtElement): Boolean {
+        var current: KtElement? = element
+        while (current != null) {
+            val lambda = current.getParentOfType<KtLambdaExpression>(strict = true)
+            if (lambda != null) {
+                val call = lambda.getParentOfType<KtCallExpression>(strict = false)
+                if (call?.calleeExpression?.text in composeEffectCalls) return true
+            }
+            current = current.parent as? KtElement
+        }
+        return false
+    }
+
+    fun isInsideEventHandlerLambda(element: KtElement): Boolean {
+        val lambda = element.getParentOfType<KtLambdaExpression>(strict = true) ?: return false
+        val valueArg = lambda.getParentOfType<KtValueArgument>(strict = true) ?: return false
+        val name = valueArg.getArgumentName()?.asName?.asString()
+            ?: valueArg.getArgumentName()?.text
+            ?: return false
+        return eventHandlerParamSuffixes.any { suffix -> name == suffix || name.endsWith(suffix) }
     }
 }

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/FlowChainAnalyzer.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/utils/FlowChainAnalyzer.kt
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+package io.github.santimattius.structured.intellij.utils
+
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtElement
+
+/**
+ * [INF-001] MVP — analyzes a Flow operator chain from a dot-qualified expression upward.
+ */
+object FlowChainAnalyzer {
+
+    data class FlowChainFinding(val symbol: String, val message: String)
+
+    private val flowOperators = setOf(
+        "map", "filter", "flatMapLatest", "flatMapMerge", "flatMapConcat",
+        "onEach", "catch", "distinctUntilChanged", "flowOn", "collect",
+        "collectLatest", "launchIn", "transform", "debounce",
+    )
+
+    fun findFlowDotChain(element: KtElement): KtDotQualifiedExpression? {
+        var current: KtElement? = element
+        while (current != null) {
+            if (current is KtDotQualifiedExpression && chainContainsFlowOperator(current)) {
+                return current
+            }
+            current = current.parent as? KtElement
+        }
+        return null
+    }
+
+    fun analyze(chainRoot: KtDotQualifiedExpression): List<FlowChainFinding> {
+        val operators = collectOperators(chainRoot)
+        val findings = mutableListOf<FlowChainFinding>()
+
+        if ("catch" in operators) {
+            findings += FlowChainFinding("✅", "catch — error handling present")
+        } else {
+            findings += FlowChainFinding("⚠️", "missing catch — upstream errors propagate to the collector scope")
+        }
+
+        if ("onEach" in operators) {
+            findings += FlowChainFinding("✅", "onEach — side effects separated from map")
+        }
+
+        if ("distinctUntilChanged" !in operators) {
+            findings += FlowChainFinding("⚠️", "missing distinctUntilChanged — potential redundant emissions")
+        }
+
+        when {
+            "flatMapLatest" in operators ->
+                findings += FlowChainFinding("ℹ️", "flatMapLatest — last-wins semantics (suitable for search, not for downloads)")
+            "flatMapConcat" in operators ->
+                findings += FlowChainFinding("ℹ️", "flatMapConcat — serializes inner flows (suitable for ordered work)")
+            "flatMapMerge" in operators ->
+                findings += FlowChainFinding("ℹ️", "flatMapMerge — concurrent inner flows (watch dispatcher pressure)")
+        }
+
+        if ("flowOn" !in operators) {
+            findings += FlowChainFinding("→", "Dispatcher: inherited (not pinned with flowOn)")
+        } else {
+            findings += FlowChainFinding("→", "Dispatcher: flowOn present in chain")
+        }
+
+        return findings
+    }
+
+    fun formatReport(findings: List<FlowChainFinding>): String {
+        val header = "Flow chain analysis:"
+        val body = findings.joinToString("\n") { "  ${it.symbol} ${it.message}" }
+        return "$header\n$body"
+    }
+
+    private fun chainContainsFlowOperator(dotExpr: KtDotQualifiedExpression): Boolean =
+        collectOperators(dotExpr).isNotEmpty()
+
+    private fun collectOperators(dotExpr: KtDotQualifiedExpression): Set<String> {
+        val names = mutableSetOf<String>()
+        var receiver: org.jetbrains.kotlin.psi.KtExpression? = dotExpr.receiverExpression
+        val terminal = dotExpr.selectorExpression as? KtCallExpression
+        terminal?.calleeExpression?.text?.let { names += it }
+
+        while (receiver is KtDotQualifiedExpression) {
+            val selectorCall = receiver.selectorExpression as? KtCallExpression
+            selectorCall?.calleeExpression?.text?.let { name ->
+                if (name in flowOperators) names += name
+            }
+            receiver = receiver.receiverExpression
+        }
+        val receiverCall = receiver as? KtCallExpression
+        receiverCall?.calleeExpression?.text?.let { name ->
+            if (name in flowOperators) names += name
+        }
+        return names
+    }
+}

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/view/InspectionGuideRegistry.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/view/InspectionGuideRegistry.kt
@@ -10,11 +10,16 @@
 package io.github.santimattius.structured.intellij.view
 
 import io.github.santimattius.structured.intellij.inspections.AsyncWithoutAwaitInspection
+import io.github.santimattius.structured.intellij.inspections.BlockingFutureGetInspection
 import io.github.santimattius.structured.intellij.inspections.CallbackFlowWithoutAwaitCloseInspection
+import io.github.santimattius.structured.intellij.inspections.ChannelFlowVsCallbackFlowInspection
+import io.github.santimattius.structured.intellij.inspections.CoroutineNotCompletedInTestInspection
 import io.github.santimattius.structured.intellij.inspections.CancellationExceptionSubclassInspection
 import io.github.santimattius.structured.intellij.inspections.CancellationExceptionSwallowedInspection
 import io.github.santimattius.structured.intellij.inspections.CollectAsStateWithoutLifecycleInspection
 import io.github.santimattius.structured.intellij.inspections.DispatchersIOInCommonMainInspection
+import io.github.santimattius.structured.intellij.inspections.FlatMapOperatorChoiceInspection
+import io.github.santimattius.structured.intellij.inspections.HardcodedDispatcherInClassInspection
 import io.github.santimattius.structured.intellij.inspections.DispatchersUnconfinedInspection
 import io.github.santimattius.structured.intellij.inspections.GlobalScopeInspection
 import io.github.santimattius.structured.intellij.inspections.InlineCoroutineScopeInspection
@@ -26,6 +31,8 @@ import io.github.santimattius.structured.intellij.inspections.MainDispatcherMisu
 import io.github.santimattius.structured.intellij.inspections.MissingCatchInFlowInspection
 import io.github.santimattius.structured.intellij.inspections.MutableFlowExposedInspection
 import io.github.santimattius.structured.intellij.inspections.RedundantWithContextInspection
+import io.github.santimattius.structured.intellij.inspections.RememberScopeForInitInspection
+import io.github.santimattius.structured.intellij.inspections.SharedFlowForOneshotEventsInspection
 import io.github.santimattius.structured.intellij.inspections.RunBlockingInSuspendInspection
 import io.github.santimattius.structured.intellij.inspections.RunBlockingInsteadOfRunTestInspection
 import io.github.santimattius.structured.intellij.inspections.ScopeReuseAfterCancelInspection
@@ -170,6 +177,34 @@ object InspectionGuideRegistry {
         SideEffectInMapOperatorInspection::class.java to GuideEntry(
             whatToDo = "Move logging/analytics/IO side effects to onEach { } and keep map { } as a pure transform.",
             guideUrl = "$BASE_URL#99-flow_008--sideeffectinmapoperator"
+        ),
+        RememberScopeForInitInspection::class.java to GuideEntry(
+            whatToDo = "Replace rememberCoroutineScope().launch { } with LaunchedEffect(Unit) { } for composable init work.",
+            guideUrl = "$BASE_URL#84-compose_002--rememberscopeforinit"
+        ),
+        HardcodedDispatcherInClassInspection::class.java to GuideEntry(
+            whatToDo = "Inject @IoDispatcher / @MainDispatcher or a CoroutineDispatcher parameter instead of Dispatchers.IO/Main in the class body.",
+            guideUrl = "$BASE_URL#65-test_005--hardcodeddispatcherinclass"
+        ),
+        CoroutineNotCompletedInTestInspection::class.java to GuideEntry(
+            whatToDo = "Call advanceUntilIdle() or advanceTimeBy() in runTest before assert/verify when work uses launch/async.",
+            guideUrl = "$BASE_URL#66-test_006--coroutinenotcompletedintest"
+        ),
+        FlatMapOperatorChoiceInspection::class.java to GuideEntry(
+            whatToDo = "Use flatMapLatest for debounced search; flatMapMerge/flatMapConcat for downloads or ordered pipelines.",
+            guideUrl = "$BASE_URL#910-flow_009--flatmapoperatorchoice"
+        ),
+        SharedFlowForOneshotEventsInspection::class.java to GuideEntry(
+            whatToDo = "Use Channel(BUFFERED) and receiveAsFlow() for one-shot navigation/snackbar/command events.",
+            guideUrl = "$BASE_URL#911-flow_011--sharedflow-for-oneshot-events"
+        ),
+        ChannelFlowVsCallbackFlowInspection::class.java to GuideEntry(
+            whatToDo = "Use callbackFlow + awaitClose for external listeners; channelFlow for internal coroutine producers.",
+            guideUrl = "$BASE_URL#103-interop_003--channelflow-vs-callbackflow"
+        ),
+        BlockingFutureGetInspection::class.java to GuideEntry(
+            whatToDo = "Replace Future.get() with await() from kotlinx-coroutines-jdk8 or kotlinx-coroutines-guava.",
+            guideUrl = "$BASE_URL#104-interop_004--blocking-future-get"
         ),
     )
 

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -398,6 +398,90 @@
             groupPath="Kotlin"
             groupBundle="messages.StructuredCoroutinesBundle"
             groupKey="inspection.group.name"
+            shortName="RememberScopeForInit"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.remember.scope.for.init.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.RememberScopeForInitInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="HardcodedDispatcherInClass"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.hardcoded.dispatcher.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.HardcodedDispatcherInClassInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="CoroutineNotCompletedInTest"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.coroutine.not.completed.in.test.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.CoroutineNotCompletedInTestInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="FlatMapOperatorChoice"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.flatmap.operator.choice.display.name"
+            enabledByDefault="true"
+            level="INFO"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.FlatMapOperatorChoiceInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="SharedFlowForOneshotEvents"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.sharedflow.oneshot.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.SharedFlowForOneshotEventsInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="ChannelFlowVsCallbackFlow"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.channelflow.vs.callbackflow.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.ChannelFlowVsCallbackFlowInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
+            shortName="BlockingFutureGet"
+            bundle="messages.StructuredCoroutinesBundle"
+            key="inspection.blocking.future.get.display.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="io.github.santimattius.structured.intellij.inspections.BlockingFutureGetInspection"/>
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.StructuredCoroutinesBundle"
+            groupKey="inspection.group.name"
             shortName="WithTimeoutScopeCancellation"
             bundle="messages.StructuredCoroutinesBundle"
             key="inspection.with.timeout.scope.cancellation.display.name"
@@ -444,6 +528,13 @@
         <intentionAction>
             <language>kotlin</language>
             <className>io.github.santimattius.structured.intellij.intentions.ConvertToRunTestIntention</className>
+            <bundleName>messages.StructuredCoroutinesBundle</bundleName>
+            <categoryKey>intention.category</categoryKey>
+        </intentionAction>
+
+        <intentionAction>
+            <language>kotlin</language>
+            <className>io.github.santimattius.structured.intellij.intentions.AnalyzeFlowChainIntention</className>
             <bundleName>messages.StructuredCoroutinesBundle</bundleName>
             <categoryKey>intention.category</categoryKey>
         </intentionAction>

--- a/intellij-plugin/src/main/resources/messages/StructuredCoroutinesBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/StructuredCoroutinesBundle.properties
@@ -170,6 +170,37 @@ inspection.sideeffect.in.map.description=<html>Non-transform statements in <code
 quickfix.replace.synchronized.with.mutex=Replace synchronized with mutex.withLock
 quickfix.replace.eagerly.with.while.subscribed=Replace Eagerly with WhileSubscribed(5_000)
 quickfix.remove.redundant.withcontext=Remove redundant inner withContext
+quickfix.replace.with.launched.effect=Replace with LaunchedEffect(Unit)
+quickfix.replace.sharedflow.with.channel=Replace MutableSharedFlow with Channel(BUFFERED)
+quickfix.replace.get.with.await=Replace .get() with .await()
+
+inspection.remember.scope.for.init.display.name=rememberCoroutineScope for init work
+inspection.remember.scope.for.init.description=<html>Use <code>LaunchedEffect</code> or <code>DisposableEffect</code> for one-shot composable setup instead of <code>rememberCoroutineScope().launch</code> in the composable body.<br/><br/><b>COMPOSE_002</b>.</html>
+inspection.hardcoded.dispatcher.display.name=Hardcoded dispatcher in class
+inspection.hardcoded.dispatcher.description=<html>Inject <code>CoroutineDispatcher</code> instead of hardcoding <code>Dispatchers.IO</code>/<code>Dispatchers.Main</code> in production classes.<br/><br/><b>TEST_005</b>.</html>
+inspection.coroutine.not.completed.in.test.display.name=Coroutine work not completed before assert
+inspection.coroutine.not.completed.in.test.description=<html>In <code>runTest</code>, call <code>advanceUntilIdle()</code> or <code>advanceTimeBy()</code> before assertions when child coroutines may still be running.<br/><br/><b>TEST_006</b>.</html>
+inspection.flatmap.operator.choice.display.name=FlatMap operator choice guidance
+inspection.flatmap.operator.choice.description=<html>Contextual guidance for <code>flatMapLatest</code> vs <code>flatMapConcat</code> in search/download flows.<br/><br/><b>FLOW_009</b> (info).</html>
+inspection.sharedflow.oneshot.display.name=SharedFlow for one-shot events
+inspection.sharedflow.oneshot.description=<html>Default <code>MutableSharedFlow</code> can drop one-shot UI events — prefer <code>Channel(BUFFERED).receiveAsFlow()</code>.<br/><br/><b>FLOW_011</b>.</html>
+inspection.channelflow.vs.callbackflow.display.name=channelFlow vs callbackFlow
+inspection.channelflow.vs.callbackflow.description=<html>External callbacks need <code>callbackFlow</code> with <code>awaitClose</code>; internal emission can use <code>channelFlow</code>.<br/><br/><b>INTEROP_003</b>.</html>
+inspection.blocking.future.get.display.name=Blocking Future.get in coroutine
+inspection.blocking.future.get.description=<html>Replace blocking <code>Future.get()</code> with <code>await()</code> from kotlinx-coroutines-jdk8 or guava.<br/><br/><b>INTEROP_004</b>.</html>
+
+error.compose.remember.scope.for.init=[COMPOSE_002] Use LaunchedEffect or DisposableEffect instead of rememberCoroutineScope().launch in composable body.
+error.test.hardcoded.dispatcher=[TEST_005] Hardcoded Dispatchers.IO/Main in production class — inject CoroutineDispatcher.
+error.test.coroutine.not.completed=[TEST_006] runTest assertion may run before child coroutines finish — call advanceUntilIdle() first.
+error.flow.flatmap.latest.download=[FLOW_009] flatMapLatest cancels in-progress downloads when a new request arrives — consider flatMapMerge or flatMapConcat.
+error.flow.flatmap.concat.search=[FLOW_009] flatMapConcat queues search requests — flatMapLatest is usually better for debounced search.
+error.flow.sharedflow.oneshot=[FLOW_011] MutableSharedFlow(replay=0) may drop one-shot events — use Channel(BUFFERED).receiveAsFlow().
+error.interop.channelflow.external.callback=[INTEROP_003] channelFlow without awaitClose — external callbacks need callbackFlow { awaitClose { } }.
+error.interop.callbackflow.internal.emission=[INTEROP_003] callbackFlow with no external callback — use channelFlow for internal multi-coroutine emission.
+error.interop.blocking.future.get=[INTEROP_004] Future.get() blocks the dispatcher — use .await() from kotlinx-coroutines-jdk8 or guava.
+
+intention.analyze.flow.chain=Analyze Flow chain
+intention.analyze.flow.chain.description=Show catch, distinctUntilChanged, and flatMap guidance for the Flow chain under the cursor (INF-001).
 
 # Action - Scan Project
 action.scan.project.text=Scan Project for Coroutine Issues

--- a/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/Iter3InspectionsTest.kt
+++ b/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/inspections/Iter3InspectionsTest.kt
@@ -1,0 +1,51 @@
+package io.github.santimattius.structured.intellij.inspections
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/** Configuration smoke tests for Iteration 3 (v1.0.0 P3) IDE inspections. */
+class Iter3InspectionsTest {
+
+    @Test
+    fun `RememberScopeForInit inspection is configured`() {
+        val i = RememberScopeForInitInspection()
+        assertThat(i.displayNameKey).isEqualTo("inspection.remember.scope.for.init.display.name")
+        assertThat(i.isEnabledByDefault).isTrue()
+    }
+
+    @Test
+    fun `HardcodedDispatcherInClass inspection is configured`() {
+        val i = HardcodedDispatcherInClassInspection()
+        assertThat(i.displayNameKey).isEqualTo("inspection.hardcoded.dispatcher.display.name")
+    }
+
+    @Test
+    fun `CoroutineNotCompletedInTest inspection is configured`() {
+        val i = CoroutineNotCompletedInTestInspection()
+        assertThat(i.descriptionKey).isEqualTo("inspection.coroutine.not.completed.in.test.description")
+    }
+
+    @Test
+    fun `FlatMapOperatorChoice inspection is configured`() {
+        val i = FlatMapOperatorChoiceInspection()
+        assertThat(i.displayNameKey).isEqualTo("inspection.flatmap.operator.choice.display.name")
+    }
+
+    @Test
+    fun `SharedFlowForOneshotEvents inspection is configured`() {
+        val i = SharedFlowForOneshotEventsInspection()
+        assertThat(i.displayNameKey).isEqualTo("inspection.sharedflow.oneshot.display.name")
+    }
+
+    @Test
+    fun `ChannelFlowVsCallbackFlow inspection is configured`() {
+        val i = ChannelFlowVsCallbackFlowInspection()
+        assertThat(i.displayNameKey).isEqualTo("inspection.channelflow.vs.callbackflow.display.name")
+    }
+
+    @Test
+    fun `BlockingFutureGet inspection is configured`() {
+        val i = BlockingFutureGetInspection()
+        assertThat(i.displayNameKey).isEqualTo("inspection.blocking.future.get.display.name")
+    }
+}

--- a/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/intentions/AnalyzeFlowChainIntentionTest.kt
+++ b/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/intentions/AnalyzeFlowChainIntentionTest.kt
@@ -1,0 +1,14 @@
+package io.github.santimattius.structured.intellij.intentions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AnalyzeFlowChainIntentionTest {
+
+    @Test
+    fun `intention can be instantiated`() {
+        val intention = AnalyzeFlowChainIntention()
+        assertThat(intention).isNotNull()
+        assertThat(intention.familyName).isNotBlank()
+    }
+}

--- a/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/utils/FlowChainAnalyzerTest.kt
+++ b/intellij-plugin/src/test/kotlin/io/github/santimattius/structured/intellij/utils/FlowChainAnalyzerTest.kt
@@ -1,0 +1,35 @@
+package io.github.santimattius.structured.intellij.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class FlowChainAnalyzerTest {
+
+    @Test
+    fun `report includes catch when catch operator present`() {
+        val findings = listOf(
+            FlowChainAnalyzer.FlowChainFinding("✅", "catch — error handling present"),
+        )
+        val report = FlowChainAnalyzer.formatReport(findings)
+        assertThat(report).contains("catch — error handling present")
+    }
+
+    @Test
+    fun `report warns when distinctUntilChanged missing`() {
+        val findings = listOf(
+            FlowChainAnalyzer.FlowChainFinding("⚠️", "missing distinctUntilChanged — potential redundant emissions"),
+        )
+        val report = FlowChainAnalyzer.formatReport(findings)
+        assertThat(report).contains("missing distinctUntilChanged")
+    }
+
+    @Test
+    fun `report notes flatMapLatest semantics`() {
+        val findings = listOf(
+            FlowChainAnalyzer.FlowChainFinding("ℹ️", "flatMapLatest — last-wins semantics (suitable for search, not for downloads)"),
+        )
+        val report = FlowChainAnalyzer.formatReport(findings)
+        assertThat(report).contains("flatMapLatest")
+        assertThat(report).contains("Flow chain analysis:")
+    }
+}


### PR DESCRIPTION
Introduce several new Kotlin inspections (RememberScopeForInit, HardcodedDispatcherInClass, CoroutineNotCompletedInTest, FlatMapOperatorChoice, SharedFlowForOneshotEvents, ChannelFlowVsCallbackFlow, BlockingFutureGet) with corresponding registrations in InspectionProvider, guide entries and plugin.xml. Add quick-fixes (ReplaceWithLaunchedEffect, ReplaceSharedFlowWithChannel, ReplaceGetWithAwait), a FlowChainAnalyzer utility and AnalyzeFlowChainIntention to show flow chain reports, and extend ComposePsiUtils with helpers for effect/event detection. Update resource bundle with new messages, add config smoke tests, and include junit4 as a test runtime dependency for IntelliJ Platform tests.