### PR TITLE
fix(detekt,lint): prune nested declarations in LOOP_WITHOUT_YIELD checks

### DIFF
--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -1031,6 +1031,59 @@ class StructuredCoroutinesPluginFunctionalTest {
     }
 
     @Test
+    fun `loop with a called local suspend fun does not report LOOP_WITHOUT_YIELD`() {
+        // Negative counterpart to the test above: `helper()` is now called on every iteration,
+        // so `delay(1)` genuinely executes as a cooperation point. The call site is resolved via
+        // real FIR symbol resolution (`isSuspendCall`), so pruning the declaration itself must
+        // not suppress detection of this call.
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun loopWithCalledLocalSuspendFun() {
+                while (true) {
+                    suspend fun helper() {
+                        delay(1)
+                    }
+                    helper()
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for a loop with a called local suspend fun but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `loop with a real top-level delay call does not report LOOP_WITHOUT_YIELD`() {
+        // Sanity/regression guard: the most basic passing case (a direct cooperation-point call
+        // in the loop body, no nested declaration involved) must keep passing after pruning is
+        // introduced.
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun loopWithTopLevelDelay() {
+                while (true) {
+                    delay(10)
+                    break
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for a loop with a real top-level delay call but got:\n$output"
+        )
+    }
+
+    @Test
     fun `val initializer, statement, and assignment cooperation points together suppress LOOP_WITHOUT_YIELD`() {
         // Literal reproduction of https://github.com/santimattius/structured-coroutines/issues/66
         // (function names a/b/c preserved from the issue). `readAvailable`/`flush` stand in for

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/LoopWithoutYieldRule.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/LoopWithoutYieldRule.kt
@@ -20,11 +20,13 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtForExpression
 import org.jetbrains.kotlin.psi.KtLoopExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 import org.jetbrains.kotlin.psi.KtWhileExpression
-import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 /**
@@ -120,11 +122,7 @@ class LoopWithoutYieldRule(config: Config = Config.empty) : Rule(config) {
 
         // Check if the loop body contains any cooperation points
         val loopBody = loop.body ?: return
-        val callExpressions = loopBody.collectDescendantsOfType<KtCallExpression>()
-        
-        val hasCooperationPoint = callExpressions.any { call ->
-            CoroutineDetektUtils.isCooperationPoint(call) || isSuspendCall(call)
-        }
+        val hasCooperationPoint = bodyHasCooperationPoint(loopBody)
 
         if (!hasCooperationPoint) {
             val loopType = when (loop) {
@@ -156,7 +154,7 @@ class LoopWithoutYieldRule(config: Config = Config.empty) : Rule(config) {
      */
     private fun isSuspendCall(call: KtCallExpression): Boolean {
         val calleeName = call.calleeExpression?.text ?: return false
-        
+
         // Common suspend function naming patterns
         return calleeName.startsWith("await") ||
             calleeName.startsWith("suspend") ||
@@ -168,5 +166,47 @@ class LoopWithoutYieldRule(config: Config = Config.empty) : Rule(config) {
             calleeName == "collect" ||
             calleeName == "send" ||
             calleeName == "receive"
+    }
+
+    /**
+     * Deep, structural search for a cooperation point anywhere in [body]'s statement tree —
+     * mirrors the compiler's [io.github.santimattius.structured.compiler.LoopWithoutYieldChecker]
+     * `CooperationPointFinder` (#66) so the two surfaces stay in parity.
+     */
+    private fun bodyHasCooperationPoint(body: KtExpression): Boolean {
+        val finder = CooperationPointFinder()
+        body.accept(finder)
+        return finder.found
+    }
+
+    /**
+     * Depth-first walk over a loop body that short-circuits as soon as a cooperation point is
+     * found anywhere in the statement tree.
+     *
+     * Pruning policy: named function/property-accessor *declarations* are not descended into — a
+     * local `suspend fun helper() { delay(1) }` that is declared but never called inside the loop
+     * must not suppress the diagnostic (see #66). Anonymous functions (`fun() { }`, a nameless
+     * [KtNamedFunction]) and lambda bodies are NOT pruned and are still searched, since they
+     * execute inline at their call site (e.g. a lambda passed to `run { }`).
+     */
+    private inner class CooperationPointFinder : KtTreeVisitorVoid() {
+        var found: Boolean = false
+            private set
+
+        override fun visitNamedFunction(function: KtNamedFunction) {
+            if (function.name != null) return // prune declaration, keep anonymous fun
+            super.visitNamedFunction(function)
+        }
+
+        override fun visitPropertyAccessor(accessor: KtPropertyAccessor) = Unit // prune
+
+        override fun visitCallExpression(expression: KtCallExpression) {
+            if (found) return
+            if (CoroutineDetektUtils.isCooperationPoint(expression) || isSuspendCall(expression)) {
+                found = true
+                return
+            }
+            super.visitCallExpression(expression)
+        }
     }
 }

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/LoopWithoutYieldRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/LoopWithoutYieldRuleTest.kt
@@ -109,6 +109,62 @@ class LoopWithoutYieldRuleTest {
     }
 
     @Test
+    fun `reports loop with only an uncalled local suspend fun containing delay (spike, #66 divergence)`() {
+        // SPIKE: unlike the compiler checker (which prunes nested FirNamedFunction/
+        // FirPropertyAccessor declarations, see #66), this rule's unpruned
+        // collectDescendantsOfType<KtCallExpression>() walk over the whole loop body finds
+        // `delay(1)` inside the *declared-but-never-called* local `helper()` and mistakes it
+        // for a real cooperation point. `helper()` is dead code: `delay(1)` never executes
+        // during loop iterations, so this while loop still busy-loops and SHOULD be reported.
+        val code = """
+            import kotlinx.coroutines.*
+
+            suspend fun processItems() {
+                var i = 0
+                while (i < 100) {
+                    suspend fun helper() {
+                        delay(1)
+                    }
+                    println(i)
+                    i++
+                }
+            }
+        """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `does not report loop when the local suspend fun cooperation point is actually called`() {
+        // Negative counterpart to the spike above: `fetchData()` is now called on every
+        // iteration, so `delay(1)` genuinely executes as a cooperation point. Pruning the
+        // declaration must not suppress detection of the call site itself. The call is named
+        // `fetchData` (matching `isSuspendCall`'s "fetch" naming heuristic) rather than `helper`,
+        // since this rule's suspend-call detection is a naming heuristic, not real type
+        // resolution — an arbitrarily-named call is not something this rule can recognize as a
+        // cooperation point regardless of pruning.
+        val code = """
+            import kotlinx.coroutines.*
+
+            suspend fun processItems() {
+                var i = 0
+                while (i < 100) {
+                    suspend fun fetchData() {
+                        delay(1)
+                    }
+                    fetchData()
+                    println(i)
+                    i++
+                }
+            }
+        """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
     fun `does not report loop in non-suspend function`() {
         val code = """
             fun processItems(items: List<Int>) {

--- a/docs/RULES_SYNC_COMPARISON.md
+++ b/docs/RULES_SYNC_COMPARISON.md
@@ -1,126 +1,19 @@
 # Rule coverage: Compiler, Detekt, and Lint
 
-This document describes **what each tool covers** and **its limitations** for structured-coroutines rules. Use it to choose the right tool(s) and to look up suppression IDs.
+This document is retired. It used to maintain an independent per-rule coverage
+matrix across the Compiler plugin, Detekt, and Android Lint, but that matrix
+regularly drifted out of sync with the real rule registries.
 
-**References:** [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md) (suppression IDs per tool), [BEST_PRACTICES_COROUTINES.md](BEST_PRACTICES_COROUTINES.md) (rule codes and practices), [rule-codes.yml](rule-codes.yml) (canonical list of codes and IDs).
+Rule coverage and suppression IDs now live in two actively maintained sources
+instead of a fourth, duplicated one:
 
----
+- **Rule codes, descriptions, and per-practice guidance**:
+  [BEST_PRACTICES_COROUTINES.md](BEST_PRACTICES_COROUTINES.md)
+- **Suppression IDs per tool (Compiler, Detekt, Lint, IntelliJ)**:
+  [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md)
+- **Canonical machine-readable list of codes, severities, and per-tool
+  coverage**: [rule-codes.yml](rule-codes.yml)
 
-## 1. Coverage matrix (by rule code)
-
-| Rule code | Practice | Compiler | Detekt | Lint |
-|-----------|----------|:--------:|:------:|:----:|
-| SCOPE_001 | GlobalScope usage | ✅ | ✅ | ✅ |
-| SCOPE_002 | async without await | ✅ | ✅ | ✅ |
-| SCOPE_003 | Inline scope / unstructured launch | ✅ | ✅ | ✅ |
-| RUNBLOCK_001 | Redundant launch in coroutineScope | ✅ | ✅ | ✅ |
-| RUNBLOCK_002 | runBlocking in suspend | ✅ | ✅ | ✅ |
-| DISPATCH_001 | Blocking call in coroutine | — | ✅ | ✅ |
-| DISPATCH_003 | Dispatchers.Unconfined | ✅ | ✅ | ✅ |
-| DISPATCH_004 | Job() in builder context | ✅ | ✅ | ✅ |
-| CANCEL_003 | Swallowing CancellationException | ✅ | ✅ | ✅ |
-| CANCEL_004 | Suspend in finally without NonCancellable | ✅ | ✅ | ✅ |
-| CANCEL_005 | Scope reuse after cancel | — | ✅ | ✅ |
-| CANCEL_001 | Loop without yield | — | ✅ | ✅ |
-| EXCEPT_002 | CancellationException subclass | ✅ | ✅ | ✅ |
-| TEST_001 | runBlocking + delay in test | — | ✅ | ✅ |
-| ARCH_002 | Lifecycle-aware scope (Android) | — | — | ✅ |
-
-**Legend:** ✅ = implemented; — = not implemented.
-
----
-
-## 2. Compiler plugin
-
-### What it covers
-
-Reports at **compile time** (all platforms):
-
-- **SCOPE_001** — GlobalScope.launch/async  
-- **SCOPE_002** — async without await  
-- **SCOPE_003** — Inline scope (e.g. `CoroutineScope(...).launch`) and launch on scopes not annotated with `@StructuredScope`  
-- **RUNBLOCK_001** — Redundant launch in coroutineScope/supervisorScope  
-- **RUNBLOCK_002** — runBlocking in suspend functions  
-- **DISPATCH_003** — Dispatchers.Unconfined  
-- **DISPATCH_004** — Job()/SupervisorJob() in builder context  
-- **CANCEL_003** — catch(Exception) that may swallow CancellationException  
-- **CANCEL_004** — Suspend calls in finally without withContext(NonCancellable)  
-- **EXCEPT_002** — Class extends CancellationException  
-
-### Limitations
-
-| Limitation | Reason |
-|------------|--------|
-| No DISPATCH_001 (blocking in coroutine) | Would require blocking-call and coroutine-context analysis; not in scope for the compiler plugin. |
-| No CANCEL_001 (loop without yield) | Needs control-flow heuristics; implemented in static analyzers instead. |
-| No CANCEL_005 (scope reuse after cancel) | Requires data-flow/usage analysis. |
-| No TEST_001 (runBlocking + delay in tests) | Would require test-file or test-symbol awareness. |
-| No ARCH_002 (Android lifecycle) | Platform-specific; compiler is multiplatform. |
-| SCOPE_003 | Compiler enforces **@StructuredScope**; Detekt/Lint use heuristics (e.g. external scope from suspend, inline scope). Compiler is stricter. |
-
----
-
-## 3. Detekt
-
-### What it covers
-
-All rules that the compiler covers (see §2), plus:
-
-- **DISPATCH_001** — Blocking call in coroutine (e.g. `Thread.sleep`) — rule name: `BlockingCallInCoroutine`  
-- **CANCEL_001** — Loop without cooperation point — `LoopWithoutYield`  
-- **CANCEL_005** — Scope reuse after cancel — `ScopeReuseAfterCancel`  
-- **TEST_001** — runBlocking + delay in test code — `RunBlockingWithDelayInTest`  
-
-Runs on **Kotlin** (JVM, MPP, etc.); no Android SDK.
-
-### Limitations
-
-| Limitation | Reason |
-|------------|--------|
-| No ARCH_002 (LifecycleAwareScope, ViewModelScopeLeak) | Android-specific (Lifecycle, ViewModel); Detekt is generic Kotlin. |
-| SCOPE_003 | Implements **InlineCoroutineScope** and **ExternalScopeLaunch** (heuristics). Does **not** check @StructuredScope like the compiler. |
-
----
-
-## 4. Android Lint
-
-### What it covers
-
-All rules that Detekt covers for structured-coroutines, plus:
-
-- **ARCH_002** — Lifecycle-aware scope / ViewModelScope leak — `LifecycleAwareScope`, `ViewModelScopeLeak` (Android only).
-
-Runs in **Android** (and Android-aware Gradle) projects.
-
-### Limitations
-
-| Limitation | Reason |
-|------------|--------|
-| Android only | Does not run for plain JVM/MPP modules without Android. |
-| DISPATCH_001 | Lint uses **MainDispatcherMisuse** (main-thread blocking); Detekt uses **BlockingCallInCoroutine** (broader list). Semantics are similar but not identical. |
-| Some rules | IntelliJ inspections may not exist for RUNBLOCK_001, CANCEL_001, TEST_001; see [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md). |
-
----
-
-## 5. Naming differences (suppression IDs)
-
-Same practice can have different IDs per tool. When suppressing, use the ID of the **tool that reports** (see [SUPPRESSING_RULES.md](SUPPRESSING_RULES.md)).
-
-| Rule code | Compiler | Detekt | Lint |
-|-----------|----------|--------|------|
-| SCOPE_002 | `UNUSED_DEFERRED` | `UnusedDeferred` | `AsyncWithoutAwait` |
-| SCOPE_003 | `UNSTRUCTURED_COROUTINE_LAUNCH`, `INLINE_COROUTINE_SCOPE` | `ExternalScopeLaunch`, `InlineCoroutineScope` | `UnstructuredLaunch`, `InlineCoroutineScope` |
-| DISPATCH_001 | — | `BlockingCallInCoroutine` | `MainDispatcherMisuse` |
-
----
-
-## 6. When to use which tool
-
-| Goal | Use |
-|------|-----|
-| Enforce at compile time, all platforms | **Compiler** (via [Gradle plugin](../gradle-plugin/README.md)) |
-| Kotlin JVM/MPP without Android | **Detekt** (optionally with Compiler) |
-| Android app or library | **Lint** (optionally with Compiler and Detekt) |
-| Scope reuse after cancel (CANCEL_005) | **Detekt** or **Lint** |
-| Lifecycle/ViewModel scope (ARCH_002) | **Lint** only (Android) |
-| @StructuredScope enforcement (SCOPE_003) | **Compiler** only (Detekt/Lint use heuristics) |
+If you were looking for which tool implements a given rule code, or its
+suppression identifier, start with `rule-codes.yml` and cross-reference
+`SUPPRESSING_RULES.md`.

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -198,7 +198,7 @@ For a full migration path (relaxed → gradual → strict) and suppression best 
 
 ### Single entry point for rules
 
-This plugin is the **recommended single entry point** for structured-coroutines: it applies the Kotlin compiler plugin and fits into the same project as **Detekt** and **Android Lint**. For consistent behavior across tools, keep severity choices aligned (e.g. use the same error/warning level for a given rule in the plugin and in `detekt.yml` / Lint config). Rule codes and suppression IDs are listed in [docs/rule-codes.yml](../docs/rule-codes.yml) and [docs/RULES_SYNC_COMPARISON.md](../docs/RULES_SYNC_COMPARISON.md).
+This plugin is the **recommended single entry point** for structured-coroutines: it applies the Kotlin compiler plugin and fits into the same project as **Detekt** and **Android Lint**. For consistent behavior across tools, keep severity choices aligned (e.g. use the same error/warning level for a given rule in the plugin and in `detekt.yml` / Lint config). Rule codes are listed in [docs/rule-codes.yml](../docs/rule-codes.yml) and per-tool suppression IDs in [docs/SUPPRESSING_RULES.md](../docs/SUPPRESSING_RULES.md).
 
 ---
 

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/LoopWithoutYieldDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/LoopWithoutYieldDetector.kt
@@ -9,11 +9,14 @@
  */
 package io.github.santimattius.structured.lint.detectors
 
+import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Severity
 import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
 import io.github.santimattius.structured.lint.utils.LintDocUrl
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.uast.*
 import org.jetbrains.uast.visitor.AbstractUastVisitor
 
@@ -93,20 +96,28 @@ class LoopWithoutYieldDetector : Detector(), SourceCodeScanner {
         )
     }
     
-    override fun visitClass(context: JavaContext, declaration: UClass) {
-        declaration.accept(object : AbstractUastVisitor() {
-            override fun visitForExpression(node: UForExpression): Boolean {
+    // NOTE (bugfix, see #66 parity work): this detector previously overrode
+    // `SourceCodeScanner.visitClass(context, declaration)` without pairing it with
+    // `applicableSuperClasses()` (the only registration mechanism `visitClass` responds to).
+    // With neither `applicableSuperClasses()` nor `getApplicableUastTypes()` registered, lint's
+    // `UElementVisitor` never added this detector to any dispatch map, so `visitClass` was never
+    // invoked and this detector never reported a single diagnostic, in production or in tests.
+    // Fixed by switching to the `getApplicableUastTypes()` + `createUastHandler()` pairing used
+    // by every other working detector in this module (e.g. SynchronizedInCoroutineDetector).
+    override fun getApplicableUastTypes(): List<Class<out UElement>> =
+        listOf(UForExpression::class.java, UWhileExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitForExpression(node: UForExpression) {
                 checkLoop(context, node, node.body)
-                return super.visitForExpression(node)
             }
-            
-            override fun visitWhileExpression(node: UWhileExpression): Boolean {
+
+            override fun visitWhileExpression(node: UWhileExpression) {
                 checkLoop(context, node, node.body)
-                return super.visitWhileExpression(node)
             }
-        })
-    }
-    
+        }
+
     private fun checkLoop(
         context: JavaContext,
         loop: ULoopExpression,
@@ -116,12 +127,12 @@ class LoopWithoutYieldDetector : Detector(), SourceCodeScanner {
         if (!CoroutineLintUtils.isInSuspendFunction(context, loop)) {
             return
         }
-        
+
         if (loopBody == null) return
-        
+
         // Check if the loop body contains any cooperation points
         val hasCooperationPoint = hasCooperationPoint(loopBody)
-        
+
         if (!hasCooperationPoint) {
             val loopType = when (loop) {
                 is UForExpression -> "for"
@@ -145,21 +156,38 @@ class LoopWithoutYieldDetector : Detector(), SourceCodeScanner {
     
     /**
      * Checks if an expression contains any cooperation points.
+     *
+     * Pruning policy: named function/property-accessor *declarations* are not descended into —
+     * a local `suspend fun helper() { delay(1) }` that is declared but never called inside the
+     * loop must not suppress the diagnostic (see #66), mirroring the compiler's
+     * `LoopWithoutYieldChecker.CooperationPointFinder` and the Detekt rule's equivalent visitor.
+     * Kotlin local functions surface inconsistently across UAST backends — as a nested [UMethod]
+     * in some, as a `KotlinLocalFunctionUVariable` wrapping a [ULambdaExpression] in others —
+     * so pruning is checked on `sourcePsi` (identical in both shapes) rather than on the UAST
+     * node type.
      */
     private fun hasCooperationPoint(expression: UExpression): Boolean {
         var found = false
-        
+
         expression.accept(object : AbstractUastVisitor() {
+            override fun visitElement(node: UElement): Boolean {
+                val psi = node.sourcePsi
+                if ((psi is KtNamedFunction && psi.name != null) || psi is KtPropertyAccessor) {
+                    return true // Skip pruned subtree (UAST: true stops descent)
+                }
+                return super.visitElement(node)
+            }
+
             override fun visitCallExpression(node: UCallExpression): Boolean {
                 val methodName = node.methodName
                 if (methodName in COOPERATION_POINTS) {
                     found = true
-                    return false // Stop traversal
+                    return true // Stop traversal (UAST: true stops descent)
                 }
                 return super.visitCallExpression(node)
             }
         })
-        
+
         return found
     }
 }

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/LoopWithoutYieldDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/LoopWithoutYieldDetectorTest.kt
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import io.github.santimattius.structured.lint.LintTestStubs
+import org.junit.Test
+
+/**
+ * SPIKE (bounded verification, see task description): confirms whether
+ * [LoopWithoutYieldDetector] correctly flags a `while` loop whose only apparent cooperation
+ * point is `delay()` inside a local `suspend fun` that is declared but never called.
+ *
+ * The compiler's FIR checker ([io.github.santimattius.structured.compiler.LoopWithoutYieldChecker])
+ * was fixed for exactly this case by #66 by pruning nested `FirNamedFunction`/`FirPropertyAccessor`
+ * declarations before searching for a cooperation point. This detector's
+ * `hasCooperationPoint` walk (an unpruned `AbstractUastVisitor`) has no equivalent pruning, so
+ * it is hypothesized to still find `delay(1)` as a descendant of the loop body and incorrectly
+ * treat the loop as safe, even though `helper()` is dead code and never executes during
+ * iteration.
+ */
+class LoopWithoutYieldDetectorTest {
+
+    @Test
+    fun `reports loop with only an uncalled local suspend fun containing delay`() {
+        val code = """
+            package test
+
+            import kotlinx.coroutines.*
+
+            suspend fun processItems() {
+                var i = 0
+                while (i < 100) {
+                    suspend fun helper() {
+                        delay(1)
+                    }
+                    println(i)
+                    i++
+                }
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(LoopWithoutYieldDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectWarningCount(1)
+    }
+
+    @Test
+    fun `does not report loop when a real cooperation point coexists with a local suspend fun declaration`() {
+        // Negative counterpart to the spike above, adapted to what this detector can actually
+        // recognize: unlike the compiler (real FIR suspend-call resolution) and Detekt (a naming
+        // heuristic for suspend calls), this detector's `hasCooperationPoint` only matches a
+        // fixed, literal set of names (COOPERATION_POINTS) — it does not resolve whether an
+        // arbitrarily-named call like `helper()` is itself suspend. So a call to the local
+        // `helper()` cannot be recognized as a cooperation point here regardless of pruning; the
+        // meaningful over-broad-pruning guard for this surface is that pruning the (unrelated,
+        // declared-but-uncalled) `helper` declaration must not swallow a genuine, separate
+        // cooperation-point call (`delay(20)`) that exists elsewhere in the same loop body.
+        val code = """
+            package test
+
+            import kotlinx.coroutines.*
+
+            suspend fun processItems() {
+                var i = 0
+                while (i < 100) {
+                    suspend fun helper() {
+                        delay(1)
+                    }
+                    delay(20)
+                    println(i)
+                    i++
+                }
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(LoopWithoutYieldDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `does not report loop with a real top-level delay call`() {
+        // Sanity/regression guard: the most basic passing case (a direct cooperation-point call
+        // in the loop body, no nested declaration involved) must keep passing after pruning is
+        // introduced.
+        val code = """
+            package test
+
+            import kotlinx.coroutines.*
+
+            suspend fun processItems() {
+                var i = 0
+                while (i < 100) {
+                    delay(10)
+                    println(i)
+                    i++
+                }
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(LoopWithoutYieldDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
## Summary

- Detekt's `LoopWithoutYieldRule` and Lint's `LoopWithoutYieldDetector` used an unpruned traversal that mistook a `delay()` call inside a declared-but-never-called local `suspend fun` for a real cooperation point — the same divergence class already fixed in the compiler's FIR checker by #66. A loop like `while (isActive) { suspend fun helper() { delay(1) }; doWork() }` (a real busy loop — `helper()` is dead code) was silently reported as fine by both. Confirmed with a repro spike this session: both surfaces returned zero findings against current code; the compiler correctly flagged it as a control.
- **Separate pre-existing bug found while writing this detector's first-ever tests**: `LoopWithoutYieldDetector` overrode `visitClass()`/`SourceCodeScanner` without pairing it with `applicableSuperClasses()` or `getApplicableUastTypes()`+`createUastHandler()` — the only mechanisms Lint's `UElementVisitor` actually uses to invoke a detector. It never ran a single check, in production or in any test (it had zero test coverage before this PR). Fixed by switching to the `getApplicableUastTypes()`+`createUastHandler()` pairing already used correctly by every other working detector in this module.
- Fixed an inverted comment on the "stop traversal" return value in the Lint visitor (UAST: `true` stops descent, not `false` — harmless today since `found` was already set, but backwards and confusing).
- Added negative-case tests (a genuinely-called local suspend fun; a direct top-level `delay()` call) to both surfaces plus the compiler's own suite, to guard against over-broad pruning.

**Note**: while fixing the dead-registration bug above, we found the same broken pattern in 3 more Lint detectors (fully dead: `SuspendInFinallyDetector`, `CancellationExceptionSubclassDetector`, `CancellationExceptionSwallowedDetector`; partially dead: `LifecycleAwareScopeDetector`'s secondary check), independently confirmed against Lint's actual API source. That's tracked as a follow-up PR in this same chain (relates to #79) — out of scope for this PR to keep it reviewable.

Relates to #79 (part 3 of the toolkit-parity-audit PR chain — targets `docs/consolidate-rules-sync-comparison`, part 2).

## Type of change

- [x] Bug fix

## Component(s)

- [x] Detekt rules
- [x] Android Lint rules
- [x] Samples / tests

## Test plan

```bash
./gradlew :detekt-rules:test :lint-rules:test :compiler:test
./gradlew testAll
```

- `detekt-rules`: 170/170 passing.
- `lint-rules`: 62/62 passing.
- `testAll`: BUILD SUCCESSFUL across compiler, detekt-rules, gradle-plugin, lint-rules, intellij-plugin.
- New positive tests (previously failing red baseline) now pass; new negative tests confirm no over-broad pruning regression.

## Checklist

- [x] Tests pass locally (relevant `./gradlew` tasks)
- [x] New/changed rules updated in `docs/rule-codes.yml` and samples where applicable — N/A, detection-logic fix only, no rule-code/coverage change
- [x] `CHANGELOG.md` updated for user-facing changes — pending in a later PR of this chain (T4 batch), per tasks breakdown
- [x] Follows CONTRIBUTING.md guidelines