### PR TITLE
docs(sample): add standalone sample-severity module demonstrating the DSL (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ analysis.
 | Annotations                   | ✅ Complete                                              | [annotations/README.md](annotations/README.md)                                                              |
 | Sample                        | ✅ Compilation examples per rule                         | [compilation/README](sample/src/main/kotlin/io/github/santimattius/structured/sample/compilation/README.md) |
 | Sample (Detekt)               | ✅ Detekt rule validation (30+ examples)                 | [sample-detekt/README.md](sample-detekt/README.md)                                                          |
+| Sample (Severity)             | ✅ Severity DSL demo (standalone build)                  | [sample-severity/README.md](sample-severity/README.md)                                                      |
 | Kotlin Coroutines Agent Skill | ✅ AI/agent guidance                                     | [docs/KOTLIN_COROUTINES_SKILL.md](docs/KOTLIN_COROUTINES_SKILL.md)                                          |
 
 ---
@@ -622,6 +623,7 @@ Each module contains its own detailed documentation:
 | **Compiler**                      | [compiler/README.md](compiler/README.md)                                                                       | K2/FIR checker implementation details                                   |
 | **Sample (compilation)**          | [compilation/README.md](sample/src/main/kotlin/io/github/santimattius/structured/sample/compilation/README.md) | One example per compiler rule (errors and warnings)                     |
 | **Sample (Detekt)**               | [sample-detekt/README.md](sample-detekt/README.md)                                                             | One example per Detekt rule; run `:sample-detekt:detekt` to validate    |
+| **Sample (Severity)**             | [sample-severity/README.md](sample-severity/README.md)                                                         | Severity DSL demo (standalone build); run `./gradlew -p sample-severity compileKotlin` |
 | **Kotlin Coroutines Agent Skill** | [docs/KOTLIN_COROUTINES_SKILL.md](docs/KOTLIN_COROUTINES_SKILL.md)                                             | AI/agent skill and decision resource: 32 practices, strict rules, triage playbook (v2.0.0) |
 | **Best Practices**                | [docs/BEST_PRACTICES_COROUTINES.md](docs/BEST_PRACTICES_COROUTINES.md)                                         | Canonical guide to coroutine good/bad practices                         |
 | **Decision Guide**                | [docs/DECISION_GUIDE.md](docs/DECISION_GUIDE.md)                                                               | Quick-reference: launch vs async, scope, dispatcher, timeout, Flow      |

--- a/sample-severity/.gitignore
+++ b/sample-severity/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/sample-severity/README.md
+++ b/sample-severity/README.md
@@ -1,0 +1,168 @@
+# sample-severity
+
+A standalone, runnable demonstration of the `structuredCoroutines { }` severity DSL: how a
+configured severity (`"error"` / `"warning"` / `"disabled"`) resolves to what actually reports at
+compile time, and how *tightening* a rule (making it stricter) behaves differently from
+*relaxing* it (making it looser) under the grace-period policy introduced in
+[#68](https://github.com/santimattius/structured-coroutines/issues/68).
+
+This module is **doc-only**: it is not wired into the root `testAll` task or CI, and it is not
+included as a subproject of the root build (see "Why a standalone build" below). All four
+behaviors it demonstrates are already covered by automated tests in
+`compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt`.
+This module exists for human-readable, hands-on demonstration — not for regression coverage.
+
+It complements [`sample/`](../sample/src/main/kotlin/io/github/santimattius/structured/sample/compilation/README.md)
+(one example per compiler rule, at default severity) by showing what happens when you
+**reconfigure** severity through the Gradle DSL instead.
+
+## Why a standalone build
+
+Unlike [`sample-detekt/`](../sample-detekt/README.md) — a subproject of the root build, because
+`io.gitlab.arturbosch.detekt` resolves from `gradlePluginPortal()` — `io.github.santimattius.structured-coroutines`
+only ever exists in `mavenLocal()`. Including a module that requires it as a root subproject
+would make Gradle try to resolve it for *every* root task (not just this module's), breaking the
+root build the moment the artifact isn't published yet. `sample-severity/` is therefore a fully
+standalone Gradle build with its own `settings.gradle.kts`, invoked with `-p`:
+
+```bash
+./gradlew -p sample-severity compileKotlin
+```
+
+`-p sample-severity` makes this directory the build root for the invocation (so its own
+`settings.gradle.kts` and `pluginManagement { }` block apply), while reusing the root project's
+Gradle wrapper — no duplicate `gradlew`/`gradle/wrapper` is copied here. The root
+`settings.gradle.kts` and root `build.gradle.kts` are untouched by this module's existence.
+
+## Prerequisite
+
+Publish the plugin artifacts to `mavenLocal()` first, from the repo root:
+
+```bash
+./gradlew publishToMavenLocal
+```
+
+`sample-severity/gradle.properties` pins `structuredCoroutinesVersion` to the plugin version this
+publishes — it must match the root project's `PROJECT_VERSION`
+(`structured-coroutines/gradle.properties`) exactly, verbatim, never invented.
+
+## The DSL block
+
+`sample-severity/build.gradle.kts` configures three rules in one block:
+
+```kotlin
+structuredCoroutines {
+    globalScopeUsage.set("disabled")   // relaxation: immediate, policy-independent
+    unusedDeferred.set("warning")      // relaxation: immediate, policy-independent
+    loopWithoutYield.set("error")      // TIGHTENING: the only policy-sensitive line
+    severityEnforcement.set(
+        providers.gradleProperty("severityEnforcement").orElse("grace")
+    )
+}
+```
+
+Only `loopWithoutYield` reacts to the `severityEnforcement` toggle. The other two lines are
+*relaxations* — they always apply immediately, regardless of policy, because a relaxation can only
+make a previously-failing build pass, never break one.
+
+## Command A — GRACE (default)
+
+```bash
+./gradlew -p sample-severity compileKotlin
+```
+
+Result: **BUILD SUCCESSFUL**.
+
+| # | Scenario | Rule | Assertion |
+|---|---|---|---|
+| 1 | Suppression | `globalScopeUsage` (default `"error"`) → `"disabled"` | `[SCOPE_001]` is **absent** from the output |
+| 2 | Immediate relaxation | `unusedDeferred` (default `"error"`) → `"warning"` | a line containing `[SCOPE_002]` whose trimmed start is `w:` |
+| 3 | Deferred tightening | `loopWithoutYield` (default `"warning"`) → `"error"` | a line containing `[CANCEL_001]` whose trimmed start is `w:` (build does not fail on it) |
+| 3b | Advisory | (same rule) | one additional warning naming the rule, the configured value, the currently-effective severity, and the enforcing release — see below |
+
+Verified output (default log level — **no `--info` required**; the advisory renders as an
+ordinary Gradle-lifecycle warning line):
+
+```
+w: Structured Coroutines: rule 'loopWithoutYield' is configured to "error" but keeps reporting as "warning" during the grace period. It will start enforcing "error" in version <ENFORCING_VERSION>. Set severityEnforcement = "strict" to enforce it now.
+w: .../DisabledRuleExample.kt:19:5 This is a delicate API and its use requires care. ...
+w: .../RelaxedRuleExample.kt:19:20 [SCOPE_002] async call creates a Deferred that is never awaited. ...
+w: .../TightenedRuleExample.kt:22:5 [CANCEL_001] Loop in suspend function without cooperation point. ...
+
+BUILD SUCCESSFUL
+```
+
+<!-- Update when SeverityGracePeriod.ENFORCING_VERSION changes -->
+`<ENFORCING_VERSION>` above is `SeverityGracePeriod.ENFORCING_VERSION` — never copy the literal
+version string into prose; only the one line above (elided) references it, flagged for update.
+
+The `[SCOPE_001]`-suppressing rule never emits a "delicate API" style warning of its own from the
+structured-coroutines plugin, but `GlobalScope.launch { }` is itself annotated `@DelicateCoroutinesApi`
+by kotlinx.coroutines, so the Kotlin compiler's own delicate-API warning still appears — that
+warning is unrelated to `structuredCoroutines { }` and is not a `[SCOPE_001]` line.
+
+## Command B — STRICT
+
+```bash
+./gradlew -p sample-severity compileKotlin -PseverityEnforcement=strict
+```
+
+Result: **BUILD FAILED**.
+
+| # | Scenario | Assertion |
+|---|---|---|
+| 4 | Immediate tightening | the line containing `[CANCEL_001]` trimmed-starts with `e:` |
+| 4b | Advisory gone | `<ENFORCING_VERSION>` is **absent** — `deferredTightenings` is empty under STRICT |
+| 4c | Relaxations still take effect | `[SCOPE_001]` remains absent — `globalScopeUsage` stays disabled regardless of policy |
+
+Verified output:
+
+```
+e: .../TightenedRuleExample.kt:22:5 [CANCEL_001] Loop in suspend function without cooperation point. ...
+
+BUILD FAILED
+```
+
+**Empirical note (verified, not assumed):** in this failed build, only the diagnostic that causes
+the failure (`[CANCEL_001]` at `e:`) is printed to the console — even with `--info`. The
+`[SCOPE_002]` warning line (still `"warning"` under this policy) does **not** appear in this run's
+output, unlike Command A's successful build, where all diagnostics are shown. This is a real
+difference between a successful and a failed `compileKotlin` invocation with this Kotlin/Gradle
+toolchain (Kotlin 2.4.0's Build Tools API compilation path); it is not evidence that
+`unusedDeferred` stopped being `"warning"` — it still is, and the parent project's functional
+test suite verifies `[SCOPE_002]` at `"warning"` in isolation
+(`StructuredCoroutinesPluginFunctionalTest.kt`). Do not rely on console output alone to prove a
+non-erroring rule's severity in a build that already failed for another reason.
+
+## Negative control (no new flag — proves the suppression, not just its absence)
+
+Absence of `[SCOPE_001]` alone is not proof that suppression works — an always-silent plugin
+would "pass" too. To prove it:
+
+1. Comment out `globalScopeUsage.set("disabled")` in `sample-severity/build.gradle.kts`.
+2. Re-run: `./gradlew -p sample-severity clean compileKotlin`.
+3. Confirm the build now **FAILS** with a line containing `[SCOPE_001]` trimmed-starting `e:`
+   (verified).
+4. Restore the `globalScopeUsage.set("disabled")` line.
+
+## Incremental-build note
+
+Commands A and B differ in a compiler-plugin option (`severityEnforcement`), so switching between
+them always re-runs `compileKotlin` (verified). Re-running the exact same command a second time
+without changes shows `compileKotlin UP-TO-DATE` and prints no diagnostics (verified) — prefix
+`clean` (e.g. `./gradlew -p sample-severity clean compileKotlin`) to see the diagnostics again.
+
+## The `SeverityGracePeriod.ENFORCING_VERSION` flip caveat
+
+The scenario table above describes **GRACE-default** behavior (`SeverityGracePeriod.DEFAULT_POLICY
+= GRACE`, this release). At `SeverityGracePeriod.ENFORCING_VERSION`, `DEFAULT_POLICY` flips to
+`STRICT`: Command A's scenario 3 will then also **fail** the build (converging with Command B's
+scenario 4), and the grace-period advisory (scenario 3b) will no longer appear under Command A
+because there is no longer anything left to defer. Re-verify this README's Command A output after
+that flip ships.
+
+## Rollback
+
+This module is fully self-contained. `rm -rf sample-severity/` plus reverting the two
+`sample-severity` rows in the root `README.md` fully restores a working repository — no other
+file references this directory, and no root build file is modified by its existence.

--- a/sample-severity/build.gradle.kts
+++ b/sample-severity/build.gradle.kts
@@ -1,0 +1,41 @@
+plugins {
+    kotlin("jvm")
+    id("io.github.santimattius.structured-coroutines")
+}
+
+val structuredCoroutinesVersion: String by project
+val coroutinesVersion: String by project
+
+dependencies {
+    implementation("io.github.santimattius:structured-coroutines-annotations:$structuredCoroutinesVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+// Demonstrates the structuredCoroutines { } severity DSL (see sdd severity-enforcement,
+// closes #68): two relaxations (suppression / immediate relaxation) that always apply
+// immediately, and one tightening (loopWithoutYield) whose behavior depends on the
+// severityEnforcement policy — GRACE (default) defers it with an advisory, STRICT enforces
+// it immediately. Toggle with: ./gradlew -p sample-severity compileKotlin -PseverityEnforcement=strict
+structuredCoroutines {
+    // Suppression: disables GLOBAL_SCOPE_USAGE (default severity "error") entirely.
+    // Relaxation, so it applies immediately regardless of severityEnforcement.
+    globalScopeUsage.set("disabled")
+
+    // Immediate relaxation: UNUSED_DEFERRED (default severity "error") relaxed to "warning".
+    // Relaxations always apply immediately, regardless of severityEnforcement.
+    unusedDeferred.set("warning")
+
+    // Tightening: LOOP_WITHOUT_YIELD (default severity "warning") tightened to "error".
+    // This is the only line sensitive to severityEnforcement below.
+    loopWithoutYield.set("error")
+
+    // "grace" (default) defers the tightening above by one release with an advisory.
+    // "strict" (via -PseverityEnforcement=strict) enforces it immediately.
+    severityEnforcement.set(
+        providers.gradleProperty("severityEnforcement").orElse("grace")
+    )
+}

--- a/sample-severity/gradle.properties
+++ b/sample-severity/gradle.properties
@@ -1,0 +1,6 @@
+# Version literals for this standalone sample build.
+# structuredCoroutinesVersion MUST match the root project's PROJECT_VERSION
+# (structured-coroutines/gradle.properties) — copy verbatim, never invent it.
+structuredCoroutinesVersion=1.1.1
+kotlinVersion=2.4.0
+coroutinesVersion=1.11.0

--- a/sample-severity/settings.gradle.kts
+++ b/sample-severity/settings.gradle.kts
@@ -1,0 +1,22 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    val kotlinVersion: String by settings
+    val structuredCoroutinesVersion: String by settings
+    plugins {
+        kotlin("jvm") version kotlinVersion
+        id("io.github.santimattius.structured-coroutines") version structuredCoroutinesVersion
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "sample-severity"

--- a/sample-severity/src/main/kotlin/io/github/santimattius/structured/sample/severity/DisabledRuleExample.kt
+++ b/sample-severity/src/main/kotlin/io/github/santimattius/structured/sample/severity/DisabledRuleExample.kt
@@ -1,0 +1,20 @@
+package io.github.santimattius.structured.sample.severity
+
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+/**
+ * Scenario: Disabled-suppression.
+ *
+ * Rule: `globalScopeUsage` (marker `[SCOPE_001]`), default severity `"error"`.
+ * Configured: `structuredCoroutines { globalScopeUsage.set("disabled") }` in `build.gradle.kts`.
+ * Direction: relaxation (suppression) — always applies immediately, regardless of
+ * `severityEnforcement`.
+ *
+ * With the rule disabled, `./gradlew -p sample-severity compileKotlin` succeeds and
+ * `[SCOPE_001]` is entirely absent from the output. See the README's negative control: comment
+ * out the `.set("disabled")` line and re-run to see `[SCOPE_001]` reported at `error` again.
+ */
+fun triggerGlobalScopeUsage() {
+    GlobalScope.launch { println("x") }
+}

--- a/sample-severity/src/main/kotlin/io/github/santimattius/structured/sample/severity/RelaxedRuleExample.kt
+++ b/sample-severity/src/main/kotlin/io/github/santimattius/structured/sample/severity/RelaxedRuleExample.kt
@@ -1,0 +1,20 @@
+package io.github.santimattius.structured.sample.severity
+
+import io.github.santimattius.structured.annotations.StructuredScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+
+/**
+ * Scenario: Immediate-relaxation.
+ *
+ * Rule: `unusedDeferred` (marker `[SCOPE_002]`), default severity `"error"`.
+ * Configured: `structuredCoroutines { unusedDeferred.set("warning") }` in `build.gradle.kts`.
+ * Direction: relaxation — applies immediately, regardless of `severityEnforcement`. No
+ * grace-period advisory is ever logged for a relaxation.
+ *
+ * `./gradlew -p sample-severity compileKotlin` succeeds and reports a `w:`-prefixed line
+ * containing `[SCOPE_002]`.
+ */
+fun triggerUnusedDeferred(@StructuredScope scope: CoroutineScope) {
+    val deferred = scope.async { 42 }
+}

--- a/sample-severity/src/main/kotlin/io/github/santimattius/structured/sample/severity/TightenedRuleExample.kt
+++ b/sample-severity/src/main/kotlin/io/github/santimattius/structured/sample/severity/TightenedRuleExample.kt
@@ -1,0 +1,25 @@
+package io.github.santimattius.structured.sample.severity
+
+/**
+ * Scenario: Deferred-tightening (GRACE, default) / Immediate-tightening (`strict`).
+ *
+ * Rule: `loopWithoutYield` (marker `[CANCEL_001]`), default severity `"warning"`.
+ * Configured: `structuredCoroutines { loopWithoutYield.set("error") }` in `build.gradle.kts`.
+ * Direction: tightening — the only line in this sample sensitive to `severityEnforcement`.
+ *
+ * - GRACE (default, no `-PseverityEnforcement` property): `./gradlew -p sample-severity
+ *   compileKotlin` succeeds; `[CANCEL_001]` still reports as a `w:`-prefixed warning, and the
+ *   build additionally logs a grace-period advisory naming the rule, the configured `"error"`
+ *   value, the current `"warning"` behavior, and the future enforcing release.
+ * - STRICT (`./gradlew -p sample-severity compileKotlin -PseverityEnforcement=strict`): the
+ *   build FAILS, `[CANCEL_001]` reports as an `e:`-prefixed error, and no advisory is logged.
+ */
+private fun triggerLoopWithoutYieldWork() {
+    println("x")
+}
+
+suspend fun triggerLoopWithoutYield() {
+    while (true) {
+        triggerLoopWithoutYieldWork()
+    }
+}


### PR DESCRIPTION
## Summary

Adds `sample-severity/`, a standalone Gradle sample demonstrating the `structuredCoroutines { }` DSL's severity-enforcement options shipped by #68. Before this, the repo had zero runnable demonstration of that DSL — the existing `sample/` module applies the compiler plugin via a raw `-Xplugin=` arg and never touches the extension at all.

Demonstrates all four scenarios via one `structuredCoroutines { }` block plus a `-PseverityEnforcement` property toggle between two commands: `"disabled"` suppression, immediate relaxation, deferred tightening under the default `"grace"` policy (with the build advisory), and immediate tightening under `severityEnforcement = "strict"`.

Base is the tracker branch, not `main` — this consumes DSL behavior (`severityEnforcement`, twin factories, real `disabled` suppression) that only exists on `feat/severity-enforcement`, not yet on `main`.

Relates to #68.

## Type of change

- [x] Documentation

## Component(s)

- [x] Samples / tests
- [x] Docs / skill / rule manifest

## Test plan

```bash
./gradlew publishToMavenLocal
./gradlew -p sample-severity compileKotlin
./gradlew -p sample-severity compileKotlin -PseverityEnforcement=strict
```

Both re-verified fresh before this commit (cache-cleared re-run): Command A → BUILD SUCCESSFUL, `[SCOPE_001]` absent, `[SCOPE_002]` at `w:`, `[CANCEL_001]` at `w:`, advisory present naming `loopWithoutYield`/`"error"`/`"warning"`/`1.3.0`. Command B → BUILD FAILED, `[CANCEL_001]` at `e:`, advisory absent.

**Notable finding, documented not fixed**: in Command B's failing build, `[SCOPE_002]` (the still-relaxed rule) does not print at all — confirmed with and without `--info`. Kotlin 2.4.0's Build Tools API only surfaces the diagnostic that causes the failure. `sample-severity/README.md`'s "Empirical note" documents this. This exposes a real gap in `StructuredCoroutinesPluginFunctionalTest.kt` (never exercises a failing build mixing relaxed + tightened rules) — flagged as a follow-up, not addressed in this PR.

Full-repo regression check: `./gradlew testAll` green, unaffected (this module isn't wired into it).

## Checklist

- [x] Tests pass locally (relevant `./gradlew` tasks)
- [x] `CHANGELOG.md` updated for user-facing changes — none needed, doc-only addition, no production behavior change
- [x] Follows CONTRIBUTING.md guidelines

## Chain Context

| Field | Value |
|-------|-------|
| Chain | severity-enforcement (#68), follow-up |
| Tracker PR | feat/severity-enforcement (not yet opened — its own PR to `main` is a separate pending step) |
| Position | Follow-up, after PR1-3 |
| Base | `feat/severity-enforcement` |
| Depends on | PR #72/#73/#74 (already merged into this base) |
| Follow-up | None from this PR; a separate follow-up for `StructuredCoroutinesPluginFunctionalTest.kt`'s coverage gap is recommended but not tracked here |
| Review budget | 306 / 400 |
| Starts at | The fully-merged #68 feature on `feat/severity-enforcement` |
| Ends with | A standalone, doc-only sample proving the DSL's severity behavior end-to-end |

### Scope
- Includes: `sample-severity/` (own `settings.gradle.kts`/`build.gradle.kts`/`gradle.properties`/3 trigger source files/README/`.gitignore`), 2 new rows in root `README.md`
- Excludes: any change to `sample/`, root `settings.gradle.kts`/`build.gradle.kts` (byte-unchanged, verified), `testAll`, or any CI workflow

### Autonomy
- [x] CI is expected to pass for this PR branch (nothing new runs in CI; existing suites unaffected)
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes — `rm -rf sample-severity/` + revert the 2 README rows
- [x] Tests, docs, or manual verification cover this unit — manual verification via the exact commands above, independently re-run by both `sdd-apply` and `sdd-verify`
