### PR TITLE
feat(compiler): add tri-state severity rule registry and CLI bridge (#68)

### DIFF
--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/PluginConfiguration.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/PluginConfiguration.kt
@@ -59,4 +59,55 @@ class PluginConfiguration(configuration: CompilerConfiguration) {
             "warning" -> Severity.WARNING
             else -> defaultSeverity
         }
+
+    /**
+     * Resolves the effective tri-state severity for [rule] (#68, ADR-1/ADR-2).
+     *
+     * Unlike [getSeverity], this recognizes `"disabled"` as the real [RuleSeverity.DISABLED]
+     * state rather than silently falling back to a [Severity] value. An unrecognized value
+     * (e.g. a typo) falls back to [ScoroutinesRule.defaultSeverity] with no build failure —
+     * the same regression-safe fallback behavior `getSeverity` already had for #67.
+     *
+     * This method does not yet apply the ADR-7 grace-period direction rule (Phase 3); it is the
+     * raw resolution step that phase builds on.
+     */
+    fun effectiveSeverityOf(rule: ScoroutinesRule): RuleSeverity =
+        when (options[rule.optionKey]?.lowercase()) {
+            "error" -> RuleSeverity.ERROR
+            "warning" -> RuleSeverity.WARNING
+            "disabled" -> RuleSeverity.DISABLED
+            else -> rule.defaultSeverity.toRuleSeverity()
+        }
+}
+
+/**
+ * Every [ScoroutinesRule.defaultSeverity] is either [Severity.ERROR] or [Severity.WARNING] —
+ * no rule defaults to disabled — so this conversion is total in practice; any other [Severity]
+ * value indicates a rule was misconfigured with an unsupported default.
+ */
+private fun Severity.toRuleSeverity(): RuleSeverity = when (this) {
+    Severity.ERROR -> RuleSeverity.ERROR
+    Severity.WARNING -> RuleSeverity.WARNING
+    else -> error("Unsupported default Severity for a ScoroutinesRule: $this")
+}
+
+/**
+ * Tri-state severity (#68, ADR-2): [org.jetbrains.kotlin.diagnostics.Severity] has no
+ * disabled/off member, so it cannot represent a rule that must report nothing at all.
+ *
+ * [rank] is an explicit constructor value, never `ordinal`. ADR-7's relax/tighten direction
+ * rule compares `configured.rank` against `default.rank`; if rank were derived from enum
+ * declaration order, reordering these entries would silently invert that comparison.
+ */
+enum class RuleSeverity(val rank: Int) {
+    DISABLED(0),
+    WARNING(1),
+    ERROR(2);
+
+    /** `null` means DISABLED — the only state [Severity] cannot represent. */
+    fun toDiagnostic(): Severity? = when (this) {
+        DISABLED -> null
+        WARNING -> Severity.WARNING
+        ERROR -> Severity.ERROR
+    }
 }

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/ScoroutinesRule.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/ScoroutinesRule.kt
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.diagnostics.Severity
+
+/**
+ * Single registry of the 14 configurable Structured Coroutines rules (#68, ADR-1).
+ *
+ * Each entry carries the Gradle DSL / CLI option key ([optionKey]) and the rule's documented
+ * default severity ([defaultSeverity]) when no override is configured. This enum is the single
+ * source of truth consumed by:
+ * - [StructuredCoroutinesCommandLineProcessor] to declare `pluginOptions`
+ * - [PluginConfiguration] for severity resolution (`effectiveSeverityOf`)
+ * - the future twin-factory selection (ADR-6, Slice B)
+ *
+ * It intentionally holds no reference to any `KtDiagnosticFactory` to avoid an initialization
+ * cycle with `StructuredCoroutinesErrors`'s `init` block.
+ */
+enum class ScoroutinesRule(val optionKey: String, val defaultSeverity: Severity) {
+    GLOBAL_SCOPE_USAGE("globalScopeUsage", Severity.ERROR),
+    INLINE_COROUTINE_SCOPE("inlineCoroutineScope", Severity.ERROR),
+    UNSTRUCTURED_LAUNCH("unstructuredLaunch", Severity.ERROR),
+    RUN_BLOCKING_IN_SUSPEND("runBlockingInSuspend", Severity.ERROR),
+    JOB_IN_BUILDER_CONTEXT("jobInBuilderContext", Severity.ERROR),
+    DISPATCHERS_UNCONFINED("dispatchersUnconfined", Severity.WARNING),
+    CANCELLATION_EXCEPTION_SUBCLASS("cancellationExceptionSubclass", Severity.ERROR),
+    SUSPEND_IN_FINALLY("suspendInFinally", Severity.WARNING),
+    CANCELLATION_EXCEPTION_SWALLOWED("cancellationExceptionSwallowed", Severity.WARNING),
+    UNUSED_DEFERRED("unusedDeferred", Severity.ERROR),
+    REDUNDANT_LAUNCH_IN_COROUTINE_SCOPE("redundantLaunchInCoroutineScope", Severity.WARNING),
+    LOOP_WITHOUT_YIELD("loopWithoutYield", Severity.WARNING),
+    SUSPEND_COROUTINE_WITHOUT_CANCELLATION("suspendCoroutineWithoutCancellation", Severity.ERROR),
+    CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE("callbackFlowWithoutAwaitClose", Severity.ERROR),
+}

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesCommandLineProcessor.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesCommandLineProcessor.kt
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOption
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+/**
+ * CLI bridge that carries every `-P plugin:<pluginId>:<key>=<value>` option emitted by
+ * [io.github.santimattius.structured.gradle.StructuredCoroutinesGradlePlugin] into
+ * [CompilerConfiguration] (#68, ADR-3).
+ *
+ * Registered via `META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor`.
+ * Deleting that service file alone restores today's behavior (options never reach the
+ * compiler) — the documented rollback kill switch for this bridge.
+ *
+ * [pluginId] MUST equal the id declared by `StructuredCoroutinesCompilerPluginRegistrar` and
+ * `StructuredCoroutinesGradlePlugin.COMPILER_PLUGIN_ID`, or the Kotlin compiler will not route
+ * options emitted for that id to this processor.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+class StructuredCoroutinesCommandLineProcessor : CommandLineProcessor {
+
+    override val pluginId: String = "io.github.santimattius.structured-coroutines"
+
+    override val pluginOptions: Collection<AbstractCliOption> = ScoroutinesRule.entries.map { rule ->
+        CliOption(
+            optionName = rule.optionKey,
+            valueDescription = "<error|warning|disabled>",
+            description = "Severity for the ${rule.optionKey} rule",
+            required = false,
+            allowMultipleOccurrences = false,
+        )
+    }
+
+    /**
+     * Read-modify-write of the single [PluginConfiguration.OPTIONS_KEY] map (ADR-3), honoring
+     * the [CompilerConfigurationKey][org.jetbrains.kotlin.config.CompilerConfigurationKey]
+     * reference-equality trap documented at `PluginConfiguration.kt:24-26`: every call must
+     * reuse that exact static key instance, never create a new one.
+     */
+    @OptIn(CompilerConfiguration.Internals::class)
+    override fun processOption(
+        option: AbstractCliOption,
+        value: String,
+        configuration: CompilerConfiguration,
+    ) {
+        val current = configuration.get(PluginConfiguration.OPTIONS_KEY) ?: emptyMap()
+        configuration.put(PluginConfiguration.OPTIONS_KEY, current + (option.optionName to value))
+    }
+}

--- a/compiler/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/compiler/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -1,0 +1,1 @@
+io.github.santimattius.structured.compiler.StructuredCoroutinesCommandLineProcessor

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/PluginConfigurationEffectiveSeverityTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/PluginConfigurationEffectiveSeverityTest.kt
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.diagnostics.Severity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Task 1.8/1.9 (severity-enforcement, #68): resolution matrix for
+ * [PluginConfiguration.effectiveSeverityOf] — 14 rules x {unset, error, warning, disabled,
+ * garbage}. This is the tri-state successor to `getSeverity`; unlike `getSeverity`, "disabled"
+ * MUST resolve to [RuleSeverity.DISABLED], not silently fall back to a [Severity] value.
+ *
+ * Negative controls are mandatory (per design.md "Testing strategy"): the "unset" and "garbage"
+ * cases below prove the fallback path independently of the "disabled"/"error"/"warning" paths,
+ * so a resolver that always returns DISABLED (or always returns the default) cannot pass all of
+ * them.
+ */
+@OptIn(CompilerConfiguration.Internals::class)
+class PluginConfigurationEffectiveSeverityTest {
+
+    private fun configOf(options: Map<String, String>): PluginConfiguration {
+        val configuration = CompilerConfiguration()
+        configuration.put(PluginConfiguration.OPTIONS_KEY, options)
+        return PluginConfiguration(configuration)
+    }
+
+    private fun defaultRuleSeverityOf(rule: ScoroutinesRule): RuleSeverity = when (rule.defaultSeverity) {
+        Severity.ERROR -> RuleSeverity.ERROR
+        Severity.WARNING -> RuleSeverity.WARNING
+        else -> error("No ScoroutinesRule documents a default of ${rule.defaultSeverity}")
+    }
+
+    @Test
+    fun `unset rule resolves to its documented default tri-state, for all 14 rules`() {
+        val pluginConfiguration = configOf(emptyMap())
+        ScoroutinesRule.entries.forEach { rule ->
+            assertEquals(
+                defaultRuleSeverityOf(rule),
+                pluginConfiguration.effectiveSeverityOf(rule),
+                "rule=${rule.optionKey}",
+            )
+        }
+    }
+
+    @Test
+    fun `error value resolves to ERROR, for all 14 rules`() {
+        ScoroutinesRule.entries.forEach { rule ->
+            val pluginConfiguration = configOf(mapOf(rule.optionKey to "error"))
+            assertEquals(RuleSeverity.ERROR, pluginConfiguration.effectiveSeverityOf(rule), "rule=${rule.optionKey}")
+        }
+    }
+
+    @Test
+    fun `warning value resolves to WARNING, for all 14 rules`() {
+        ScoroutinesRule.entries.forEach { rule ->
+            val pluginConfiguration = configOf(mapOf(rule.optionKey to "warning"))
+            assertEquals(RuleSeverity.WARNING, pluginConfiguration.effectiveSeverityOf(rule), "rule=${rule.optionKey}")
+        }
+    }
+
+    @Test
+    fun `disabled value resolves to the disabled tri-state, not a Severity fallback, for all 14 rules`() {
+        ScoroutinesRule.entries.forEach { rule ->
+            val pluginConfiguration = configOf(mapOf(rule.optionKey to "disabled"))
+            assertEquals(RuleSeverity.DISABLED, pluginConfiguration.effectiveSeverityOf(rule), "rule=${rule.optionKey}")
+        }
+    }
+
+    @Test
+    fun `unrecognized garbage value falls back to the documented default with no failure, for all 14 rules`() {
+        ScoroutinesRule.entries.forEach { rule ->
+            val pluginConfiguration = configOf(mapOf(rule.optionKey to "disabed"))
+            assertEquals(
+                defaultRuleSeverityOf(rule),
+                pluginConfiguration.effectiveSeverityOf(rule),
+                "rule=${rule.optionKey}",
+            )
+        }
+    }
+
+    @Test
+    fun `resolution is case-insensitive`() {
+        val upper = configOf(mapOf("loopWithoutYield" to "ERROR"))
+        val mixed = configOf(mapOf("loopWithoutYield" to "DiSaBlEd"))
+        assertEquals(RuleSeverity.ERROR, upper.effectiveSeverityOf(ScoroutinesRule.LOOP_WITHOUT_YIELD))
+        assertEquals(RuleSeverity.DISABLED, mixed.effectiveSeverityOf(ScoroutinesRule.LOOP_WITHOUT_YIELD))
+    }
+}

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/RuleSeverityTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/RuleSeverityTest.kt
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.diagnostics.Severity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Task 1.3/1.4 (severity-enforcement, #68, ADR-2): [RuleSeverity] is the tri-state severity
+ * representation (`disabled`/`warning`/`error`) that a plain [Severity] cannot express, since
+ * `Severity` has no disabled/off member.
+ *
+ * [RuleSeverity.rank] MUST be an explicit constructor value, never `ordinal` — ADR-7's
+ * relax/tighten direction rule (`configured.rank` vs `default.rank`) depends on rank being
+ * stable even if entries are reordered.
+ */
+class RuleSeverityTest {
+
+    @Test
+    fun `ranks are DISABLED0, WARNING1, ERROR2`() {
+        assertEquals(0, RuleSeverity.DISABLED.rank)
+        assertEquals(1, RuleSeverity.WARNING.rank)
+        assertEquals(2, RuleSeverity.ERROR.rank)
+    }
+
+    @Test
+    fun `rank strictly increases from DISABLED to WARNING to ERROR`() {
+        assertEquals(
+            listOf(RuleSeverity.DISABLED, RuleSeverity.WARNING, RuleSeverity.ERROR),
+            listOf(RuleSeverity.DISABLED, RuleSeverity.WARNING, RuleSeverity.ERROR)
+                .sortedBy { it.rank },
+        )
+    }
+
+    @Test
+    fun `toDiagnostic maps DISABLED to null since Severity has no disabled member`() {
+        assertNull(RuleSeverity.DISABLED.toDiagnostic())
+    }
+
+    @Test
+    fun `toDiagnostic maps WARNING and ERROR to the matching Severity`() {
+        assertEquals(Severity.WARNING, RuleSeverity.WARNING.toDiagnostic())
+        assertEquals(Severity.ERROR, RuleSeverity.ERROR.toDiagnostic())
+    }
+}

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/ScoroutinesRuleTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/ScoroutinesRuleTest.kt
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.diagnostics.Severity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Task 1.1/1.2 (severity-enforcement, #68, ADR-1): [ScoroutinesRule] is the single registry of
+ * the 14 configurable rules, replacing the 14 hand-written `val`s in [PluginConfiguration] and
+ * the duplicated key literals in `StructuredCoroutinesGradlePlugin`. This test pins its 14
+ * entries against the defaults currently hard-coded in `PluginConfiguration.kt:41-54`.
+ */
+class ScoroutinesRuleTest {
+
+    // The exact optionKey -> defaultSeverity pairs from PluginConfiguration.kt:41-54, before
+    // ScoroutinesRule existed. This is the ground truth this enum MUST reproduce exactly.
+    private val expectedDefaults: Map<String, Severity> = mapOf(
+        "globalScopeUsage" to Severity.ERROR,
+        "inlineCoroutineScope" to Severity.ERROR,
+        "unstructuredLaunch" to Severity.ERROR,
+        "runBlockingInSuspend" to Severity.ERROR,
+        "jobInBuilderContext" to Severity.ERROR,
+        "dispatchersUnconfined" to Severity.WARNING,
+        "cancellationExceptionSubclass" to Severity.ERROR,
+        "suspendInFinally" to Severity.WARNING,
+        "cancellationExceptionSwallowed" to Severity.WARNING,
+        "unusedDeferred" to Severity.ERROR,
+        "redundantLaunchInCoroutineScope" to Severity.WARNING,
+        "loopWithoutYield" to Severity.WARNING,
+        "suspendCoroutineWithoutCancellation" to Severity.ERROR,
+        "callbackFlowWithoutAwaitClose" to Severity.ERROR,
+    )
+
+    @Test
+    fun `has exactly 14 entries`() {
+        assertEquals(14, ScoroutinesRule.entries.size)
+    }
+
+    @Test
+    fun `each entry's optionKey and defaultSeverity match current PluginConfiguration defaults`() {
+        val actual = ScoroutinesRule.entries.associate { it.optionKey to it.defaultSeverity }
+        assertEquals(expectedDefaults, actual)
+    }
+
+    @Test
+    fun `optionKeys are unique`() {
+        val keys = ScoroutinesRule.entries.map { it.optionKey }
+        assertEquals(keys.size, keys.toSet().size, "optionKey must be unique per rule: $keys")
+    }
+}

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesCommandLineProcessorTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesCommandLineProcessorTest.kt
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Task 1.5/1.6 (severity-enforcement, #68, ADR-3): [StructuredCoroutinesCommandLineProcessor]
+ * bridges Gradle's `SubpluginOption`s into [CompilerConfiguration]. Before this class (and its
+ * `META-INF/services` registration), [PluginConfiguration.OPTIONS_KEY] was never populated in a
+ * real build, so DSL severities never reached the compiler at all (Ground truth in design.md).
+ */
+@OptIn(ExperimentalCompilerApi::class, CompilerConfiguration.Internals::class)
+class StructuredCoroutinesCommandLineProcessorTest {
+
+    @Test
+    fun `pluginId matches the registered compiler plugin id`() {
+        val processor = StructuredCoroutinesCommandLineProcessor()
+        assertEquals("io.github.santimattius.structured-coroutines", processor.pluginId)
+    }
+
+    @Test
+    fun `pluginOptions declares the 14 ScoroutinesRule option keys`() {
+        val processor = StructuredCoroutinesCommandLineProcessor()
+        assertEquals(14, processor.pluginOptions.size)
+        assertEquals(
+            ScoroutinesRule.entries.map { it.optionKey }.toSet(),
+            processor.pluginOptions.map { it.optionName }.toSet(),
+        )
+    }
+
+    @Test
+    fun `processOption called twice with different keys accumulates both without clobbering`() {
+        val processor = StructuredCoroutinesCommandLineProcessor()
+        val configuration = CompilerConfiguration()
+        val loopOption = processor.pluginOptions.first { it.optionName == "loopWithoutYield" }
+        val suspendOption = processor.pluginOptions.first { it.optionName == "suspendInFinally" }
+
+        processor.processOption(loopOption, "error", configuration)
+        processor.processOption(suspendOption, "disabled", configuration)
+
+        val stored = configuration.get(PluginConfiguration.OPTIONS_KEY)
+        assertEquals(
+            mapOf("loopWithoutYield" to "error", "suspendInFinally" to "disabled"),
+            stored,
+        )
+    }
+
+    @Test
+    fun `processOption called again for the same key overwrites only that key`() {
+        val processor = StructuredCoroutinesCommandLineProcessor()
+        val configuration = CompilerConfiguration()
+        val loopOption = processor.pluginOptions.first { it.optionName == "loopWithoutYield" }
+
+        processor.processOption(loopOption, "warning", configuration)
+        processor.processOption(loopOption, "error", configuration)
+
+        assertEquals(
+            mapOf("loopWithoutYield" to "error"),
+            configuration.get(PluginConfiguration.OPTIONS_KEY),
+        )
+    }
+}

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -22,7 +22,8 @@ class StructuredCoroutinesPluginFunctionalTest {
     private fun createTestProject(
         sourceCode: String,
         fileName: String = "Test.kt",
-        gradlePropertiesExtra: String? = null
+        gradlePropertiesExtra: String? = null,
+        extensionBlock: String? = null,
     ): File {
         val projectDir = File.createTempFile("test-project", "").apply {
             delete()
@@ -74,6 +75,8 @@ class StructuredCoroutinesPluginFunctionalTest {
             kotlin {
                 jvmToolchain(17)
             }
+
+            ${extensionBlock.orEmpty()}
         """.trimIndent())
 
         // Source directory
@@ -1096,6 +1099,58 @@ class StructuredCoroutinesPluginFunctionalTest {
         assertTrue(
             "SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE" in output || "[CANCEL_004]" in output,
             "Expected SUSPEND_IN_FINALLY_WITHOUT_NON_CANCELLABLE for an unprotected suspend call in finally but got:\n$output"
+        )
+    }
+
+    // ============================================================================
+    // CLI bridge (#68, ADR-3, Phase 0/1) — StructuredCoroutinesCommandLineProcessor +
+    // META-INF/services registration. Before this bridge existed, every SubpluginOption the
+    // Gradle plugin emits for the 14 rule keys was silently dropped: no CommandLineProcessor was
+    // registered, so PluginConfiguration.OPTIONS_KEY was never populated in a real build
+    // (Ground truth in design.md). This section proves the bridge survives real jar packaging
+    // and java.util.ServiceLoader discovery, which unit tests instantiating the classes directly
+    // cannot cover.
+    // ============================================================================
+
+    @Test
+    fun `real build with all 14 severity options set via the DSL succeeds through the new CLI bridge`() {
+        val sourceCode = """
+            fun ok() = println("hello")
+        """.trimIndent()
+
+        // A mix of error/warning/disabled across all 14 rule keys: if the CLI bridge (the
+        // registered StructuredCoroutinesCommandLineProcessor + its META-INF/services file)
+        // were broken — wrong pluginId, missing/malformed service file, an option key typo, or
+        // an exception thrown from processOption — this real build would fail here, unlike the
+        // pre-bridge behavior where these options were always silently ignored.
+        val projectDir = createTestProject(
+            sourceCode,
+            extensionBlock = """
+                structuredCoroutines {
+                    globalScopeUsage.set("warning")
+                    inlineCoroutineScope.set("warning")
+                    unstructuredLaunch.set("warning")
+                    runBlockingInSuspend.set("warning")
+                    jobInBuilderContext.set("disabled")
+                    dispatchersUnconfined.set("error")
+                    cancellationExceptionSubclass.set("disabled")
+                    suspendInFinally.set("error")
+                    cancellationExceptionSwallowed.set("disabled")
+                    unusedDeferred.set("warning")
+                    redundantLaunchInCoroutineScope.set("disabled")
+                    loopWithoutYield.set("error")
+                    suspendCoroutineWithoutCancellation.set("warning")
+                    callbackFlowWithoutAwaitClose.set("disabled")
+                }
+            """.trimIndent(),
+        )
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "BUILD SUCCESSFUL" in output || "compileKotlin" in output,
+            "Expected the CLI bridge (StructuredCoroutinesCommandLineProcessor + its " +
+                "META-INF/services registration) to accept all 14 severity options — including " +
+                "\"disabled\" — without failing the build, but got:\n$output",
         )
     }
 }


### PR DESCRIPTION
## Summary

Foundation slice of #68 (severity-enforcement). Adds the rule registry, the tri-state severity type, and the CLI bridge that carries Gradle DSL options into the compiler plugin — with zero checker behavior change. Before this bridge existed, every severity option the Gradle plugin emitted was silently dropped: no `CommandLineProcessor` was registered, so `PluginConfiguration.OPTIONS_KEY` was never populated in a real build.

Relates to #68.

## Type of change

- [x] Enhancement to existing rule or tooling

## Component(s)

- [x] Compiler plugin

## Test plan

```bash
./gradlew :compiler:test :gradle-plugin:test
```

57 tests, 0 failures. New coverage: `ScoroutinesRuleTest`, `RuleSeverityTest`, `StructuredCoroutinesCommandLineProcessorTest`, `PluginConfigurationEffectiveSeverityTest`, plus one new TestKit functional test proving the CLI bridge survives real jar packaging + `ServiceLoader` discovery (`real build with all 14 severity options set via the DSL succeeds through the new CLI bridge`).

## Checklist

- [x] Tests pass locally (relevant `./gradlew` tasks)
- [x] `CHANGELOG.md` updated for user-facing changes — none needed yet, no behavior change in this slice
- [x] Follows CONTRIBUTING.md guidelines

## Chain Context

| Field | Value |
|-------|-------|
| Chain | severity-enforcement (#68) |
| Tracker PR | feat/severity-enforcement |
| Position | 1 of 3 |
| Base | `feat/severity-enforcement` |
| Depends on | None |
| Follow-up | PR2 (real `disabled` enforcement) |
| Review budget | 496 / 400 |
| Starts at | `main` |
| Ends with | `ScoroutinesRule` registry, `RuleSeverity` tri-state, `effectiveSeverityOf()` resolution, and a working CLI bridge — inert plumbing, no compile-time behavior changes yet |

### Chain Overview

```text
main
 └── feat/severity-enforcement (tracker, draft)
      └── 📍 #PR1 feat/severity-enforcement-01-foundation (this PR)
           └── #PR2 feat/severity-enforcement-02-enforcement
                └── #PR3 feat/severity-enforcement-03-twins-grace
```

### Scope
- Includes: `ScoroutinesRule` (14-entry registry), `RuleSeverity` tri-state, `PluginConfiguration.effectiveSeverityOf()`, `StructuredCoroutinesCommandLineProcessor` + its `META-INF/services` registration
- Excludes: checker injection, real `disabled` suppression, twin factories, grace-period tightening — all in PR2/PR3

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes — deleting the `META-INF/services` file alone restores pre-#68 behavior
- [x] Tests, docs, or manual verification cover this unit

**Review budget note**: 496 changed lines, over the 400-line guideline by a small margin — mostly test code (4 new test files). Not further split since it's foundation-only with no behavior change; splitting further would fragment a single cohesive unit (registry + its own tests) with no independent review value.
