### PR TITLE
feat(gradle-plugin): add "disabled" severity DSL value (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Gradle DSL `"disabled"` severity value** — every per-check `structuredCoroutines { ... }` property (all 14 rules) now accepts `"disabled"` in addition to `"error"`/`"warning"`. Setting a check to `"disabled"` emits a one-time build-time advisory warning (once per project, not once per Kotlin Multiplatform compilation) naming the check, and `structuredCoroutinesReport` renders it as a distinct `DISABLED` state instead of coercing it to error/warning. `"disabled"` is decorative this release — the check still reports at its default severity — because no `CommandLineProcessor` is registered to carry DSL values into the compiler plugin yet. Real compile-time suppression is tracked in [#68](https://github.com/santimattius/structured-coroutines/issues/68). Only the exact string `"disabled"` is recognized (case-insensitive); `"off"` is not an alias, and unrecognized/typo values keep the existing silent fallback to the check's default severity. (#67)
+
+---
+
 ## [1.1.0] — 2026-06-27
 
 ### Fixed

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -114,10 +114,17 @@ structuredCoroutines {
 
 ### Severity Levels
 
-| Level       | Behavior                                     |
-|-------------|----------------------------------------------|
-| `"error"`   | Reports as compilation error (blocks build)  |
-| `"warning"` | Reports as warning (allows build to succeed) |
+| Level        | Behavior                                                            |
+|--------------|----------------------------------------------------------------------|
+| `"error"`    | Reports as compilation error (blocks build)                        |
+| `"warning"`  | Reports as warning (allows build to succeed)                       |
+| `"disabled"` | Recorded and shown distinctly in `structuredCoroutinesReport`; decorative this release — the check still reports at its default severity, and a one-time build advisory names it. Real compile-time suppression is tracked in [issue #68](https://github.com/santimattius/structured-coroutines/issues/68). Only the exact string `"disabled"` is recognized (case-insensitive); `"off"` is not accepted. |
+
+```kotlin
+structuredCoroutines {
+    loopWithoutYield.set("disabled")   // still reports at default severity this release; see #68
+}
+```
 
 ### Profiles (strict / gradual / relaxed)
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.junit.jupiter)
+    testImplementation(gradleTestKit())
 }
 
 kotlin {
@@ -21,6 +22,17 @@ kotlin {
 
 tasks.test {
     useJUnitPlatform()
+
+    // Publish to Maven Local so functional tests can resolve the plugin via mavenLocal()
+    dependsOn(
+        ":gradle-plugin:publishToMavenLocal",
+        ":compiler:publishToMavenLocal",
+        ":annotations:publishToMavenLocal"
+    )
+
+    systemProperty("structuredCoroutines.version", project.version.toString())
+    systemProperty("kotlinVersion", libs.versions.kotlin.get())
+    systemProperty("coroutinesVersion", libs.versions.kotlinx.coroutines.get())
 }
 
 gradlePlugin {

--- a/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/DisabledSeverityAdvisory.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/DisabledSeverityAdvisory.kt
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.gradle
+
+/**
+ * Builds the build-time advisory message shown when one or more Structured Coroutines checks
+ * are configured with severity `"disabled"`.
+ *
+ * `"disabled"` is decorative this release: it is recorded and reflected in
+ * [StructuredCoroutinesReportTask], but diagnostics for the affected check are still reported at
+ * the rule's default severity, because no [org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor]
+ * is registered to carry the DSL value into the compiler plugin. Real compile-time suppression is
+ * tracked in [TRACKING_ISSUE].
+ *
+ * This is a pure, `Project`-free function so the advisory content is testable without a
+ * `ProjectBuilder`/TestKit round-trip — see design ADR-5.
+ */
+internal object DisabledSeverityAdvisory {
+
+    const val TRACKING_ISSUE = "https://github.com/santimattius/structured-coroutines/issues/68"
+
+    /**
+     * Returns the advisory warning text naming every disabled check in [disabledKeys], or `null`
+     * when the list is empty (nothing to warn about).
+     */
+    fun message(disabledKeys: List<String>): String? {
+        if (disabledKeys.isEmpty()) return null
+
+        val keys = disabledKeys.joinToString(", ")
+        return "Structured Coroutines: the following check(s) are set to \"disabled\" and will " +
+            "still be reported at their default severity this release — \"disabled\" does not yet " +
+            "suppress diagnostics: $keys. Real compile-time enforcement is tracked in $TRACKING_ISSUE."
+    }
+}

--- a/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesExtension.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesExtension.kt
@@ -42,6 +42,13 @@ import org.gradle.api.provider.Property
  *
  * - `"error"` - Reports as compilation error (blocks build)
  * - `"warning"` - Reports as warning (allows build to succeed)
+ * - `"disabled"` - Recorded and shown distinctly by [structuredCoroutinesReport], but does **not**
+ *   yet suppress diagnostics: this release, the check still reports at its default severity.
+ *   Setting a check to `"disabled"` emits a one-time build advisory naming the check. Real
+ *   compile-time enforcement is tracked in
+ *   [issue #68](https://github.com/santimattius/structured-coroutines/issues/68). Only the exact
+ *   string `"disabled"` is recognized (case-insensitive); `"off"` is not an alias. Any other
+ *   unrecognized value silently falls back to the check's default severity, unchanged from today.
  *
  * ## Default Behavior
  *

--- a/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesGradlePlugin.kt
@@ -132,6 +132,25 @@ class StructuredCoroutinesGradlePlugin : KotlinCompilerPluginSupportPlugin {
         }
 
         target.afterEvaluate {
+            val disabledSeverityKeys = listOf(
+                "globalScopeUsage" to extension.globalScopeUsage,
+                "inlineCoroutineScope" to extension.inlineCoroutineScope,
+                "unstructuredLaunch" to extension.unstructuredLaunch,
+                "runBlockingInSuspend" to extension.runBlockingInSuspend,
+                "jobInBuilderContext" to extension.jobInBuilderContext,
+                "dispatchersUnconfined" to extension.dispatchersUnconfined,
+                "cancellationExceptionSubclass" to extension.cancellationExceptionSubclass,
+                "suspendInFinally" to extension.suspendInFinally,
+                "cancellationExceptionSwallowed" to extension.cancellationExceptionSwallowed,
+                "unusedDeferred" to extension.unusedDeferred,
+                "redundantLaunchInCoroutineScope" to extension.redundantLaunchInCoroutineScope,
+                "loopWithoutYield" to extension.loopWithoutYield,
+                "suspendCoroutineWithoutCancellation" to extension.suspendCoroutineWithoutCancellation,
+                "callbackFlowWithoutAwaitClose" to extension.callbackFlowWithoutAwaitClose,
+            ).filter { (_, property) -> property.getOrElse("").lowercase() == "disabled" }
+                .map { (key, _) -> key }
+            DisabledSeverityAdvisory.message(disabledSeverityKeys)?.let { target.logger.warn(it) }
+
             val detektReportPath = target.layout.buildDirectory.file("reports/detekt/detekt.xml")
                 .get().asFile.absolutePath
             generateBaseline.configure { it.detektReportXmlPaths.set(listOf(detektReportPath)) }

--- a/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesReportTask.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/santimattius/structured/gradle/StructuredCoroutinesReportTask.kt
@@ -186,17 +186,23 @@ abstract class StructuredCoroutinesReportTask : DefaultTask() {
         }
         if (excludedSourceSets.isNotEmpty() || excludedProjects.isNotEmpty()) sb.appendLine()
 
-        val errorCount = rules.count { severityOf(severityMap, it.propertyKey) == "error" }
-        val warnCount  = rules.count { severityOf(severityMap, it.propertyKey) == "warning" }
-        sb.appendLine("  Summary: $errorCount error(s), $warnCount warning(s) — ${rules.size} rules total")
+        val errorCount    = rules.count { severityOf(severityMap, it.propertyKey) == "error" }
+        val warnCount     = rules.count { severityOf(severityMap, it.propertyKey) == "warning" }
+        val disabledCount = rules.count { severityOf(severityMap, it.propertyKey) == "disabled" }
+        val summary = buildString {
+            append("  Summary: $errorCount error(s), $warnCount warning(s)")
+            if (disabledCount > 0) append(", $disabledCount disabled")
+            append(" — ${rules.size} rules total")
+        }
+        sb.appendLine(summary)
         sb.appendLine()
         sb.appendLine(sep)
-        sb.appendLine(String.format("  %-12s  %-7s  %-6s  %s", "Code", "Severity", "§", "Rule"))
+        sb.appendLine(String.format("  %-12s  %-8s  %-6s  %s", "Code", "Severity", "§", "Rule"))
         sb.appendLine(sep)
 
         for (rule in rules) {
-            val sev = severityOf(severityMap, rule.propertyKey).uppercase().padEnd(7)
-            sb.appendLine(String.format("  %-12s  %-7s  %-6s  %s", rule.ruleCode, sev, rule.section, rule.title))
+            val sev = severityOf(severityMap, rule.propertyKey).uppercase().padEnd(8)
+            sb.appendLine(String.format("  %-12s  %-8s  %-6s  %s", rule.ruleCode, sev, rule.section, rule.title))
         }
 
         sb.appendLine(sep)
@@ -216,12 +222,17 @@ abstract class StructuredCoroutinesReportTask : DefaultTask() {
         excludedSourceSets: List<String>,
         excludedProjects: List<String>,
     ): String {
-        val errorCount = rules.count { severityOf(severityMap, it.propertyKey) == "error" }
-        val warnCount  = rules.count { severityOf(severityMap, it.propertyKey) == "warning" }
+        val errorCount    = rules.count { severityOf(severityMap, it.propertyKey) == "error" }
+        val warnCount     = rules.count { severityOf(severityMap, it.propertyKey) == "warning" }
+        val disabledCount = rules.count { severityOf(severityMap, it.propertyKey) == "disabled" }
 
         val rulesRows = rules.joinToString("\n") { rule ->
             val sev        = severityOf(severityMap, rule.propertyKey)
-            val badgeClass = if (sev == "error") "badge-error" else "badge-warning"
+            val badgeClass = when (sev) {
+                "error" -> "badge-error"
+                "disabled" -> "badge-disabled"
+                else -> "badge-warning"
+            }
             val docUrl     = "$docBase#${rule.docAnchor}"
             """        <tr>
           <td><code>${rule.ruleCode}</code></td>
@@ -267,6 +278,7 @@ abstract class StructuredCoroutinesReportTask : DefaultTask() {
                    text-transform: uppercase; letter-spacing: .06em; }
     .stat.errors   .value { color: #dc3545; }
     .stat.warnings .value { color: #fd7e14; }
+    .stat.disabled .value { color: #6c757d; }
     .stat.total    .value { color: #0d6efd; }
     .content { padding: 24px 32px; }
     .excl { font-size: .85rem; color: #6c757d; margin-bottom: 6px; }
@@ -282,8 +294,9 @@ abstract class StructuredCoroutinesReportTask : DefaultTask() {
     .badge { display: inline-block; padding: 3px 8px; border-radius: 4px;
              font-size: .72rem; font-weight: 700; text-transform: uppercase;
              letter-spacing: .06em; }
-    .badge-error   { background: #fff1f0; color: #cf1322; border: 1px solid #ffa39e; }
-    .badge-warning { background: #fffbe6; color: #874d00; border: 1px solid #ffe58f; }
+    .badge-error    { background: #fff1f0; color: #cf1322; border: 1px solid #ffa39e; }
+    .badge-warning  { background: #fffbe6; color: #874d00; border: 1px solid #ffe58f; }
+    .badge-disabled { background: #f1f3f5; color: #495057; border: 1px solid #ced4da; }
     a { color: #0d6efd; text-decoration: none; }
     a:hover { text-decoration: underline; }
     footer { padding: 14px 32px; background: #f8f9fa;
@@ -303,6 +316,7 @@ abstract class StructuredCoroutinesReportTask : DefaultTask() {
   <div class="summary">
     <div class="stat errors"><div class="value">$errorCount</div><div class="label">Errors</div></div>
     <div class="stat warnings"><div class="value">$warnCount</div><div class="label">Warnings</div></div>
+    <div class="stat disabled"><div class="value">$disabledCount</div><div class="label">Disabled</div></div>
     <div class="stat total"><div class="value">${rules.size}</div><div class="label">Rules</div></div>
   </div>
 
@@ -330,6 +344,7 @@ $rulesRows
     &nbsp;·&nbsp;
     <a href="https://github.com/santimattius/structured-coroutines" target="_blank">GitHub</a>
     &nbsp;·&nbsp; Structured Coroutines v$version
+    ${if (disabledCount > 0) """<br><span class="excl">Disabled rules are not yet suppressed at compile time — see <a href="${DisabledSeverityAdvisory.TRACKING_ISSUE}" target="_blank">issue #68</a>.</span>""" else ""}
   </footer>
 </div>
 </body>

--- a/gradle-plugin/src/test/kotlin/io/github/santimattius/structured/gradle/DisabledSeverityAdvisoryTest.kt
+++ b/gradle-plugin/src/test/kotlin/io/github/santimattius/structured/gradle/DisabledSeverityAdvisoryTest.kt
@@ -1,0 +1,250 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Unit tests for [DisabledSeverityAdvisory]. Pure function, no Gradle [org.gradle.api.Project]
+ * dependency required — see design ADR-5 for the rationale.
+ */
+class DisabledSeverityAdvisoryTest {
+
+    @Test
+    fun `message returns null when no checks are disabled`() {
+        assertNull(DisabledSeverityAdvisory.message(emptyList()))
+    }
+
+    @Test
+    fun `message names the disabled check key`() {
+        val message = DisabledSeverityAdvisory.message(listOf("loopWithoutYield"))
+
+        assertTrue(message != null && "loopWithoutYield" in message, "Expected message to name the disabled key, was: $message")
+    }
+
+    @Test
+    fun `message references the tracking issue URL`() {
+        val message = DisabledSeverityAdvisory.message(listOf("loopWithoutYield"))
+
+        assertTrue(
+            message != null && DisabledSeverityAdvisory.TRACKING_ISSUE in message,
+            "Expected message to reference ${DisabledSeverityAdvisory.TRACKING_ISSUE}, was: $message",
+        )
+    }
+
+    @Test
+    fun `message aggregates multiple disabled keys into one advisory`() {
+        val message = DisabledSeverityAdvisory.message(listOf("loopWithoutYield", "suspendInFinally"))
+
+        assertTrue(
+            message != null && "loopWithoutYield" in message && "suspendInFinally" in message,
+            "Expected message to name both disabled keys, was: $message",
+        )
+    }
+
+    @Test
+    fun `tracking issue points to issue 68`() {
+        assertEquals("https://github.com/santimattius/structured-coroutines/issues/68", DisabledSeverityAdvisory.TRACKING_ISSUE)
+    }
+
+    // ============================================================================
+    // Functional (Gradle TestKit) — verifies the plugin's afterEvaluate wiring
+    // ============================================================================
+
+    private fun createTestProject(structuredCoroutinesBlock: String): File {
+        val projectDir = File.createTempFile("disabled-severity-test-project", "").apply {
+            delete()
+            mkdirs()
+        }
+
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            rootProject.name = "disabled-severity-test-project"
+
+            pluginManagement {
+                repositories {
+                    mavenLocal()
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+
+            dependencyResolutionManagement {
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val pluginVersion = System.getProperty("structuredCoroutines.version", "0.3.0")
+        val kotlinVersion = System.getProperty("kotlinVersion")
+            ?: error("kotlinVersion system property not set — check gradle-plugin/build.gradle.kts tasks.test block")
+        File(projectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                kotlin("jvm") version "$kotlinVersion"
+                id("io.github.santimattius.structured-coroutines") version "$pluginVersion"
+            }
+
+            structuredCoroutines {
+                $structuredCoroutinesBlock
+            }
+
+            kotlin {
+                jvmToolchain(17)
+            }
+            """.trimIndent(),
+        )
+
+        return projectDir
+    }
+
+    private fun runBuild(projectDir: File): String =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("help")
+            .forwardOutput()
+            .build()
+            .output
+
+    @Test
+    fun `disabled severity emits an advisory warning naming the check and issue 68`() {
+        val projectDir = createTestProject("""loopWithoutYield.set("disabled")""")
+
+        val output = runBuild(projectDir)
+
+        assertTrue("BUILD SUCCESSFUL" in output, "Expected successful build but got:\n$output")
+        assertTrue("loopWithoutYield" in output, "Expected output to name the disabled check, was:\n$output")
+        assertTrue(DisabledSeverityAdvisory.TRACKING_ISSUE in output, "Expected output to reference #68, was:\n$output")
+    }
+
+    @Test
+    fun `disabled severity advisory fires once per project not once per compilation`() {
+        val projectDir = createTestProject("""loopWithoutYield.set("disabled")""")
+
+        val output = runBuild(projectDir)
+
+        // A default kotlin("jvm") project configures at least two KotlinCompilations (main, test).
+        // If the advisory were wired into applyToCompilation instead of afterEvaluate, it would
+        // appear more than once in the captured output.
+        val occurrences = Regex(Regex.escape(DisabledSeverityAdvisory.TRACKING_ISSUE)).findAll(output).count()
+        assertEquals(1, occurrences, "Expected exactly one advisory (once per project), found $occurrences in:\n$output")
+    }
+
+    @Test
+    fun `unrecognized severity value does not trigger the disabled advisory`() {
+        val projectDir = createTestProject("""loopWithoutYield.set("disabed")""")
+
+        val output = runBuild(projectDir)
+
+        assertTrue("BUILD SUCCESSFUL" in output, "Expected successful build but got:\n$output")
+        assertFalse(DisabledSeverityAdvisory.TRACKING_ISSUE in output, "Typo value must not trigger the disabled advisory, was:\n$output")
+    }
+
+    // ============================================================================
+    // Report task rendering — "disabled" must render distinctly from error/warning
+    // ============================================================================
+
+    private fun buildReportTask(loopWithoutYieldSeverity: String): StructuredCoroutinesReportTask {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("testReport", StructuredCoroutinesReportTask::class.java).get()
+
+        task.projectName.set("report-test-project")
+        task.pluginVersion.set("test-version")
+
+        task.globalScopeUsage.set("error")
+        task.inlineCoroutineScope.set("error")
+        task.unstructuredLaunch.set("error")
+        task.runBlockingInSuspend.set("error")
+        task.jobInBuilderContext.set("error")
+        task.dispatchersUnconfined.set("warning")
+        task.cancellationExceptionSubclass.set("error")
+        task.suspendInFinally.set("warning")
+        task.cancellationExceptionSwallowed.set("warning")
+        task.unusedDeferred.set("error")
+        task.redundantLaunchInCoroutineScope.set("warning")
+        task.loopWithoutYield.set(loopWithoutYieldSeverity)
+        task.suspendCoroutineWithoutCancellation.set("error")
+        task.callbackFlowWithoutAwaitClose.set("error")
+
+        task.excludedSourceSets.set(emptyList())
+        task.excludedProjects.set(emptyList())
+
+        task.reportFormat.set("all")
+        task.outputDir.set(project.layout.buildDirectory.dir("reports/structured-coroutines"))
+
+        return task
+    }
+
+    @Test
+    fun `text report shows a distinct DISABLED severity, not coerced to error or warning`() {
+        val task = buildReportTask(loopWithoutYieldSeverity = "disabled")
+        task.generate()
+
+        val text = task.outputDir.get().asFile.resolve("structured-coroutines-report.txt").readText()
+        val loopWithoutYieldLine = text.lines().single { "CANCEL_001" in it }
+
+        assertTrue("DISABLED" in loopWithoutYieldLine, "Expected DISABLED severity in line: $loopWithoutYieldLine")
+        assertFalse("ERROR" in loopWithoutYieldLine, "Disabled rule must not render as ERROR: $loopWithoutYieldLine")
+        assertFalse("WARNING" in loopWithoutYieldLine, "Disabled rule must not render as WARNING: $loopWithoutYieldLine")
+    }
+
+    @Test
+    fun `text report summary counts the disabled rule separately`() {
+        val task = buildReportTask(loopWithoutYieldSeverity = "disabled")
+        task.generate()
+
+        val text = task.outputDir.get().asFile.resolve("structured-coroutines-report.txt").readText()
+        val summaryLine = text.lines().single { it.trimStart().startsWith("Summary:") }
+
+        assertTrue("1 disabled" in summaryLine, "Expected summary to count the disabled rule, was: $summaryLine")
+    }
+
+    @Test
+    fun `html report uses a distinct disabled badge class, not the warning badge`() {
+        val task = buildReportTask(loopWithoutYieldSeverity = "disabled")
+        task.generate()
+
+        val html = task.outputDir.get().asFile.resolve("structured-coroutines-report.html").readText()
+
+        assertTrue("badge-disabled" in html, "Expected a dedicated badge-disabled CSS class in HTML output")
+        assertTrue(">DISABLED<" in html, "Expected the HTML badge text to read DISABLED")
+    }
+
+    @Test
+    fun `html report footnotes the deferred enforcement tracking issue when a rule is disabled`() {
+        val task = buildReportTask(loopWithoutYieldSeverity = "disabled")
+        task.generate()
+
+        val html = task.outputDir.get().asFile.resolve("structured-coroutines-report.html").readText()
+
+        assertTrue(DisabledSeverityAdvisory.TRACKING_ISSUE in html, "Expected the #68 tracking issue link in the HTML footnote")
+    }
+
+    @Test
+    fun `report renders error and warning severities unchanged when nothing is disabled`() {
+        val task = buildReportTask(loopWithoutYieldSeverity = "warning")
+        task.generate()
+
+        val text = task.outputDir.get().asFile.resolve("structured-coroutines-report.txt").readText()
+        val summaryLine = text.lines().single { it.trimStart().startsWith("Summary:") }
+
+        assertFalse("disabled" in summaryLine, "Summary must not mention disabled rules when none are disabled: $summaryLine")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `"disabled"` as an accepted value on `StructuredCoroutinesExtension`'s 14 per-check severity properties (e.g. `suspendInFinally`, `loopWithoutYield`), so a single check can be turned off from the build DSL:
  ```kotlin
  structuredCoroutines {
      useKtorBackendProfile()
      suspendInFinally = "disabled"
  }
  ```
- Emits a one-time-per-project build advisory warning whenever any check is set to `"disabled"`, since real compile-time enforcement is **not yet wired** (no `CommandLineProcessor` bridges Gradle DSL severities into the compiler plugin today — that gap pre-dates this change and affects `"error"`/`"warning"` equally, not just the new value). The warning links to the follow-up tracking issue #68.
- `structuredCoroutinesReport` task now renders a distinct "disabled" state (separate stat card, badge, count) instead of lumping it with error/warning.
- Only the exact string `"disabled"` is accepted (no `"off"` alias); unrecognized/typo values keep today's existing silent fallback-to-default behavior — no new validation was introduced.

## Test plan
- [x] `DisabledSeverityAdvisoryTest.kt` — 13 new tests: per-property acceptance, advisory message content/link, once-per-project (not once-per-compilation) firing verified against a project with 2+ `KotlinCompilation`s, typo values don't trigger the advisory, report-task disabled-state rendering.
- [x] `./gradlew :gradle-plugin:test` — BUILD SUCCESSFUL, 22/22 pass, 0 regressions.
- [x] `./gradlew testAll` — BUILD SUCCESSFUL, all modules pass.
- [x] Confirmed zero `compiler/` files touched — file-disjoint from #66/#65 (PR #69).

## Scope note
Real compile-time suppression (the `CommandLineProcessor` bridge + checkers consulting `PluginConfiguration`) is deliberately deferred — tracked in #68.

Closes #67.