### PR TITLE
fix(cancel-003): suppress false positive when catch block rethrows

### DIFF
--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/CancellationExceptionSwallowedRule.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/CancellationExceptionSwallowedRule.kt
@@ -122,6 +122,9 @@ class CancellationExceptionSwallowedRule(config: Config = Config.empty) : Rule(c
         val body = catchClause.catchBody?.text ?: return false
         if (body.contains("throw") && body.contains("CancellationException")) return true
         val paramName = catchClause.catchParameter?.name ?: "e"
-        return body.contains("if") && body.contains("CancellationException") && body.contains("throw $paramName")
+        if (body.contains("if") && body.contains("CancellationException") && body.contains("throw $paramName")) return true
+        // Direct rethrow of the caught exception: catch(t: Throwable) { ...; throw t }
+        if (body.contains("throw $paramName")) return true
+        return false
     }
 }

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/CancellationExceptionSwallowedRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/CancellationExceptionSwallowedRuleTest.kt
@@ -100,6 +100,65 @@ class CancellationExceptionSwallowedRuleTest {
     }
 
     @Test
+    fun `does not report catch Throwable when rethrown directly`() {
+        val code = """
+            import kotlinx.coroutines.*
+
+            suspend fun fetch() {
+                try {
+                    val x = 1
+                } catch (t: Throwable) {
+                    println(t)
+                    throw t
+                }
+            }
+        """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report catch Exception when rethrown directly`() {
+        val code = """
+            import kotlinx.coroutines.*
+
+            suspend fun fetch() {
+                try {
+                    val x = 1
+                } catch (e: Exception) {
+                    throw e
+                }
+            }
+        """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report catch Throwable when rethrown directly inside launch`() {
+        val code = """
+            import kotlinx.coroutines.CoroutineScope
+            import kotlinx.coroutines.launch
+
+            fun update(scope: CoroutineScope) {
+                scope.launch {
+                    try {
+                        val x = 1
+                    } catch (t: Throwable) {
+                        println(t)
+                        throw t
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
     fun `does not report catch specific exception`() {
         val code = """
             import kotlinx.coroutines.launch

--- a/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/CancellationExceptionSwallowedInspection.kt
+++ b/intellij-plugin/src/main/kotlin/io/github/santimattius/structured/intellij/inspections/CancellationExceptionSwallowedInspection.kt
@@ -87,6 +87,11 @@ class CancellationExceptionSwallowedInspection : CoroutineInspectionBase() {
                     return
                 }
 
+                // Direct rethrow of the caught exception: catch(t: Throwable) { ...; throw t }
+                if (catchBody.contains("throw $paramName")) {
+                    return
+                }
+
                 holder.registerProblem(
                     catchClause.catchParameter ?: catchClause,
                     StructuredCoroutinesBundle.message("error.cancellation.swallowed"),


### PR DESCRIPTION
## Summary

When catch(t: Throwable) or catch(e: Exception) rethrows the caught parameter unconditionally (throw t / throw e), CancellationException always propagates — no swallowing occurs. The text-based escape logic in the Detekt rule and IntelliJ inspection was only checking for CancellationException mentions, missing this safe pattern.

Adds 3 new regression tests covering rethrow of Throwable/Exception in suspend functions and coroutine builder blocks.

## Type of change

- [ ] Bug fix
- [ ] New rule / inspection
- [ ] Enhancement to existing rule or tooling
- [ ] Documentation
- [ ] Build / CI
- [ ] Other (describe below)

## Component(s)

- [x] Compiler plugin
- [x] Detekt rules
- [ ] Android Lint rules
- [x] IntelliJ plugin
- [ ] Gradle plugin
- [ ] Samples / tests
- [ ] Docs / skill / rule manifest

## Test plan

<!-- Commands run and results. For new rules, mention sample + unit tests added. -->

```bash
# Example:
./gradlew :detekt-rules:test
```

## Checklist

- [ ] Tests pass locally (relevant `./gradlew` tasks)
- [ ] New/changed rules updated in `docs/rule-codes.yml` and samples where applicable
- [ ] `CHANGELOG.md` updated for user-facing changes
- [ ] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
