### PR TITLE
fix(compiler): DISPATCH_003 and RUNBLOCK_001 never report diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [1.2.0] — Unreleased
 
+### Fixed
+
+- **DISPATCH_003 silent no-fire on `Dispatchers.Unconfined`** — `DispatchersUnconfinedChecker` matched the `Dispatchers` receiver against `FirPropertyAccessExpression`, but a resolved object reference (e.g. the `Dispatchers` in `Dispatchers.Unconfined`) surfaces as `FirResolvedQualifier` — so the check always returned false and the rule never fired, even for the exact pattern documented in its own KDoc. It now also resolves via `FirResolvedQualifier.classId`, with a `ConeClassLikeType` lookup-tag fallback for a receiver reached through a property alias. (#71)
+- **RUNBLOCK_001 silent no-fire on a single trailing `launch`** — `RedundantLaunchInCoroutineScopeChecker` cast the trailing lambda argument of `coroutineScope { }` directly to `FirBlock`, but it is actually wrapped in a `FirAnonymousFunctionExpression` whose `anonymousFunction.body` is the real block — so the cast always returned null and the rule never fired. The checker's statement counter also now unwraps `FirReturnExpression` (the implicit-return wrapper for a lambda's last expression) so a trailing `launch` reached via implicit return is counted correctly. (#71)
+
 ### Changed
 
 - **`"disabled"` severity now really suppresses diagnostics at compile time (#68)** — a `structuredCoroutines { <rule>.set("disabled") }` check no longer just records the value for `structuredCoroutinesReport`; it now actually skips reporting for that rule. This is a real (non-breaking) behavior change: builds that were previously still failing/warning on a check set to `"disabled"` will now pass cleanly for that check. The `PluginConfiguration` object is now injected into every checker via a bound member reference (replacing the internal `PluginConfigurationHolder` global), and the decorative build-time "disabled" advisory warning introduced in 1.1.1 has been removed, since its message is no longer accurate.

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/DispatchersUnconfinedChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/DispatchersUnconfinedChecker.kt
@@ -16,8 +16,12 @@ import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChec
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
-import org.jetbrains.kotlin.fir.expressions.FirQualifiedAccessExpression
+import org.jetbrains.kotlin.fir.expressions.FirResolvedQualifier
 import org.jetbrains.kotlin.fir.expressions.arguments
+import org.jetbrains.kotlin.fir.types.ConeClassLikeType
+import org.jetbrains.kotlin.fir.types.resolvedType
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
 /**
@@ -116,9 +120,12 @@ class DispatchersUnconfinedChecker(
         )
 
         /**
-         * Name of the Dispatchers object.
+         * ClassId for kotlinx.coroutines.Dispatchers.
          */
-        private val DISPATCHERS_NAME = Name.identifier("Dispatchers")
+        private val DISPATCHERS_CLASS_ID = ClassId(
+            FqName("kotlinx.coroutines"),
+            Name.identifier("Dispatchers"),
+        )
 
         /**
          * Name of the Unconfined property to detect.
@@ -152,16 +159,30 @@ class DispatchersUnconfinedChecker(
      */
     private fun isDispatchersUnconfined(expression: FirExpression): Boolean {
         // Check for property access like Dispatchers.Unconfined
-        if (expression is FirPropertyAccessExpression) {
-            val propertyName = expression.calleeReference.name
-            if (propertyName == UNCONFINED_NAME) {
-                // Check if the receiver is Dispatchers
-                val receiver = (expression as? FirQualifiedAccessExpression)?.explicitReceiver
-                if (receiver is FirPropertyAccessExpression) {
-                    return receiver.calleeReference.name == DISPATCHERS_NAME
-                }
-            }
+        if (expression !is FirPropertyAccessExpression) return false
+        if (expression.calleeReference.name != UNCONFINED_NAME) return false
+
+        // Check if the receiver resolves to the Dispatchers object
+        val receiver = expression.explicitReceiver ?: return false
+        return isDispatchersReceiver(receiver)
+    }
+
+    /**
+     * Checks whether [expression] resolves to the `kotlinx.coroutines.Dispatchers` object.
+     *
+     * Mirrors the verified precedent in `SuspendInFinallyChecker.isNonCancellable`: a resolved
+     * object reference (e.g. the `Dispatchers` in `Dispatchers.Unconfined`) surfaces as a
+     * [FirResolvedQualifier], not a [FirPropertyAccessExpression] as the previous implementation
+     * assumed — which made the check always return false. The [ConeClassLikeType.lookupTag]
+     * fallback additionally covers a [FirPropertyAccessExpression] receiver whose resolved type
+     * is `Dispatchers` (e.g. referenced through a property alias).
+     */
+    private fun isDispatchersReceiver(expression: FirExpression): Boolean {
+        if (expression is FirResolvedQualifier) {
+            return expression.classId == DISPATCHERS_CLASS_ID
         }
-        return false
+
+        val classId = (expression.resolvedType as? ConeClassLikeType)?.lookupTag?.classId
+        return classId == DISPATCHERS_CLASS_ID
     }
 }

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/RedundantLaunchInCoroutineScopeChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/RedundantLaunchInCoroutineScopeChecker.kt
@@ -13,9 +13,11 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
+import org.jetbrains.kotlin.fir.expressions.FirAnonymousFunctionExpression
 import org.jetbrains.kotlin.fir.expressions.FirBlock
 import org.jetbrains.kotlin.fir.expressions.FirDoWhileLoop
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirReturnExpression
 import org.jetbrains.kotlin.fir.expressions.FirStatement
 import org.jetbrains.kotlin.fir.expressions.FirWhileLoop
 import org.jetbrains.kotlin.name.Name
@@ -102,19 +104,20 @@ class RedundantLaunchInCoroutineScopeChecker(
     /**
      * Gets the lambda block from the coroutineScope call.
      *
+     * Mirrors the verified precedent in `CallbackFlowWithoutAwaitCloseChecker.getTrailingLambdaBlock`:
+     * a trailing lambda argument is wrapped as a [FirAnonymousFunctionExpression] whose
+     * `anonymousFunction.body` is the actual [FirBlock] — casting the argument directly to
+     * [FirBlock] (the previous implementation) always yields null.
+     *
      * @param call The coroutineScope call
      * @return The block expression, or null if not found
      */
     private fun getLambdaBlock(call: FirFunctionCall): FirBlock? {
-        // The lambda is typically the last argument
-        val arguments = call.argumentList.arguments
-        if (arguments.isEmpty()) return null
+        // Get the last argument (the trailing lambda)
+        val lambdaArg = call.argumentList.arguments.lastOrNull() ?: return null
 
-        // Get the last argument (the lambda)
-        val lambdaArg = arguments.lastOrNull() ?: return null
-
-        // The lambda body is a FirBlock
-        return lambdaArg as? FirBlock
+        (lambdaArg as? FirBlock)?.let { return it }
+        return (lambdaArg as? FirAnonymousFunctionExpression)?.anonymousFunction?.body as? FirBlock
     }
 
     /**
@@ -166,6 +169,15 @@ class RedundantLaunchInCoroutineScopeChecker(
                 return BuilderCountResult(launchCount, asyncCount, singleLaunchInsideRepeating)
             }
             is FirBlock -> return countBuildersAndRepeating(statement, insideRepeating)
+            is FirReturnExpression -> {
+                // The last statement of a lambda body is desugared into an implicit
+                // `return <lastExpression>` (FirReturnExpression) wrapping that expression, e.g.
+                // in `coroutineScope { launch { } }` the block's only statement is this wrapper,
+                // not a bare FirFunctionCall — so a trailing launch/async must be unwrapped here
+                // or it silently drops out of the count (and, worse, throws off the counting of
+                // any builder before it, since a truthful count requires this to still be seen).
+                return countBuildersInStatement(statement.result, insideRepeating)
+            }
             is FirWhileLoop -> {
                 val body = statement.block ?: return BuilderCountResult(0, 0, false)
                 return countBuildersAndRepeating(body, insideRepeating = true)

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -412,7 +412,7 @@ class StructuredCoroutinesPluginFunctionalTest {
             import kotlinx.coroutines.Dispatchers
             import kotlinx.coroutines.launch
             import io.github.santimattius.structured.annotations.StructuredScope
-            
+
             fun test(@StructuredScope scope: CoroutineScope) {
                 scope.launch(Dispatchers.Unconfined) {
                     println("Warning!")
@@ -423,10 +423,119 @@ class StructuredCoroutinesPluginFunctionalTest {
         val projectDir = createTestProject(sourceCode)
         // Should succeed (warning, not error) - compilation completes
         val output = runBuild(projectDir, expectSuccess = true)
-        
+
         // Build should succeed even with warning
         assertTrue("BUILD SUCCESSFUL" in output || "compileKotlin" in output,
             "Expected successful build but got:\n$output")
+
+        // Regression test for #71: DispatchersUnconfinedChecker.isDispatchersUnconfined() used to
+        // cast the `Dispatchers` receiver to FirPropertyAccessExpression, but a resolved object
+        // reference surfaces as FirResolvedQualifier — so the check was always false and
+        // DISPATCH_003 never fired for this exact shape.
+        assertTrue(
+            "[DISPATCH_003]" in output,
+            "Expected [DISPATCH_003] (dispatchersUnconfined) for Dispatchers.Unconfined but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `fully-qualified Dispatchers Unconfined reference fires DISPATCH_003`() {
+        val sourceCode = """
+            import kotlinx.coroutines.CoroutineScope
+            import kotlinx.coroutines.launch
+            import io.github.santimattius.structured.annotations.StructuredScope
+
+            fun test(@StructuredScope scope: CoroutineScope) {
+                scope.launch(kotlinx.coroutines.Dispatchers.Unconfined) {
+                    println("Warning!")
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        // Regression test for #71: the fully-qualified spelling must resolve to the same
+        // ClassId as the imported short-name form and trigger DISPATCH_003 identically.
+        assertTrue(
+            "[DISPATCH_003]" in output,
+            "Expected [DISPATCH_003] (dispatchersUnconfined) for fully-qualified kotlinx.coroutines.Dispatchers.Unconfined but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `Dispatchers IO and Default do not trigger DISPATCH_003`() {
+        val sourceCode = """
+            import kotlinx.coroutines.CoroutineScope
+            import kotlinx.coroutines.Dispatchers
+            import kotlinx.coroutines.launch
+            import io.github.santimattius.structured.annotations.StructuredScope
+
+            fun test(@StructuredScope scope: CoroutineScope) {
+                scope.launch(Dispatchers.IO) {
+                    println("IO")
+                }
+                scope.launch(Dispatchers.Default) {
+                    println("Default")
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "[DISPATCH_003]" !in output,
+            "Expected no [DISPATCH_003] for Dispatchers.IO/Default but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `single launch on the last line of coroutineScope produces RUNBLOCK_001 warning`() {
+        val sourceCode = """
+            import kotlinx.coroutines.coroutineScope
+            import kotlinx.coroutines.launch
+
+            suspend fun test() = coroutineScope {
+                launch { println("Warning!") }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue("BUILD SUCCESSFUL" in output || "compileKotlin" in output,
+            "Expected successful build but got:\n$output")
+
+        // Regression test for #71: RedundantLaunchInCoroutineScopeChecker.getLambdaBlock() used to
+        // cast the trailing lambda argument directly to FirBlock, but it is actually wrapped as a
+        // FirAnonymousFunctionExpression whose anonymousFunction.body is the FirBlock — so the
+        // cast always yielded null and RUNBLOCK_001 never fired.
+        assertTrue(
+            "[RUNBLOCK_001]" in output,
+            "Expected [RUNBLOCK_001] (redundantLaunchInCoroutineScope) for a single launch but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `two launches in coroutineScope do not trigger RUNBLOCK_001`() {
+        val sourceCode = """
+            import kotlinx.coroutines.coroutineScope
+            import kotlinx.coroutines.launch
+
+            suspend fun test() = coroutineScope {
+                launch { println("one") }
+                launch { println("two") }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "[RUNBLOCK_001]" !in output,
+            "Expected no [RUNBLOCK_001] for two launches but got:\n$output"
+        )
     }
 
     // ============================================================================
@@ -1276,29 +1385,29 @@ class StructuredCoroutinesPluginFunctionalTest {
     // catalog (CompilerBundle.properties:7,11), so this list's shared marker's presence/absence
     // proves both rules together.
     //
-    // EXCLUDES dispatchersUnconfined ("[DISPATCH_003]") and redundantLaunchInCoroutineScope
-    // ("[RUNBLOCK_001]"): manually isolated during this task (outside GradleRunner, via a plain
-    // `gradlew compileKotlin` invocation against the published plugin jar) and confirmed that
-    // `DispatchersUnconfinedChecker`/`RedundantLaunchInCoroutineScopeChecker` never report at all,
-    // even for the exact trigger shape documented in their own KDoc and in the pre-existing
-    // (assertion-free) `Dispatchers Unconfined produces warning but compiles` test. This is a
-    // pre-existing bug in the checkers' own detection logic — present in the released 1.1.1 jar,
-    // byte-identical in this session's diff except for the constructor/report-call-site changes —
-    // not something introduced by, or in scope for, PR2 (injection + disabled enforcement only).
-    // The config-resolution side for both rules IS still proven correct by
-    // `PluginConfigurationEffectiveSeverityTest` (all 14 rules, including these 2) and both
-    // `reportDispatchersUnconfinedUsage`/`reportRedundantLaunchInCoroutineScope` are wired to
-    // `config.report(...)` with the exact same shape as the other 12 rules that ARE proven live
-    // here. Flagged as a risk/follow-up for sdd-verify and a separate GitHub issue.
+    // dispatchersUnconfined ("[DISPATCH_003]") and redundantLaunchInCoroutineScope
+    // ("[RUNBLOCK_001]") are included below. They used to be excluded because
+    // `DispatchersUnconfinedChecker`/`RedundantLaunchInCoroutineScopeChecker` never reported at
+    // all (see issue #71): the former matched the `Dispatchers` receiver against
+    // FirPropertyAccessExpression when a resolved object reference actually surfaces as
+    // FirResolvedQualifier, and the latter cast the trailing lambda argument directly to FirBlock
+    // when it is really wrapped in a FirAnonymousFunctionExpression. Both are now fixed and
+    // proven live here, and standalone positive/negative-case coverage lives in
+    // `Dispatchers Unconfined produces warning but compiles`,
+    // `Dispatchers IO and Default do not trigger DISPATCH_003`,
+    // `single launch on the last line of coroutineScope produces RUNBLOCK_001 warning`, and
+    // `two launches in coroutineScope do not trigger RUNBLOCK_001`.
     private val allRuleDiagnosticMarkers = listOf(
         "[SCOPE_001]", // globalScopeUsage
         "[SCOPE_003]", // unstructuredLaunch + inlineCoroutineScope (shared code)
         "[RUNBLOCK_002]", // runBlockingInSuspend
         "[DISPATCH_004]", // jobInBuilderContext
+        "[DISPATCH_003]", // dispatchersUnconfined
         "[EXCEPT_002]", // cancellationExceptionSubclass
         "[CANCEL_004]", // suspendInFinally
         "[CANCEL_003]", // cancellationExceptionSwallowed
         "[SCOPE_002]", // unusedDeferred
+        "[RUNBLOCK_001]", // redundantLaunchInCoroutineScope
         "[CANCEL_001]", // loopWithoutYield
         "[INTEROP_001]", // suspendCoroutineWithoutCancellation
         "[INTEROP_002]", // callbackFlowWithoutAwaitClose
@@ -1473,12 +1582,14 @@ class StructuredCoroutinesPluginFunctionalTest {
         }
     """.trimIndent()
 
-    // Excludes "[DISPATCH_003]" (dispatchersUnconfined) and "[RUNBLOCK_001]"
-    // (redundantLaunchInCoroutineScope) — see the exclusion note on allRuleDiagnosticMarkers
-    // above; both checkers were confirmed (independent of this PR) to never report at all.
+    // "[DISPATCH_003]" (dispatchersUnconfined) and "[RUNBLOCK_001]"
+    // (redundantLaunchInCoroutineScope) are included below — see the note on
+    // allRuleDiagnosticMarkers above; both checkers are now fixed (issue #71).
     private val warningDefaultRuleMarkers = listOf(
+        "[DISPATCH_003]", // dispatchersUnconfined
         "[CANCEL_004]", // suspendInFinally
         "[CANCEL_003]", // cancellationExceptionSwallowed
+        "[RUNBLOCK_001]", // redundantLaunchInCoroutineScope
         "[CANCEL_001]", // loopWithoutYield
     )
 


### PR DESCRIPTION
## Summary

- `DispatchersUnconfinedChecker` (DISPATCH_003) matched the `Dispatchers` receiver against `FirPropertyAccessExpression`, but a resolved singleton object reference surfaces as `FirResolvedQualifier`, so the check was always `false` and the rule never fired. Fixed by resolving the receiver's real `ClassId`, same pattern used for `NonCancellable` in #65.
- `RedundantLaunchInCoroutineScopeChecker` (RUNBLOCK_001) had two stacked bugs: the trailing lambda argument was cast directly to `FirBlock` (always `null` — needs unwrapping through `FirAnonymousFunctionExpression`), and the builder-counting walk didn't unwrap `FirReturnExpression`, so a lambda's desugared trailing statement (Kotlin's implicit `return <lastExpr>`) was never counted.

Closes #71

## Type of change

- [x] Bug fix

## Component(s)

- [x] Compiler plugin
- [x] Samples / tests
- [x] Docs / skill / rule manifest

## Test plan

```bash
./gradlew :compiler:test --rerun-tasks
```

- 93/93 tests passing, 0 failures, 0 regressions (independently re-run twice with `--rerun-tasks` to bypass Gradle's UP-TO-DATE cache).
- New regression tests cover both positive and negative cases for each rule: `Dispatchers.Unconfined` (short + fully-qualified form) fires DISPATCH_003; `Dispatchers.IO`/`Dispatchers.Default` don't; a single trailing `launch` in `coroutineScope` fires RUNBLOCK_001; two `launch`es don't.

## Checklist

- [x] Tests pass locally (relevant `./gradlew` tasks)
- [x] New/changed rules updated in `docs/rule-codes.yml` and samples where applicable (rule codes unchanged, detection logic only)
- [x] `CHANGELOG.md` updated for user-facing changes
- [x] Follows CONTRIBUTING.md guidelines