### PR TITLE
Bump Kotlin to 2.4.0 and fix KT-83341 ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ---
 
+## [1.0.1] — 2026-06-23
+
+### Fixed
+
+- Kotlin 2.4.0 binary incompatibility in the compiler plugin caused by KT-83341 (`FirExtensionRegistrarAdapter.Companion` no longer extends `ProjectExtensionDescriptor`). The plugin is now compiled and published against Kotlin 2.4.0.
+- Added `@OptIn(CompilerConfiguration.Internals::class)` in `ScoroutinesCallCheckerExtension` and `PluginConfigurationInteropOptionsTest` to satisfy the new opt-in requirement introduced in Kotlin 2.4.0.
+
+### Changed
+
+- Bumped Kotlin from `2.3.20` to `2.4.0` in the version catalog (`gradle/libs.versions.toml`).
+- Functional test scratch project template now derives `kotlin` and `kotlinx-coroutines-core` versions from system properties injected by Gradle (`compiler/build.gradle.kts`) instead of hardcoded literals.
+- Added `CatalogVersionConsistencyTest` to detect version drift between the catalog and functional test template — prevents silent reintroduction of the KT-83341 ABI crash.
+- Updated comment on `kotlin-stdlib:2.0.21` force pin in `lint-rules/build.gradle.kts` to document the 2.4.0 catalog bump and Lint 31.4.0 constraint.
+
+---
+
 ## [1.0.0] — 2026-06-04
 
 ### Added

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -34,6 +34,8 @@ tasks.test {
 
     systemProperty("structuredCoroutines.version", project.version.toString())
     systemProperty("structuredCoroutines.rootDir", project.rootProject.projectDir.absolutePath)
+    systemProperty("kotlinVersion", libs.versions.kotlin.get())
+    systemProperty("coroutinesVersion", libs.versions.kotlinx.coroutines.get())
 }
 
 // Configure JAR to include the service file

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/ScoroutinesCallCheckerExtension.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/ScoroutinesCallCheckerExtension.kt
@@ -74,6 +74,7 @@ class ScoroutinesCallCheckerExtension(session: FirSession) : FirAdditionalChecke
     /**
      * Gets the plugin configuration from the holder.
      */
+    @OptIn(org.jetbrains.kotlin.config.CompilerConfiguration.Internals::class)
     private val configuration: PluginConfiguration
         get() = PluginConfigurationHolder.configuration
             ?: PluginConfiguration(org.jetbrains.kotlin.config.CompilerConfiguration())

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/CatalogVersionConsistencyTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/CatalogVersionConsistencyTest.kt
@@ -1,0 +1,55 @@
+package io.github.santimattius.structured.compiler
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Guard test that asserts the Kotlin and kotlinx-coroutines versions declared in
+ * `gradle/libs.versions.toml` match the values injected as system properties by
+ * `compiler/build.gradle.kts`. If this test fails, the functional-test scratch project
+ * template will have drifted from the catalog and can reintroduce the KT-83341 ABI crash.
+ */
+class CatalogVersionConsistencyTest {
+
+    private val catalogFile: File by lazy {
+        val rootDir = System.getProperty("structuredCoroutines.rootDir")
+            ?: error("structuredCoroutines.rootDir system property not set — run via Gradle (:compiler:test)")
+        File(rootDir, "gradle/libs.versions.toml")
+    }
+
+    private fun parseCatalogVersion(key: String): String {
+        val pattern = Regex("""^\s*$key\s*=\s*"([^"]+)"""", RegexOption.MULTILINE)
+        val content = catalogFile.readText()
+        return pattern.find(content)?.groupValues?.get(1)
+            ?: error("Key '$key' not found in ${catalogFile.absolutePath}")
+    }
+
+    @Test
+    fun `catalog kotlin version matches kotlinVersion system property`() {
+        val catalogKotlin = parseCatalogVersion("kotlin")
+        val propertyKotlin = System.getProperty("kotlinVersion")
+            ?: error("kotlinVersion system property not set — check compiler/build.gradle.kts tasks.test block")
+
+        assertEquals(
+            catalogKotlin,
+            propertyKotlin,
+            "Catalog kotlin=$catalogKotlin but test system property kotlinVersion=$propertyKotlin; " +
+                "functional-test template will drift from the catalog and can reintroduce the KT-83341 ABI crash."
+        )
+    }
+
+    @Test
+    fun `catalog kotlinx-coroutines version matches coroutinesVersion system property`() {
+        val catalogCoroutines = parseCatalogVersion("kotlinx-coroutines")
+        val propertyCoroutines = System.getProperty("coroutinesVersion")
+            ?: error("coroutinesVersion system property not set — check compiler/build.gradle.kts tasks.test block")
+
+        assertEquals(
+            catalogCoroutines,
+            propertyCoroutines,
+            "Catalog kotlinx-coroutines=$catalogCoroutines but test system property coroutinesVersion=$propertyCoroutines; " +
+                "functional-test template will drift from the catalog and can reintroduce the KT-83341 ABI crash."
+        )
+    }
+}

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/PluginConfigurationInteropOptionsTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/PluginConfigurationInteropOptionsTest.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.diagnostics.Severity
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(CompilerConfiguration.Internals::class)
 class PluginConfigurationInteropOptionsTest {
 
     @Test

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -56,15 +56,19 @@ class StructuredCoroutinesPluginFunctionalTest {
 
         // build.gradle.kts - version from system property (set by test task) or default for local runs
         val pluginVersion = System.getProperty("structuredCoroutines.version", "0.3.0")
+        val kotlinVersion = System.getProperty("kotlinVersion")
+            ?: error("kotlinVersion system property not set — check compiler/build.gradle.kts tasks.test block")
+        val coroutinesVersion = System.getProperty("coroutinesVersion")
+            ?: error("coroutinesVersion system property not set — check compiler/build.gradle.kts tasks.test block")
         File(projectDir, "build.gradle.kts").writeText("""
             plugins {
-                kotlin("jvm") version "2.3.20"
+                kotlin("jvm") version "$kotlinVersion"
                 id("io.github.santimattius.structured-coroutines") version "$pluginVersion"
             }
-            
+
             dependencies {
                 implementation("io.github.santimattius:structured-coroutines-annotations:$pluginVersion")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
             }
             
             kotlin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ kotlin.code.style=official
 # Single source for group/version; applied in root build.gradle.kts allprojects {}.
 # Artifact IDs are set per module via mavenPublishing.coordinates().
 PROJECT_GROUP=io.github.santimattius
-PROJECT_VERSION=1.0.0
+PROJECT_VERSION=1.0.1
 # Maven Central
 mavenCentralPublishing=true
 signAllPublications=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.20"
+kotlin = "2.4.0"
 detekt = "1.23.7"
 maven-publish-plugin = "0.36.0"
 lint = "31.4.0"

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1095,6 +1095,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-path-inside@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
 is-plain-obj@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
@@ -1361,10 +1366,10 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@11.7.2:
-  version "11.7.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.2.tgz#3c0079fe5cc2f8ea86d99124debcc42bb1ab22b5"
-  integrity sha512-lkqVJPmqqG/w5jmmFtiRvtA2jkDyNVUcefFJKb2uyX4dekk8Okgqop3cgbFiaIvj8uCRJVTP5x9dfxGyXm2jvQ==
+mocha@11.7.5:
+  version "11.7.5"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.5.tgz#58f5bbfa5e0211ce7e5ee6128107cefc2515a627"
+  integrity sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==
   dependencies:
     browser-stdout "^1.3.1"
     chokidar "^4.0.1"
@@ -1374,6 +1379,7 @@ mocha@11.7.2:
     find-up "^5.0.0"
     glob "^10.4.5"
     he "^1.2.0"
+    is-path-inside "^3.0.3"
     js-yaml "^4.1.0"
     log-symbols "^4.1.0"
     minimatch "^9.0.5"
@@ -1821,7 +1827,16 @@ streamroller@^3.1.5:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1839,7 +1854,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2074,7 +2096,16 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -16,7 +16,9 @@ dependencies {
     testImplementation(libs.assertj.core)
 }
 
-// Lint 31.4.0 embeds Kotlin 2.0; align test runtime to avoid "metadata version 2.3.0, expected 2.0.0"
+// Lint 31.4.0 embeds Kotlin 2.0; align test runtime to avoid "metadata version X.Y.Z, expected 2.0.0".
+// The catalog bumped kotlin to 2.4.0 (KT-83341 fix) but Lint 31.4.0 still expects 2.0 metadata on
+// testRuntimeClasspath. Keeping the pin at 2.0.21; revisit when upgrading lint past 31.4.0.
 configurations.testRuntimeClasspath.get().resolutionStrategy.force("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 
 kotlin {


### PR DESCRIPTION
## Summary

Resolve Kotlin 2.4.0 binary incompatibility (KT-83341) by compiling and publishing the plugin against Kotlin 2.4.0. Changes include: bumping the catalog kotlin version, updating PROJECT_VERSION to 1.0.1, adding system properties for kotlin/coroutines versions to the compiler test task, and making the functional-test template derive versions from those properties. Add CatalogVersionConsistencyTest to guard against version drift between the catalog and the functional-test template. Apply @OptIn(CompilerConfiguration.Internals::class) where required, update lint comment and keep the kotlin-stdlib pin, update CHANGELOG, and refresh yarn.lock.

Issue -> #59 

## Type of change

- [X] Bug fix
- [ ] New rule / inspection
- [ ] Enhancement to existing rule or tooling
- [ ] Documentation
- [ ] Build / CI
- [ ] Other (describe below)

## Component(s)

- [X] Compiler plugin
- [ ] Detekt rules
- [ ] Android Lint rules
- [ ] IntelliJ plugin
- [ ] Gradle plugin
- [ ] Samples / tests
- [ ] Docs / skill / rule manifest

## Test plan

<!-- Commands run and results. For new rules, mention sample + unit tests added. -->

```bash
# Example:
./gradlew :detekt-rules:test
```

## Checklist

- [X] Tests pass locally (relevant `./gradlew` tasks)
- [] New/changed rules updated in `docs/rule-codes.yml` and samples where applicable
- [X] `CHANGELOG.md` updated for user-facing changes
- [X] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
