### PR TITLE
feat(codex): add OpenAI Codex plugin support for kotlin-coroutines-skill

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "kotlin-coroutines-skill",
+  "version": "1.1.0",
+  "description": "Expert guidance for Kotlin Coroutines: structured concurrency, safe scopes, Dispatchers, cancellation, exception handling, and testing. Use when reviewing or writing Kotlin/Android async code. Includes a playbook and per-practice reference files.",
+  "author": {
+    "name": "Santiago Mattiauda"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/santimattius/structured-coroutines",
+  "keywords": [
+    "kotlin",
+    "coroutines",
+    "structured-concurrency",
+    "async-await",
+    "suspend",
+    "dispatchers",
+    "cancellation",
+    "flow",
+    "channels",
+    "viewModelScope",
+    "lifecycleScope",
+    "coroutineScope",
+    "supervisorScope",
+    "GlobalScope",
+    "CancellationException",
+    "SupervisorJob",
+    "launch",
+    "withContext",
+    "runBlocking",
+    "runTest",
+    "TestDispatcher",
+    "kotlinx-coroutines",
+    "kotlinx-coroutines-test",
+    "android",
+    "kotlin-multiplatform",
+    "concurrency",
+    "exception-handling"
+  ],
+  "skills": "./skills"
+}

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -1,0 +1,38 @@
+# Guards against silent drift between the plugin manifests: `.claude-plugin/plugin.json`,
+# `.claude-plugin/marketplace.json`, and `.codex-plugin/plugin.json` (when present).
+#
+# Kept as its own workflow, separate from validate-skill.yml, because that file is part of the
+# upstream-compliance story and filters on `kotlin-coroutines-skill/**` -- manifest paths are
+# disjoint, and `paths:` filters are per-workflow, not per-job.
+
+name: Validate Plugin Manifests
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - ".claude-plugin/**"
+      - ".codex-plugin/**"
+      - "tools/scripts/check_manifest_sync.py"
+  pull_request:
+    branches: [main, master]
+    paths:
+      - ".claude-plugin/**"
+      - ".codex-plugin/**"
+      - "tools/scripts/check_manifest_sync.py"
+
+jobs:
+  validate-manifests:
+    name: Check manifest sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run manifest sync guard
+        run: python3 tools/scripts/check_manifest_sync.py

--- a/docs/KOTLIN_COROUTINES_SKILL.md
+++ b/docs/KOTLIN_COROUTINES_SKILL.md
@@ -114,7 +114,58 @@ repo root/
 
 ---
 
-### Option B: Claude (Projects — System Prompt)
+### Option B: OpenAI Codex (Plugin)
+
+Codex CLI natively supports plugins via a marketplace, the same way Claude Code does.
+
+**Requirements:** [OpenAI Codex CLI](https://developers.openai.com/codex) installed.
+
+#### Install from the marketplace
+
+```bash
+codex plugin marketplace add santimattius/structured-coroutines
+codex plugin add kotlin-coroutines-skill@structured-coroutines
+```
+
+#### Manual install (no plugin manifest required)
+
+If you don't want to install the plugin, or the plugin path is unavailable, Codex also
+auto-discovers skills placed directly under an `.agents/skills/` directory:
+
+- Repo-scoped: `$REPO_ROOT/.agents/skills/kotlin-coroutines-skill/`
+- User-scoped: `$HOME/.agents/skills/kotlin-coroutines-skill/`
+
+Copy or symlink the `kotlin-coroutines-skill/` folder (containing `SKILL.md` and
+`references/`) into either location — this works independently of `.codex-plugin/plugin.json`.
+
+#### How it works
+
+Once installed (either path), the skill is available automatically when you work on
+Kotlin/Android code. Codex reads:
+
+- `SKILL.md` — triage playbook with strict rules (maps your topic/error to the right reference)
+- `references/ref-*.md` — per-practice guidance loaded on demand
+
+**Plugin layout:**
+
+```
+repo root/
+├── .codex-plugin/
+│   └── plugin.json          ← plugin definition (skills: "./skills")
+├── skills/
+│   └── kotlin-coroutines-skill/   ← symlink → ../kotlin-coroutines-skill
+└── kotlin-coroutines-skill/
+    ├── SKILL.md
+    └── references/
+```
+
+**Verify installation:** Open a `.kt` file containing `GlobalScope.launch { }` and ask Codex to
+review it for coroutine best practices. The response should follow the format: **Analysis →
+Erroneous Code → Optimized Code → Technical Explanation**.
+
+---
+
+### Option C: Claude (Projects — System Prompt)
 
 Use this when you want the skill active for a specific Claude project without the Claude Code CLI.
 
@@ -128,7 +179,7 @@ Use this project when working on Kotlin/Android codebases for consistent advice.
 
 ---
 
-### Option C: ChatGPT (Custom GPTs)
+### Option D: ChatGPT (Custom GPTs)
 
 1. Create a new **Custom GPT** (ChatGPT Plus or Team).
 2. In **Configure → Instructions**, paste the Agent Behavior Contract from **SKILL.md**.
@@ -139,7 +190,7 @@ Use this project when working on Kotlin/Android codebases for consistent advice.
 
 ---
 
-### Option D: Cursor (Rules for AI)
+### Option E: Cursor (Rules for AI)
 
 1. In your repo, open or create `.cursor/rules/`.
 2. Create a file `kotlin-coroutines.mdc`.

--- a/skills/kotlin-coroutines-skill
+++ b/skills/kotlin-coroutines-skill
@@ -1,0 +1,1 @@
+../kotlin-coroutines-skill

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -121,3 +121,31 @@ iteration-N/
   script was written on, so the exact flags for JSON output and for disabling a
   project-registered skill could not be confirmed. Check `codex exec --help` and fix
   `run_codex()` in `run_evals.py` before trusting numbers from this path.
+
+# Manifest sync guard
+
+Asserts `.claude-plugin/plugin.json`, its matching `.claude-plugin/marketplace.json` `plugins[]`
+entry, and `.codex-plugin/plugin.json` (when present) agree on `name`, `description`, `author`,
+`license`, and `keywords`. An assertion script, not a generator — three hand-edited JSON files
+justify a check, not a build step.
+
+```bash
+python3 tools/scripts/check_manifest_sync.py
+```
+
+Wired into CI via `.github/workflows/validate-manifests.yml` (own workflow, separate from
+`validate-skill.yml`), triggered on changes under `.claude-plugin/**`, `.codex-plugin/**`, or the
+script itself.
+
+**Excluded from comparison, on purpose:** `version` / `metadata.version`. Manifest `version`
+(package release, currently `1.1.0`) and `kotlin-coroutines-skill/SKILL.md`'s
+`metadata.version` (skill content revision, currently `3.0.0`) are independent semantics —
+comparing them would produce permanent false positives. `marketplace.json`'s top-level
+`version` (catalog version) is excluded for the same reason. `repository` is present in both
+plugin manifests but is out of scope for this guard's compared-field set.
+
+**Absent-manifest behavior:** if `.codex-plugin/plugin.json` doesn't exist yet, the script exits
+`0` with a printed skip notice instead of failing — Codex packaging (Tier 2) can slip or be
+rolled back independently of this guard without reddening CI. Mirrors this repo's existing
+`--client codex` **unverified** convention above: Codex support here degrades gracefully rather
+than hard-failing when unconfirmed/not-yet-shipped.

--- a/tools/scripts/check_manifest_sync.py
+++ b/tools/scripts/check_manifest_sync.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Assert that the shared metadata fields declared across the plugin manifests never silently
+drift: `.claude-plugin/plugin.json`, the matching entry in `.claude-plugin/marketplace.json`,
+and (when present) `.codex-plugin/plugin.json`.
+
+This is an assertion script, not a generator (unlike generate_refs.py) -- three hand-edited
+JSON files justify a check, not a build step.
+
+Compared fields: name, description, author (compared via `.name`), license, keywords (set
+equality, order-insensitive).
+
+Deliberately NOT compared, so a future contributor does not "fix" it:
+  - `version` (package version, e.g. 1.1.0) vs `kotlin-coroutines-skill/SKILL.md`
+    `metadata.version` (content version, e.g. 3.0.0) -- these are legitimately independent
+    semantics (package release vs. skill content revision) and comparing them would produce
+    permanent false positives.
+  - `marketplace.json` top-level `version` -- catalog version, a different semantic again.
+  - `repository` -- present in both `.claude-plugin/plugin.json` and
+    `.codex-plugin/plugin.json`, but intentionally left out of the compared-field set for this
+    guard (spec/design scope: name, description, author, license, keywords only).
+
+If `.codex-plugin/plugin.json` is absent, the guard exits 0 with a printed skip notice --
+Tier 2 (Codex packaging) is allowed to slip or be rolled back independently of Tier 3 (this
+guard) without reddening CI.
+
+Usage (from repo root):
+  python3 tools/scripts/check_manifest_sync.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = TOOLS_DIR.parent
+
+CLAUDE_PLUGIN = REPO_ROOT / ".claude-plugin" / "plugin.json"
+MARKETPLACE = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+CODEX_PLUGIN = REPO_ROOT / ".codex-plugin" / "plugin.json"
+
+# Fields compared across manifests. `version` is deliberately excluded -- see module docstring.
+COMPARED_FIELDS = ("name", "description", "author", "license", "keywords")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def normalize_author(value: Any) -> str | None:
+    """Author may be `{"name": "..."}` (or, in principle, a bare string) -- compare on name."""
+    if isinstance(value, dict):
+        return value.get("name")
+    return value
+
+
+def normalize_field(field: str, value: Any) -> Any:
+    if field == "author":
+        return normalize_author(value)
+    if field == "keywords":
+        return set(value) if value is not None else None
+    return value
+
+
+def extract_fields(manifest: dict[str, Any]) -> dict[str, Any]:
+    return {field: normalize_field(field, manifest.get(field)) for field in COMPARED_FIELDS}
+
+
+def find_marketplace_entry(marketplace: dict[str, Any], name: str) -> dict[str, Any] | None:
+    for plugin in marketplace.get("plugins", []):
+        if plugin.get("name") == name:
+            return plugin
+    return None
+
+
+def diff_fields(
+    reference_label: str,
+    reference: dict[str, Any],
+    other_label: str,
+    other: dict[str, Any],
+) -> list[str]:
+    """Return human-readable diff lines for fields that disagree between two manifests."""
+    mismatches: list[str] = []
+    for field in COMPARED_FIELDS:
+        ref_value = reference.get(field)
+        other_value = other.get(field)
+        if ref_value != other_value:
+            mismatches.append(
+                f"  - field `{field}` differs: {reference_label}={ref_value!r} "
+                f"vs {other_label}={other_value!r} (in {other_label})"
+            )
+    return mismatches
+
+
+def main() -> int:
+    if not CLAUDE_PLUGIN.is_file():
+        print(f"ERROR: required manifest not found: {CLAUDE_PLUGIN}", file=sys.stderr)
+        return 1
+    if not MARKETPLACE.is_file():
+        print(f"ERROR: required manifest not found: {MARKETPLACE}", file=sys.stderr)
+        return 1
+
+    claude_plugin = load_json(CLAUDE_PLUGIN)
+    marketplace = load_json(MARKETPLACE)
+
+    plugin_name = claude_plugin.get("name")
+    marketplace_entry = find_marketplace_entry(marketplace, plugin_name)
+    if marketplace_entry is None:
+        print(
+            f"ERROR: no marketplace.json plugins[] entry with name == {plugin_name!r} "
+            f"found in {MARKETPLACE}",
+            file=sys.stderr,
+        )
+        return 1
+
+    claude_fields = extract_fields(claude_plugin)
+    marketplace_fields = extract_fields(marketplace_entry)
+
+    all_mismatches: list[str] = []
+    all_mismatches += diff_fields(
+        ".claude-plugin/plugin.json", claude_fields, ".claude-plugin/marketplace.json",
+        marketplace_fields,
+    )
+
+    if not CODEX_PLUGIN.is_file():
+        print(
+            f"SKIP: {CODEX_PLUGIN} not found -- Codex packaging (Tier 2) is optional; "
+            "sync check limited to Claude manifests.",
+        )
+    else:
+        codex_plugin = load_json(CODEX_PLUGIN)
+        codex_fields = extract_fields(codex_plugin)
+        all_mismatches += diff_fields(
+            ".claude-plugin/plugin.json", claude_fields, ".codex-plugin/plugin.json",
+            codex_fields,
+        )
+
+    if all_mismatches:
+        print("Manifest sync check FAILED. Shared fields diverged:", file=sys.stderr)
+        for line in all_mismatches:
+            print(line, file=sys.stderr)
+        return 1
+
+    print("Manifest sync check passed: name/description/author/license/keywords agree.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? Link issues with "Fixes #123" or "Relates to #123". -->

Adds an installation path for `kotlin-coroutines-skill` via the OpenAI Codex CLI plugin system, alongside the existing Claude Code plugin. The skill content itself is unchanged and frozen; this only adds packaging, docs, and a drift guard between the two plugin manifests.

- New `.codex-plugin/plugin.json` mirrors `.claude-plugin/plugin.json`'s shared fields (name/description/author/license/repository/keywords), with `skills: "./skills"` pointing at a new `skills/kotlin-coroutines-skill` symlink to the unchanged skill directory.
- New `tools/scripts/check_manifest_sync.py` (stdlib-only) plus `.github/workflows/validate-manifests.yml` CI check so the Claude and Codex manifests can't silently drift on shared fields.
- `docs/KOTLIN_COROUTINES_SKILL.md`: new "Option B: OpenAI Codex (Plugin)" section (marketplace install commands + manual `.agents/skills/` fallback + verify step); existing options relettered B/C/D → C/D/E.

## Type of change

- [ ] Bug fix
- [ ] New rule / inspection
- [ ] Enhancement to existing rule or tooling
- [x] Documentation
- [x] Build / CI
- [ ] Other (describe below)

## Component(s)

- [ ] Compiler plugin
- [ ] Detekt rules
- [ ] Android Lint rules
- [ ] IntelliJ plugin
- [ ] Gradle plugin
- [ ] Samples / tests
- [x] Docs / skill / rule manifest

## Test plan

- `python3 -m json.tool .codex-plugin/plugin.json` — valid JSON.
- `python3 tools/scripts/check_manifest_sync.py` — exit 0, manifests agree.
- Reproduced the script's full exit-code contract in a scratch dir: induced a field mismatch → exit 1 with correct field-by-field diff; removed the Codex manifest → exit 0 with skip notice.
- `readlink skills/kotlin-coroutines-skill` → `../kotlin-coroutines-skill`; `git diff -- kotlin-coroutines-skill/` → 0 lines (skill content untouched).
- `git diff -- .github/workflows/validate-skill.yml` → 0 lines (no regression to the existing workflow).
- `grep -rn "#option-" docs/ README.md` → no matches (no broken anchors after relettering).

```bash
python3 tools/scripts/check_manifest_sync.py
```

## Checklist

- [x] Tests pass locally (relevant `./gradlew` tasks) — N/A, no Gradle-built code touched
- [x] New/changed rules updated in `docs/rule-codes.yml` and samples where applicable — N/A, no rules added
- [x] `CHANGELOG.md` updated for user-facing changes — N/A, packaging/install-path change, not a user-facing rule change
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines