### PR TITLE
fix(compiler): CANCEL_001 deep traversal (#66) and CANCEL_004 NonCancellable recognition (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **CANCEL_001 false negatives on non-top-level cooperation points** — `LoopWithoutYieldChecker` now performs a deep, structural search for cooperation points (`yield`, `ensureActive`, `delay`, `suspendCancellableCoroutine`, `withTimeout`, `withTimeoutOrNull`, or any resolved suspend call) anywhere in a loop body's statement tree — including `val`/`var` initializers, assignment RHS, `if`/`when` conditions and branches, elvis (`?:`) RHS, and `try`/`catch` blocks — instead of only top-level statements. Previously, `while (true) { val n = suspendCall() }` was incorrectly flagged even though the loop suspends on every iteration. (#66)
+
+---
+
 ## [1.1.0] — 2026-06-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 ### Fixed
 
 - **CANCEL_001 false negatives on non-top-level cooperation points** — `LoopWithoutYieldChecker` now performs a deep, structural search for cooperation points (`yield`, `ensureActive`, `delay`, `suspendCancellableCoroutine`, `withTimeout`, `withTimeoutOrNull`, or any resolved suspend call) anywhere in a loop body's statement tree — including `val`/`var` initializers, assignment RHS, `if`/`when` conditions and branches, elvis (`?:`) RHS, and `try`/`catch` blocks — instead of only top-level statements. Previously, `while (true) { val n = suspendCall() }` was incorrectly flagged even though the loop suspends on every iteration. (#66)
+- **CANCEL_004 false positive on the recommended `withContext(NonCancellable)` pattern** — `SuspendInFinallyChecker` now recognizes a resolved reference to `kotlinx.coroutines.NonCancellable` (via `FirResolvedQualifier.classId`, matching the precedent established in `UnstructuredLaunchChecker.isGlobalScope`), whether written as a bare imported name, fully qualified (`kotlinx.coroutines.NonCancellable`), or combined via `+` (e.g. `NonCancellable + Dispatchers.IO`). Previously, the check could never pass — even the exact pattern the diagnostic message recommends was flagged. (#65)
+
+### Changed
+
+- **Deliberate tightening (#65)** — a user-defined property or variable merely *named* `NonCancellable` no longer suppresses `CANCEL_004`; only a reference that resolves to `kotlinx.coroutines.NonCancellable`'s `ClassId` does. The previous check matched on the bare identifier name only, which was a false negative.
 
 ---
 

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/LoopWithoutYieldChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/LoopWithoutYieldChecker.kt
@@ -10,19 +10,21 @@
 package io.github.santimattius.structured.compiler
 
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.FirPropertyAccessor
 import org.jetbrains.kotlin.fir.expressions.FirBlock
 import org.jetbrains.kotlin.fir.expressions.FirDoWhileLoop
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
-import org.jetbrains.kotlin.fir.expressions.FirStatement
 import org.jetbrains.kotlin.fir.expressions.FirWhileLoop
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.expressions.FirLoop
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.visitors.FirVisitorVoid
 import org.jetbrains.kotlin.name.Name
 
 /**
@@ -84,34 +86,55 @@ class LoopWithoutYieldChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) 
         rep.reportOn(loop.source, StructuredCoroutinesErrors.LOOP_WITHOUT_YIELD, ctx)
     }
 
+    /**
+     * Deep, structural search for a cooperation point anywhere in [block]'s statement tree —
+     * property initializers, assignments, conditions, `when` branches, elvis RHS, `try`/`catch`
+     * bodies, and so on. A generic FIR walk is used instead of enumerating node kinds so the
+     * next unlisted node shape cannot silently reintroduce a false negative (see #66).
+     */
     private fun bodyHasCooperationPoint(block: FirBlock): Boolean {
-        for (statement in block.statements) {
-            if (statementHasCooperationPoint(statement)) return true
-        }
-        return false
+        val finder = CooperationPointFinder()
+        block.accept(finder)
+        return finder.found
     }
 
-    private fun statementHasCooperationPoint(statement: FirStatement): Boolean {
-        when (statement) {
-            is FirFunctionCall -> {
-                if (COOPERATION_POINT_NAMES.contains(statement.calleeReference.name)) return true
-                if (isSuspendCall(statement)) return true
-                for (arg in statement.argumentList.arguments) {
-                    if (arg is FirBlock && bodyHasCooperationPoint(arg)) return true
-                }
-            }
-            is FirBlock -> {
-                for (s in statement.statements) {
-                    if (statementHasCooperationPoint(s)) return true
-                }
-            }
-            else -> {}
-        }
-        return false
+    private fun isCooperationPoint(call: FirFunctionCall): Boolean {
+        if (COOPERATION_POINT_NAMES.contains(call.calleeReference.name)) return true
+        return isSuspendCall(call)
     }
 
     private fun isSuspendCall(call: FirFunctionCall): Boolean {
         val symbol = call.calleeReference.toResolvedCallableSymbol() as? FirNamedFunctionSymbol ?: return false
         return symbol.resolvedStatus.isSuspend
+    }
+
+    /**
+     * Depth-first walk over a loop body that short-circuits as soon as a cooperation point is
+     * found anywhere in the statement tree.
+     *
+     * Pruning policy: named function/accessor *declarations* are not descended into — a local
+     * `suspend fun helper() { delay(1) }` that is declared but never called inside the loop must
+     * not suppress the diagnostic. Lambda bodies ([org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction])
+     * are NOT pruned and are still searched, since a lambda passed to e.g. `run { }` executes
+     * inline at the call site.
+     */
+    private inner class CooperationPointFinder : FirVisitorVoid() {
+        var found: Boolean = false
+            private set
+
+        override fun visitElement(element: FirElement) {
+            if (found) return
+            when (element) {
+                is FirNamedFunction, is FirPropertyAccessor -> return
+                is FirFunctionCall -> {
+                    if (isCooperationPoint(element)) {
+                        found = true
+                        return
+                    }
+                }
+                else -> {}
+            }
+            element.acceptChildren(this)
+        }
     }
 }

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/SuspendInFinallyChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/SuspendInFinallyChecker.kt
@@ -14,11 +14,17 @@ import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirTryExpressionChecker
 import org.jetbrains.kotlin.fir.expressions.FirBlock
+import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirResolvedQualifier
 import org.jetbrains.kotlin.fir.expressions.FirStatement
 import org.jetbrains.kotlin.fir.expressions.FirTryExpression
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.types.ConeClassLikeType
+import org.jetbrains.kotlin.fir.types.resolvedType
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 /**
@@ -72,7 +78,9 @@ class SuspendInFinallyChecker : FirTryExpressionChecker(MppCheckerKind.Common) {
 
     companion object {
         private val WITH_CONTEXT_NAME = Name.identifier("withContext")
-        private val NON_CANCELLABLE_NAME = Name.identifier("NonCancellable")
+        private val PLUS_NAME = Name.identifier("plus")
+        private val NON_CANCELLABLE_CLASS_ID =
+            ClassId(FqName("kotlinx.coroutines"), Name.identifier("NonCancellable"))
     }
 
     context(context: CheckerContext, reporter: DiagnosticReporter)
@@ -144,19 +152,39 @@ class SuspendInFinallyChecker : FirTryExpressionChecker(MppCheckerKind.Common) {
     }
 
     /**
-     * Checks if a function call is `withContext(NonCancellable)`.
+     * Checks if a function call is `withContext(NonCancellable)` (or a `NonCancellable`-derived
+     * combination such as `withContext(NonCancellable + Dispatchers.IO)`).
      */
     private fun isWithContextNonCancellable(call: FirFunctionCall): Boolean {
         if (call.calleeReference.name != WITH_CONTEXT_NAME) return false
 
-        // Check if first argument is NonCancellable
         val firstArg = call.argumentList.arguments.firstOrNull() ?: return false
-        
-        if (firstArg is org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression) {
-            return firstArg.calleeReference.name == NON_CANCELLABLE_NAME
+        return isNonCancellable(firstArg)
+    }
+
+    /**
+     * Checks if [expression] resolves to `kotlinx.coroutines.NonCancellable`, whether referenced
+     * as a bare imported name, fully qualified, combined via `+` with another
+     * `CoroutineContext`, or through a variable typed as `NonCancellable`.
+     *
+     * Mirrors the verified precedent in `UnstructuredLaunchChecker.isGlobalScope`: a resolved
+     * object reference is a [FirResolvedQualifier], and [ConeClassLikeType.lookupTag] is used
+     * instead of the unstable `ConeKotlinType.toClassSymbol()` API that changed signature in
+     * Kotlin 2.3.20.
+     */
+    private fun isNonCancellable(expression: FirExpression): Boolean {
+        if (expression is FirResolvedQualifier) {
+            return expression.classId == NON_CANCELLABLE_CLASS_ID
         }
-        
-        return false
+
+        if (expression is FirFunctionCall && expression.calleeReference.name == PLUS_NAME) {
+            val receiver = expression.explicitReceiver
+            if (receiver != null && isNonCancellable(receiver)) return true
+            return expression.argumentList.arguments.any { isNonCancellable(it) }
+        }
+
+        val classId = (expression.resolvedType as? ConeClassLikeType)?.lookupTag?.classId
+        return classId == NON_CANCELLABLE_CLASS_ID
     }
 
     /**

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -919,7 +919,7 @@ class StructuredCoroutinesPluginFunctionalTest {
     }
 
     @Test
-    fun `GitHub issue 66 repro - functions a, b and c all cooperate identically`() {
+    fun `val initializer, statement, and assignment cooperation points together suppress LOOP_WITHOUT_YIELD`() {
         // Literal reproduction of https://github.com/santimattius/structured-coroutines/issues/66
         // (function names a/b/c preserved from the issue). `readAvailable`/`flush` stand in for
         // the issue's Ktor ByteReadChannel/ByteWriteChannel calls: this module's functional test

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -918,27 +918,86 @@ class StructuredCoroutinesPluginFunctionalTest {
         )
     }
 
+    @Test
+    fun `GitHub issue 66 repro - functions a, b and c all cooperate identically`() {
+        // Literal reproduction of https://github.com/santimattius/structured-coroutines/issues/66
+        // (function names a/b/c preserved from the issue). `readAvailable`/`flush` stand in for
+        // the issue's Ktor ByteReadChannel/ByteWriteChannel calls: this module's functional test
+        // harness has no Ktor on its classpath, and the checker is suspend-call-shape agnostic,
+        // not type-specific, so a dependency-free suspend fun exercises the exact same FIR path.
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun readAvailable(): Int {
+                delay(1)
+                return 1
+            }
+
+            suspend fun flush() {
+                delay(1)
+            }
+
+            // a: only suspend call is a property initializer
+            suspend fun a(): Int {
+                var total = 0
+                while (true) {
+                    val n = readAvailable()
+                    if (n <= 0) break
+                    total += n
+                }
+                return total
+            }
+
+            // b: same loop plus one statement-level suspend call
+            suspend fun b(): Int {
+                var total = 0
+                while (true) {
+                    val n = readAvailable()
+                    if (n <= 0) break
+                    flush()
+                    total += n
+                }
+                return total
+            }
+
+            // c: suspend call in an assignment
+            suspend fun c(): Int {
+                var n = 1
+                while (n > 0) {
+                    n = readAvailable()
+                }
+                return n
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for issue #66's a/b/c but got:\n$output"
+        )
+    }
+
     // ============================================================================
     // SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE ClassId recognition (#65 / CANCEL_004)
     // ============================================================================
 
     @Test
     fun `bare NonCancellable reference in withContext suppresses SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE`() {
+        // Literal reproduction of variant A from
+        // https://github.com/santimattius/structured-coroutines/issues/65 (function `a`).
         val sourceCode = """
             import kotlinx.coroutines.NonCancellable
             import kotlinx.coroutines.delay
             import kotlinx.coroutines.withContext
 
-            suspend fun saveToDb() {
-                delay(1)
-            }
-
-            suspend fun cleanupBare() {
+            suspend fun a() {
                 try {
                     delay(1)
                 } finally {
                     withContext(NonCancellable) {
-                        saveToDb()
+                        delay(1)
                     }
                 }
             }
@@ -955,20 +1014,18 @@ class StructuredCoroutinesPluginFunctionalTest {
 
     @Test
     fun `fully-qualified NonCancellable reference in withContext suppresses SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE`() {
+        // Literal reproduction of variant B from
+        // https://github.com/santimattius/structured-coroutines/issues/65 (function `b`).
         val sourceCode = """
             import kotlinx.coroutines.delay
             import kotlinx.coroutines.withContext
 
-            suspend fun saveToDb() {
-                delay(1)
-            }
-
-            suspend fun cleanupQualified() {
+            suspend fun b() {
                 try {
                     delay(1)
                 } finally {
                     withContext(kotlinx.coroutines.NonCancellable) {
-                        saveToDb()
+                        delay(1)
                     }
                 }
             }

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -917,4 +917,128 @@ class StructuredCoroutinesPluginFunctionalTest {
             "Expected LOOP_WITHOUT_YIELD for a loop with only an uncalled local suspend fun but got:\n$output"
         )
     }
+
+    // ============================================================================
+    // SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE ClassId recognition (#65 / CANCEL_004)
+    // ============================================================================
+
+    @Test
+    fun `bare NonCancellable reference in withContext suppresses SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE`() {
+        val sourceCode = """
+            import kotlinx.coroutines.NonCancellable
+            import kotlinx.coroutines.delay
+            import kotlinx.coroutines.withContext
+
+            suspend fun saveToDb() {
+                delay(1)
+            }
+
+            suspend fun cleanupBare() {
+                try {
+                    delay(1)
+                } finally {
+                    withContext(NonCancellable) {
+                        saveToDb()
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE" !in output && "[CANCEL_004]" !in output,
+            "Did not expect SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE for bare withContext(NonCancellable) but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `fully-qualified NonCancellable reference in withContext suppresses SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE`() {
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+            import kotlinx.coroutines.withContext
+
+            suspend fun saveToDb() {
+                delay(1)
+            }
+
+            suspend fun cleanupQualified() {
+                try {
+                    delay(1)
+                } finally {
+                    withContext(kotlinx.coroutines.NonCancellable) {
+                        saveToDb()
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE" !in output && "[CANCEL_004]" !in output,
+            "Did not expect SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE for fully-qualified withContext(NonCancellable) but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `NonCancellable plus Dispatchers combo in withContext suppresses SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE`() {
+        val sourceCode = """
+            import kotlinx.coroutines.Dispatchers
+            import kotlinx.coroutines.NonCancellable
+            import kotlinx.coroutines.delay
+            import kotlinx.coroutines.withContext
+
+            suspend fun saveToDb() {
+                delay(1)
+            }
+
+            suspend fun cleanupPlusCombo() {
+                try {
+                    delay(1)
+                } finally {
+                    withContext(NonCancellable + Dispatchers.IO) {
+                        saveToDb()
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE" !in output && "[CANCEL_004]" !in output,
+            "Did not expect SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE for withContext(NonCancellable + Dispatchers.IO) but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `unprotected suspend call in finally still reports SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE`() {
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun saveToDb() {
+                delay(1)
+            }
+
+            suspend fun cleanupUnprotected() {
+                try {
+                    delay(1)
+                } finally {
+                    saveToDb()
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE" in output || "[CANCEL_004]" in output,
+            "Expected SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE for an unprotected suspend call in finally but got:\n$output"
+        )
+    }
 }

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -678,12 +678,243 @@ class StructuredCoroutinesPluginFunctionalTest {
     fun `channelFlow compiles without awaitClose`() {
         val sourceCode = """
             import kotlinx.coroutines.flow.channelFlow
-            
+
             fun ok() = channelFlow<Int> { send(42) }
         """.trimIndent()
 
         val projectDir = createTestProject(sourceCode)
         val output = runBuild(projectDir, expectSuccess = true)
         assertTrue("BUILD SUCCESSFUL" in output || "compileKotlin" in output, output)
+    }
+
+    // ============================================================================
+    // LOOP_WITHOUT_YIELD deep traversal (#66 / CANCEL_001)
+    // ============================================================================
+
+    @Test
+    fun `cooperation point in val initializer suppresses LOOP_WITHOUT_YIELD`() {
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun suspendCall(): Int {
+                delay(1)
+                return 1
+            }
+
+            suspend fun loopValInitializer() {
+                while (true) {
+                    val n = suspendCall()
+                    if (n <= 0) break
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for a cooperation point in a val initializer but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `cooperation point in assignment RHS suppresses LOOP_WITHOUT_YIELD`() {
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun suspendCall(): Int {
+                delay(1)
+                return 1
+            }
+
+            suspend fun loopAssignment() {
+                var n = 1
+                while (n > 0) {
+                    n = suspendCall()
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for a cooperation point in an assignment RHS but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `cooperation point in if condition suppresses LOOP_WITHOUT_YIELD`() {
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun suspendCall(): Int {
+                delay(1)
+                return 1
+            }
+
+            suspend fun loopIfCondition() {
+                while (true) {
+                    if (suspendCall() <= 0) {
+                        break
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for a cooperation point in an if condition but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `cooperation point in when branch suppresses LOOP_WITHOUT_YIELD`() {
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun suspendCall(): Int {
+                delay(1)
+                return 1
+            }
+
+            suspend fun loopWhenBranch(): Int {
+                var count = 0
+                while (count < 10) {
+                    when {
+                        count % 2 == 0 -> suspendCall()
+                        else -> count++
+                    }
+                    count++
+                }
+                return count
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for a cooperation point in a when branch but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `cooperation point on elvis RHS suppresses LOOP_WITHOUT_YIELD`() {
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun suspendCall(): Int {
+                delay(1)
+                return 1
+            }
+
+            suspend fun loopElvis(): Int {
+                var total = 0
+                while (total < 10) {
+                    val maybe: Int? = null
+                    val n = maybe ?: suspendCall()
+                    total += n
+                }
+                return total
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for a cooperation point on an elvis RHS but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `cooperation point inside try block suppresses LOOP_WITHOUT_YIELD`() {
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun suspendCall(): Int {
+                delay(1)
+                return 1
+            }
+
+            suspend fun loopTryBlock(): Int {
+                var total = 0
+                while (total < 10) {
+                    try {
+                        total += suspendCall()
+                    } catch (e: Exception) {
+                        total++
+                    }
+                }
+                return total
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for a cooperation point inside a try block but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `loop with no cooperation point anywhere still reports LOOP_WITHOUT_YIELD`() {
+        val sourceCode = """
+            fun doWork() {
+                println("working")
+            }
+
+            suspend fun loopNoCooperation() {
+                while (true) {
+                    doWork()
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" in output || "[CANCEL_001]" in output,
+            "Expected LOOP_WITHOUT_YIELD for a loop with no cooperation point but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `loop with only an uncalled local suspend fun still reports LOOP_WITHOUT_YIELD`() {
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            fun doWork() {
+                println("working")
+            }
+
+            suspend fun loopWithUncalledLocalSuspendFun() {
+                while (true) {
+                    suspend fun helper() {
+                        delay(1)
+                    }
+                    doWork()
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" in output || "[CANCEL_001]" in output,
+            "Expected LOOP_WITHOUT_YIELD for a loop with only an uncalled local suspend fun but got:\n$output"
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #66: `LoopWithoutYieldChecker` only treated a suspend call as a cooperation point when it was a top-level loop-body statement. Now walks the full expression tree (val initializers, assignment RHS, if/when conditions, elvis RHS, try blocks) via a `FirVisitorVoid` deep traversal, so `val n = suspendCall()` inside a loop is detected the same as a bare statement-level call.
- Fixes #65: `SuspendInFinallyChecker.isWithContextNonCancellable` cast `withContext(...)`'s first argument to `FirPropertyAccessExpression`, which a resolved `NonCancellable` object reference never is (it resolves as `FirResolvedQualifier`) — so the checker's own recommended fix pattern (`withContext(NonCancellable) { ... }`) could never pass. Now recognizes `NonCancellable` via `ClassId` comparison on `FirResolvedQualifier` (bare and fully-qualified references), plus the `NonCancellable + Dispatchers.IO` combinator form.

## Test plan
- [x] New TDD-driven functional tests in `StructuredCoroutinesPluginFunctionalTest.kt`: 6 positive cooperation-point shapes + 2 negative controls for #66, 3 positive `NonCancellable` recognition forms + 1 negative control for #65, plus a combined test literally reproducing issue #66's `a`/`b`/`c` functions by name.
- [x] `./gradlew :compiler:test` — BUILD SUCCESSFUL, 0 failures, 0 regressions.
- [x] `./gradlew publishToMavenLocal` — required before compiler functional tests exercise plugin changes.

Closes #66, closes #65.