### PR TITLE
fix(docs): correct CANCEL_001/ARCH_002 coverage and dedupe CANCEL_006

### DIFF
--- a/docs/rule-codes.yml
+++ b/docs/rule-codes.yml
@@ -90,10 +90,10 @@ rules:
     section: "4.1"
     title: "Ignoring Cancellation in Intensive Loops"
     doc_anchor: "41-cancel_001--ignoring-cancellation-in-intensive-loops"
-    compiler: []
+    compiler: [LOOP_WITHOUT_YIELD]
     detekt: [LoopWithoutYield]
     lint: [LoopWithoutYield]
-    intellij: []
+    intellij: [LoopWithoutYield]
     default_severity: warning
 
   - code: CANCEL_003
@@ -174,8 +174,8 @@ rules:
     doc_anchor: "82-lifecycle-aware-flow-collection-android"
     compiler: []
     detekt: []
-    lint: [LifecycleAwareScope, ViewModelScopeLeak]
-    intellij: []
+    lint: [LifecycleAwareScope, ViewModelScopeLeak, LifecycleAwareFlowCollection]
+    intellij: [LifecycleAwareFlowCollection]
     default_severity: warning
     notes: "Android-only; not implemented in Detekt or Compiler."
 
@@ -469,16 +469,6 @@ rules:
     intellij: []
     default_severity: warning
     notes: "Documentation and skill guidance; heuristic inspections optional."
-
-  - code: CANCEL_006
-    section: "4.6"
-    title: "withTimeout and Scope Cancellation"
-    doc_anchor: "46-cancel_006--withtimeout-and-scope-cancellation"
-    compiler: []
-    detekt: [WithTimeoutScopeCancellation]
-    lint: []
-    intellij: [WithTimeoutScopeCancellation]
-    default_severity: warning
 
   - code: EXCEPT_001
     section: "5.1"


### PR DESCRIPTION
## Summary

- `docs/rule-codes.yml` under-reported real coverage for CANCEL_001 (missing `compiler: [LOOP_WITHOUT_YIELD]` and `intellij: [LoopWithoutYield]`, both fully implemented) and ARCH_002 (missing the `LifecycleAwareFlowCollection` lint detector ID and its IntelliJ inspection coverage).
- Removed a literal duplicate `CANCEL_006` entry (kept the complete one with the `notes:` field).

Relates to #79 (part 1 of the toolkit-parity-audit PR chain — targets tracker branch `feat/toolkit-parity-audit`, not `main`).

## Type of change

- [x] Documentation

## Component(s)

- [x] Docs / skill / rule manifest

## Test plan

```bash
python3 -c "import yaml; yaml.safe_load(open('docs/rule-codes.yml'))"
```

- YAML parses cleanly, 50 unique rule entries (was 51 raw entries with 1 duplicate).
- Every corrected coverage claim independently verified against real source (`ScoroutinesRule.kt`, `plugin.xml`, `LifecycleAwareFlowCollectionDetector.kt`) before editing — no blind-apply.

## Checklist

- [x] Tests pass locally (relevant `./gradlew` tasks) — N/A, doc-only change, YAML validated instead
- [x] New/changed rules updated in `docs/rule-codes.yml` and samples where applicable
- [x] `CHANGELOG.md` updated for user-facing changes — N/A, internal manifest accuracy fix, not user-facing behavior
- [x] Follows CONTRIBUTING.md guidelines