### PR TITLE
docs: consolidate RULES_SYNC_COMPARISON.md into a redirect stub

### DIFF
--- a/docs/RULES_SYNC_COMPARISON.md
+++ b/docs/RULES_SYNC_COMPARISON.md
@@ -1,126 +1,19 @@
 # Rule coverage: Compiler, Detekt, and Lint
 
-This document describes **what each tool covers** and **its limitations** for structured-coroutines rules. Use it to choose the right tool(s) and to look up suppression IDs.
+This document is retired. It used to maintain an independent per-rule coverage
+matrix across the Compiler plugin, Detekt, and Android Lint, but that matrix
+regularly drifted out of sync with the real rule registries.
 
-**References:** [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md) (suppression IDs per tool), [BEST_PRACTICES_COROUTINES.md](BEST_PRACTICES_COROUTINES.md) (rule codes and practices), [rule-codes.yml](rule-codes.yml) (canonical list of codes and IDs).
+Rule coverage and suppression IDs now live in two actively maintained sources
+instead of a fourth, duplicated one:
 
----
+- **Rule codes, descriptions, and per-practice guidance**:
+  [BEST_PRACTICES_COROUTINES.md](BEST_PRACTICES_COROUTINES.md)
+- **Suppression IDs per tool (Compiler, Detekt, Lint, IntelliJ)**:
+  [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md)
+- **Canonical machine-readable list of codes, severities, and per-tool
+  coverage**: [rule-codes.yml](rule-codes.yml)
 
-## 1. Coverage matrix (by rule code)
-
-| Rule code | Practice | Compiler | Detekt | Lint |
-|-----------|----------|:--------:|:------:|:----:|
-| SCOPE_001 | GlobalScope usage | ✅ | ✅ | ✅ |
-| SCOPE_002 | async without await | ✅ | ✅ | ✅ |
-| SCOPE_003 | Inline scope / unstructured launch | ✅ | ✅ | ✅ |
-| RUNBLOCK_001 | Redundant launch in coroutineScope | ✅ | ✅ | ✅ |
-| RUNBLOCK_002 | runBlocking in suspend | ✅ | ✅ | ✅ |
-| DISPATCH_001 | Blocking call in coroutine | — | ✅ | ✅ |
-| DISPATCH_003 | Dispatchers.Unconfined | ✅ | ✅ | ✅ |
-| DISPATCH_004 | Job() in builder context | ✅ | ✅ | ✅ |
-| CANCEL_003 | Swallowing CancellationException | ✅ | ✅ | ✅ |
-| CANCEL_004 | Suspend in finally without NonCancellable | ✅ | ✅ | ✅ |
-| CANCEL_005 | Scope reuse after cancel | — | ✅ | ✅ |
-| CANCEL_001 | Loop without yield | — | ✅ | ✅ |
-| EXCEPT_002 | CancellationException subclass | ✅ | ✅ | ✅ |
-| TEST_001 | runBlocking + delay in test | — | ✅ | ✅ |
-| ARCH_002 | Lifecycle-aware scope (Android) | — | — | ✅ |
-
-**Legend:** ✅ = implemented; — = not implemented.
-
----
-
-## 2. Compiler plugin
-
-### What it covers
-
-Reports at **compile time** (all platforms):
-
-- **SCOPE_001** — GlobalScope.launch/async  
-- **SCOPE_002** — async without await  
-- **SCOPE_003** — Inline scope (e.g. `CoroutineScope(...).launch`) and launch on scopes not annotated with `@StructuredScope`  
-- **RUNBLOCK_001** — Redundant launch in coroutineScope/supervisorScope  
-- **RUNBLOCK_002** — runBlocking in suspend functions  
-- **DISPATCH_003** — Dispatchers.Unconfined  
-- **DISPATCH_004** — Job()/SupervisorJob() in builder context  
-- **CANCEL_003** — catch(Exception) that may swallow CancellationException  
-- **CANCEL_004** — Suspend calls in finally without withContext(NonCancellable)  
-- **EXCEPT_002** — Class extends CancellationException  
-
-### Limitations
-
-| Limitation | Reason |
-|------------|--------|
-| No DISPATCH_001 (blocking in coroutine) | Would require blocking-call and coroutine-context analysis; not in scope for the compiler plugin. |
-| No CANCEL_001 (loop without yield) | Needs control-flow heuristics; implemented in static analyzers instead. |
-| No CANCEL_005 (scope reuse after cancel) | Requires data-flow/usage analysis. |
-| No TEST_001 (runBlocking + delay in tests) | Would require test-file or test-symbol awareness. |
-| No ARCH_002 (Android lifecycle) | Platform-specific; compiler is multiplatform. |
-| SCOPE_003 | Compiler enforces **@StructuredScope**; Detekt/Lint use heuristics (e.g. external scope from suspend, inline scope). Compiler is stricter. |
-
----
-
-## 3. Detekt
-
-### What it covers
-
-All rules that the compiler covers (see §2), plus:
-
-- **DISPATCH_001** — Blocking call in coroutine (e.g. `Thread.sleep`) — rule name: `BlockingCallInCoroutine`  
-- **CANCEL_001** — Loop without cooperation point — `LoopWithoutYield`  
-- **CANCEL_005** — Scope reuse after cancel — `ScopeReuseAfterCancel`  
-- **TEST_001** — runBlocking + delay in test code — `RunBlockingWithDelayInTest`  
-
-Runs on **Kotlin** (JVM, MPP, etc.); no Android SDK.
-
-### Limitations
-
-| Limitation | Reason |
-|------------|--------|
-| No ARCH_002 (LifecycleAwareScope, ViewModelScopeLeak) | Android-specific (Lifecycle, ViewModel); Detekt is generic Kotlin. |
-| SCOPE_003 | Implements **InlineCoroutineScope** and **ExternalScopeLaunch** (heuristics). Does **not** check @StructuredScope like the compiler. |
-
----
-
-## 4. Android Lint
-
-### What it covers
-
-All rules that Detekt covers for structured-coroutines, plus:
-
-- **ARCH_002** — Lifecycle-aware scope / ViewModelScope leak — `LifecycleAwareScope`, `ViewModelScopeLeak` (Android only).
-
-Runs in **Android** (and Android-aware Gradle) projects.
-
-### Limitations
-
-| Limitation | Reason |
-|------------|--------|
-| Android only | Does not run for plain JVM/MPP modules without Android. |
-| DISPATCH_001 | Lint uses **MainDispatcherMisuse** (main-thread blocking); Detekt uses **BlockingCallInCoroutine** (broader list). Semantics are similar but not identical. |
-| Some rules | IntelliJ inspections may not exist for RUNBLOCK_001, CANCEL_001, TEST_001; see [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md). |
-
----
-
-## 5. Naming differences (suppression IDs)
-
-Same practice can have different IDs per tool. When suppressing, use the ID of the **tool that reports** (see [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md)).
-
-| Rule code | Compiler | Detekt | Lint |
-|-----------|----------|--------|------|
-| SCOPE_002 | `UNUSED_DEFERRED` | `UnusedDeferred` | `AsyncWithoutAwait` |
-| SCOPE_003 | `UNSTRUCTURED_COROUTINE_LAUNCH`, `INLINE_COROUTINE_SCOPE` | `ExternalScopeLaunch`, `InlineCoroutineScope` | `UnstructuredLaunch`, `InlineCoroutineScope` |
-| DISPATCH_001 | — | `BlockingCallInCoroutine` | `MainDispatcherMisuse` |
-
----
-
-## 6. When to use which tool
-
-| Goal | Use |
-|------|-----|
-| Enforce at compile time, all platforms | **Compiler** (via [Gradle plugin](../gradle-plugin/README.md)) |
-| Kotlin JVM/MPP without Android | **Detekt** (optionally with Compiler) |
-| Android app or library | **Lint** (optionally with Compiler and Detekt) |
-| Scope reuse after cancel (CANCEL_005) | **Detekt** or **Lint** |
-| Lifecycle/ViewModel scope (ARCH_002) | **Lint** only (Android) |
-| @StructuredScope enforcement (SCOPE_003) | **Compiler** only (Detekt/Lint use heuristics) |
+If you were looking for which tool implements a given rule code, or its
+suppression identifier, start with `rule-codes.yml` and cross-reference
+`SUPPRESSING_RULES.md`.

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -198,7 +198,7 @@ For a full migration path (relaxed → gradual → strict) and suppression best 
 
 ### Single entry point for rules
 
-This plugin is the **recommended single entry point** for structured-coroutines: it applies the Kotlin compiler plugin and fits into the same project as **Detekt** and **Android Lint**. For consistent behavior across tools, keep severity choices aligned (e.g. use the same error/warning level for a given rule in the plugin and in `detekt.yml` / Lint config). Rule codes and suppression IDs are listed in [docs/rule-codes.yml](../docs/rule-codes.yml) and [docs/RULES_SYNC_COMPARISON.md](../docs/RULES_SYNC_COMPARISON.md).
+This plugin is the **recommended single entry point** for structured-coroutines: it applies the Kotlin compiler plugin and fits into the same project as **Detekt** and **Android Lint**. For consistent behavior across tools, keep severity choices aligned (e.g. use the same error/warning level for a given rule in the plugin and in `detekt.yml` / Lint config). Rule codes are listed in [docs/rule-codes.yml](../docs/rule-codes.yml) and per-tool suppression IDs in [docs/SUPPRESSING_RULES.md](../docs/SUPPRESSING_RULES.md).
 
 ---
 


### PR DESCRIPTION
## Summary

- `docs/RULES_SYNC_COMPARISON.md` only covered ~15 of ~50 rule codes and had drifted stale (it repeated the CANCEL_001 coverage error fixed in the previous PR of this chain). Replaced it with a redirect stub pointing at `docs/rule-codes.yml`, `docs/BEST_PRACTICES_COROUTINES.md`, and `docs/SUPPRESSING_RULES.md` — both already accurate and covering all rule codes — instead of maintaining a fourth, competing source of truth.
- Retargeted the one inbound link (`gradle-plugin/README.md:201`) directly to `SUPPRESSING_RULES.md`.

Relates to #79 (part 2 of the toolkit-parity-audit PR chain — targets `fix/rule-manifest-accuracy`, part 1).

## Type of change

- [x] Documentation

## Component(s)

- [x] Docs / skill / rule manifest

## Test plan

- N/A — doc-only change. Verified full-repo grep found no other inbound links to the old doc besides the one updated.

## Checklist

- [x] Tests pass locally (relevant `./gradlew` tasks) — N/A, doc-only
- [x] New/changed rules updated in `docs/rule-codes.yml` and samples where applicable — N/A
- [x] `CHANGELOG.md` updated for user-facing changes — N/A, internal doc reorganization, not user-facing behavior
- [x] Follows CONTRIBUTING.md guidelines