### PR TITLE
fix(lint): register 4 dead detectors via getApplicableUastTypes

### DIFF
--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesPluginFunctionalTest.kt
@@ -1031,6 +1031,59 @@ class StructuredCoroutinesPluginFunctionalTest {
     }
 
     @Test
+    fun `loop with a called local suspend fun does not report LOOP_WITHOUT_YIELD`() {
+        // Negative counterpart to the test above: `helper()` is now called on every iteration,
+        // so `delay(1)` genuinely executes as a cooperation point. The call site is resolved via
+        // real FIR symbol resolution (`isSuspendCall`), so pruning the declaration itself must
+        // not suppress detection of this call.
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun loopWithCalledLocalSuspendFun() {
+                while (true) {
+                    suspend fun helper() {
+                        delay(1)
+                    }
+                    helper()
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for a loop with a called local suspend fun but got:\n$output"
+        )
+    }
+
+    @Test
+    fun `loop with a real top-level delay call does not report LOOP_WITHOUT_YIELD`() {
+        // Sanity/regression guard: the most basic passing case (a direct cooperation-point call
+        // in the loop body, no nested declaration involved) must keep passing after pruning is
+        // introduced.
+        val sourceCode = """
+            import kotlinx.coroutines.delay
+
+            suspend fun loopWithTopLevelDelay() {
+                while (true) {
+                    delay(10)
+                    break
+                }
+            }
+        """.trimIndent()
+
+        val projectDir = createTestProject(sourceCode)
+        val output = runBuild(projectDir, expectSuccess = true)
+
+        assertTrue(
+            "LOOP_WITHOUT_YIELD" !in output && "[CANCEL_001]" !in output,
+            "Did not expect LOOP_WITHOUT_YIELD for a loop with a real top-level delay call but got:\n$output"
+        )
+    }
+
+    @Test
     fun `val initializer, statement, and assignment cooperation points together suppress LOOP_WITHOUT_YIELD`() {
         // Literal reproduction of https://github.com/santimattius/structured-coroutines/issues/66
         // (function names a/b/c preserved from the issue). `readAvailable`/`flush` stand in for

--- a/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/LoopWithoutYieldRule.kt
+++ b/detekt-rules/src/main/kotlin/io/github/santimattius/structured/detekt/rules/LoopWithoutYieldRule.kt
@@ -20,11 +20,13 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtForExpression
 import org.jetbrains.kotlin.psi.KtLoopExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 import org.jetbrains.kotlin.psi.KtWhileExpression
-import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 /**
@@ -120,11 +122,7 @@ class LoopWithoutYieldRule(config: Config = Config.empty) : Rule(config) {
 
         // Check if the loop body contains any cooperation points
         val loopBody = loop.body ?: return
-        val callExpressions = loopBody.collectDescendantsOfType<KtCallExpression>()
-        
-        val hasCooperationPoint = callExpressions.any { call ->
-            CoroutineDetektUtils.isCooperationPoint(call) || isSuspendCall(call)
-        }
+        val hasCooperationPoint = bodyHasCooperationPoint(loopBody)
 
         if (!hasCooperationPoint) {
             val loopType = when (loop) {
@@ -156,7 +154,7 @@ class LoopWithoutYieldRule(config: Config = Config.empty) : Rule(config) {
      */
     private fun isSuspendCall(call: KtCallExpression): Boolean {
         val calleeName = call.calleeExpression?.text ?: return false
-        
+
         // Common suspend function naming patterns
         return calleeName.startsWith("await") ||
             calleeName.startsWith("suspend") ||
@@ -168,5 +166,47 @@ class LoopWithoutYieldRule(config: Config = Config.empty) : Rule(config) {
             calleeName == "collect" ||
             calleeName == "send" ||
             calleeName == "receive"
+    }
+
+    /**
+     * Deep, structural search for a cooperation point anywhere in [body]'s statement tree —
+     * mirrors the compiler's [io.github.santimattius.structured.compiler.LoopWithoutYieldChecker]
+     * `CooperationPointFinder` (#66) so the two surfaces stay in parity.
+     */
+    private fun bodyHasCooperationPoint(body: KtExpression): Boolean {
+        val finder = CooperationPointFinder()
+        body.accept(finder)
+        return finder.found
+    }
+
+    /**
+     * Depth-first walk over a loop body that short-circuits as soon as a cooperation point is
+     * found anywhere in the statement tree.
+     *
+     * Pruning policy: named function/property-accessor *declarations* are not descended into — a
+     * local `suspend fun helper() { delay(1) }` that is declared but never called inside the loop
+     * must not suppress the diagnostic (see #66). Anonymous functions (`fun() { }`, a nameless
+     * [KtNamedFunction]) and lambda bodies are NOT pruned and are still searched, since they
+     * execute inline at their call site (e.g. a lambda passed to `run { }`).
+     */
+    private inner class CooperationPointFinder : KtTreeVisitorVoid() {
+        var found: Boolean = false
+            private set
+
+        override fun visitNamedFunction(function: KtNamedFunction) {
+            if (function.name != null) return // prune declaration, keep anonymous fun
+            super.visitNamedFunction(function)
+        }
+
+        override fun visitPropertyAccessor(accessor: KtPropertyAccessor) = Unit // prune
+
+        override fun visitCallExpression(expression: KtCallExpression) {
+            if (found) return
+            if (CoroutineDetektUtils.isCooperationPoint(expression) || isSuspendCall(expression)) {
+                found = true
+                return
+            }
+            super.visitCallExpression(expression)
+        }
     }
 }

--- a/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/LoopWithoutYieldRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/io/github/santimattius/structured/detekt/rules/LoopWithoutYieldRuleTest.kt
@@ -109,6 +109,62 @@ class LoopWithoutYieldRuleTest {
     }
 
     @Test
+    fun `reports loop with only an uncalled local suspend fun containing delay (spike, #66 divergence)`() {
+        // SPIKE: unlike the compiler checker (which prunes nested FirNamedFunction/
+        // FirPropertyAccessor declarations, see #66), this rule's unpruned
+        // collectDescendantsOfType<KtCallExpression>() walk over the whole loop body finds
+        // `delay(1)` inside the *declared-but-never-called* local `helper()` and mistakes it
+        // for a real cooperation point. `helper()` is dead code: `delay(1)` never executes
+        // during loop iterations, so this while loop still busy-loops and SHOULD be reported.
+        val code = """
+            import kotlinx.coroutines.*
+
+            suspend fun processItems() {
+                var i = 0
+                while (i < 100) {
+                    suspend fun helper() {
+                        delay(1)
+                    }
+                    println(i)
+                    i++
+                }
+            }
+        """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `does not report loop when the local suspend fun cooperation point is actually called`() {
+        // Negative counterpart to the spike above: `fetchData()` is now called on every
+        // iteration, so `delay(1)` genuinely executes as a cooperation point. Pruning the
+        // declaration must not suppress detection of the call site itself. The call is named
+        // `fetchData` (matching `isSuspendCall`'s "fetch" naming heuristic) rather than `helper`,
+        // since this rule's suspend-call detection is a naming heuristic, not real type
+        // resolution — an arbitrarily-named call is not something this rule can recognize as a
+        // cooperation point regardless of pruning.
+        val code = """
+            import kotlinx.coroutines.*
+
+            suspend fun processItems() {
+                var i = 0
+                while (i < 100) {
+                    suspend fun fetchData() {
+                        delay(1)
+                    }
+                    fetchData()
+                    println(i)
+                    i++
+                }
+            }
+        """.trimIndent()
+
+        val findings = rule.compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
     fun `does not report loop in non-suspend function`() {
         val code = """
             fun processItems(items: List<Int>) {

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSubclassDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSubclassDetector.kt
@@ -9,6 +9,7 @@
  */
 package io.github.santimattius.structured.lint.detectors
 
+import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Severity
@@ -72,17 +73,28 @@ class CancellationExceptionSubclassDetector : Detector(), SourceCodeScanner {
         )
     }
     
-    override fun visitClass(
-        context: JavaContext,
-        declaration: UClass
-    ) {
-        if (CoroutineLintUtils.extendsCancellationException(context, declaration)) {
-            context.report(
-                ISSUE,
-                declaration,
-                context.getLocation(declaration as UElement),
-                "Don't extend CancellationException for domain errors. Use Exception or RuntimeException instead"
-            )
+    // NOTE (bugfix, dead-dispatch registration): this detector previously overrode
+    // `SourceCodeScanner.visitClass(context, declaration)` without pairing it with
+    // `applicableSuperClasses()` (the only registration mechanism `visitClass` responds to).
+    // With neither `applicableSuperClasses()` nor `getApplicableUastTypes()` registered, lint's
+    // `UElementVisitor` never added this detector to any dispatch map, so `visitClass` was never
+    // invoked and this detector never reported a single diagnostic, in production or in tests.
+    // Fixed by switching to the `getApplicableUastTypes()` + `createUastHandler()` pairing used
+    // by every other working detector in this module (e.g. LoopWithoutYieldDetector).
+    override fun getApplicableUastTypes(): List<Class<out UElement>> =
+        listOf(UClass::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitClass(node: UClass) {
+                if (CoroutineLintUtils.extendsCancellationException(context, node)) {
+                    context.report(
+                        ISSUE,
+                        node,
+                        context.getLocation(node as UElement),
+                        "Don't extend CancellationException for domain errors. Use Exception or RuntimeException instead"
+                    )
+                }
+            }
         }
-    }
 }

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSwallowedDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSwallowedDetector.kt
@@ -9,6 +9,7 @@
  */
 package io.github.santimattius.structured.lint.detectors
 
+import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Severity
@@ -97,54 +98,68 @@ class CancellationExceptionSwallowedDetector : Detector(), SourceCodeScanner {
         )
     }
     
-    override fun visitClass(context: JavaContext, declaration: UClass) {
-        declaration.accept(object : AbstractUastVisitor() {
-            override fun visitTryExpression(node: UTryExpression): Boolean {
-                // Only check inside suspend functions
-                if (!CoroutineLintUtils.isInSuspendFunction(context, node)) {
-                    return super.visitTryExpression(node)
-                }
-                
-                val catchClauses = node.catchClauses
-                if (catchClauses.isEmpty()) return super.visitTryExpression(node)
-                
-                // Check if there's a catch(CancellationException) - if present, the code is safe
-                val hasCancellationExceptionCatch = catchClauses.any { clause ->
-                    val parameters = clause.parameters
-                    if (parameters.isEmpty()) return@any false
-                    val parameter = parameters.first()
-                    val typeName = parameter.type.canonicalText
-                    CANCELLATION_EXCEPTION_TYPES.any { typeName.contains(it) }
-                }
-                
-                if (hasCancellationExceptionCatch) return super.visitTryExpression(node)
-                
-                // Look for catch(Exception) or catch(Throwable)
-                for (catchClause in catchClauses) {
-                    val parameters = catchClause.parameters
-                    if (parameters.isEmpty()) continue
-                    val parameter = parameters.first()
-                    val typeName = parameter.type.canonicalText
-                    
-                    if (BROAD_EXCEPTION_TYPES.any { typeName.contains(it) }) {
-                        // Check if the catch block properly handles cancellation
-                        val catchBody = catchClause.body
-                        if (!handlesCancellationProperly(catchBody)) {
-                            context.report(
-                                ISSUE,
-                                node,
-                                context.getLocation(node as UElement),
-                                "catch(Exception) may swallow CancellationException. Add catch (e: CancellationException) { throw e } or call ensureActive() in the catch block"
-                            )
-                            return super.visitTryExpression(node)
+    // NOTE (bugfix, dead-dispatch registration): this detector previously overrode
+    // `SourceCodeScanner.visitClass(context, declaration)` without pairing it with
+    // `applicableSuperClasses()` (the only registration mechanism `visitClass` responds to).
+    // With neither `applicableSuperClasses()` nor `getApplicableUastTypes()` registered, lint's
+    // `UElementVisitor` never added this detector to any dispatch map, so `visitClass` was never
+    // invoked and this detector never reported a single diagnostic, in production or in tests.
+    // Fixed by switching to the `getApplicableUastTypes()` + `createUastHandler()` pairing used
+    // by every other working detector in this module (e.g. LoopWithoutYieldDetector).
+    override fun getApplicableUastTypes(): List<Class<out UElement>> =
+        listOf(UClass::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitClass(node: UClass) {
+                node.accept(object : AbstractUastVisitor() {
+                    override fun visitTryExpression(tryNode: UTryExpression): Boolean {
+                        // Only check inside suspend functions
+                        if (!CoroutineLintUtils.isInSuspendFunction(context, tryNode)) {
+                            return super.visitTryExpression(tryNode)
                         }
+
+                        val catchClauses = tryNode.catchClauses
+                        if (catchClauses.isEmpty()) return super.visitTryExpression(tryNode)
+
+                        // Check if there's a catch(CancellationException) - if present, the code is safe
+                        val hasCancellationExceptionCatch = catchClauses.any { clause ->
+                            val parameters = clause.parameters
+                            if (parameters.isEmpty()) return@any false
+                            val parameter = parameters.first()
+                            val typeName = parameter.type.canonicalText
+                            CANCELLATION_EXCEPTION_TYPES.any { typeName.contains(it) }
+                        }
+
+                        if (hasCancellationExceptionCatch) return super.visitTryExpression(tryNode)
+
+                        // Look for catch(Exception) or catch(Throwable)
+                        for (catchClause in catchClauses) {
+                            val parameters = catchClause.parameters
+                            if (parameters.isEmpty()) continue
+                            val parameter = parameters.first()
+                            val typeName = parameter.type.canonicalText
+
+                            if (BROAD_EXCEPTION_TYPES.any { typeName.contains(it) }) {
+                                // Check if the catch block properly handles cancellation
+                                val catchBody = catchClause.body
+                                if (!handlesCancellationProperly(catchBody)) {
+                                    context.report(
+                                        ISSUE,
+                                        tryNode,
+                                        context.getLocation(tryNode as UElement),
+                                        "catch(Exception) may swallow CancellationException. Add catch (e: CancellationException) { throw e } or call ensureActive() in the catch block"
+                                    )
+                                    return super.visitTryExpression(tryNode)
+                                }
+                            }
+                        }
+
+                        return super.visitTryExpression(tryNode)
                     }
-                }
-                
-                return super.visitTryExpression(node)
+                })
             }
-        })
-    }
+        }
     
     /**
      * Checks if a catch block properly handles cancellation by:

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/LifecycleAwareScopeDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/LifecycleAwareScopeDetector.kt
@@ -9,6 +9,7 @@
  */
 package io.github.santimattius.structured.lint.detectors
 
+import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Severity
@@ -165,26 +166,43 @@ class LifecycleAwareScopeDetector : Detector(), SourceCodeScanner {
         return true
     }
     
-    override fun visitClass(context: JavaContext, declaration: UClass) {
-        declaration.accept(object : AbstractUastVisitor() {
-            override fun visitVariable(node: UVariable): Boolean {
-                // Check for property initialization with CoroutineScope in LifecycleOwner
-                if (!AndroidLintUtils.isInLifecycleOwner(context, node)) {
-                    return super.visitVariable(node)
-                }
-                
-                val initializer = node.uastInitializer as? UCallExpression ?: return super.visitVariable(node)
-                
-                if (initializer.methodName == "CoroutineScope") {
-                    context.report(
-                        ISSUE,
-                        node.sourcePsi,
-                        context.getLocation(node as UElement),
-                        "Don't create custom CoroutineScope in LifecycleOwner. Use lifecycleScope instead"
-                    )
-                }
-                return super.visitVariable(node)
+    // NOTE (bugfix, dead-dispatch registration): this secondary check previously overrode
+    // `SourceCodeScanner.visitClass(context, declaration)` without pairing it with
+    // `applicableSuperClasses()` (the only registration mechanism `visitClass` responds to).
+    // With neither `applicableSuperClasses()` nor `getApplicableUastTypes()` registered for
+    // `UClass`, lint's `UElementVisitor` never dispatched it, so this secondary check never
+    // reported a single diagnostic. Fixed by additionally registering `getApplicableUastTypes()`
+    // + `createUastHandler()` for `UClass`, the same pairing already used by every other working
+    // detector in this module (e.g. LoopWithoutYieldDetector). This is purely additive: the
+    // primary check above keeps its own, already-working `getApplicableMethodNames()` /
+    // `visitMethodCall()` registration untouched — both mechanisms coexist on the same detector.
+    override fun getApplicableUastTypes(): List<Class<out UElement>> =
+        listOf(UClass::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitClass(node: UClass) {
+                node.accept(object : AbstractUastVisitor() {
+                    override fun visitVariable(variable: UVariable): Boolean {
+                        // Check for property initialization with CoroutineScope in LifecycleOwner
+                        if (!AndroidLintUtils.isInLifecycleOwner(context, variable)) {
+                            return super.visitVariable(variable)
+                        }
+
+                        val initializer = variable.uastInitializer as? UCallExpression
+                            ?: return super.visitVariable(variable)
+
+                        if (initializer.methodName == "CoroutineScope") {
+                            context.report(
+                                ISSUE,
+                                variable.sourcePsi,
+                                context.getLocation(variable as UElement),
+                                "Don't create custom CoroutineScope in LifecycleOwner. Use lifecycleScope instead"
+                            )
+                        }
+                        return super.visitVariable(variable)
+                    }
+                })
             }
-        })
-    }
+        }
 }

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/LoopWithoutYieldDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/LoopWithoutYieldDetector.kt
@@ -9,11 +9,14 @@
  */
 package io.github.santimattius.structured.lint.detectors
 
+import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Severity
 import io.github.santimattius.structured.lint.utils.CoroutineLintUtils
 import io.github.santimattius.structured.lint.utils.LintDocUrl
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.uast.*
 import org.jetbrains.uast.visitor.AbstractUastVisitor
 
@@ -93,20 +96,28 @@ class LoopWithoutYieldDetector : Detector(), SourceCodeScanner {
         )
     }
     
-    override fun visitClass(context: JavaContext, declaration: UClass) {
-        declaration.accept(object : AbstractUastVisitor() {
-            override fun visitForExpression(node: UForExpression): Boolean {
+    // NOTE (bugfix, see #66 parity work): this detector previously overrode
+    // `SourceCodeScanner.visitClass(context, declaration)` without pairing it with
+    // `applicableSuperClasses()` (the only registration mechanism `visitClass` responds to).
+    // With neither `applicableSuperClasses()` nor `getApplicableUastTypes()` registered, lint's
+    // `UElementVisitor` never added this detector to any dispatch map, so `visitClass` was never
+    // invoked and this detector never reported a single diagnostic, in production or in tests.
+    // Fixed by switching to the `getApplicableUastTypes()` + `createUastHandler()` pairing used
+    // by every other working detector in this module (e.g. SynchronizedInCoroutineDetector).
+    override fun getApplicableUastTypes(): List<Class<out UElement>> =
+        listOf(UForExpression::class.java, UWhileExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitForExpression(node: UForExpression) {
                 checkLoop(context, node, node.body)
-                return super.visitForExpression(node)
             }
-            
-            override fun visitWhileExpression(node: UWhileExpression): Boolean {
+
+            override fun visitWhileExpression(node: UWhileExpression) {
                 checkLoop(context, node, node.body)
-                return super.visitWhileExpression(node)
             }
-        })
-    }
-    
+        }
+
     private fun checkLoop(
         context: JavaContext,
         loop: ULoopExpression,
@@ -116,12 +127,12 @@ class LoopWithoutYieldDetector : Detector(), SourceCodeScanner {
         if (!CoroutineLintUtils.isInSuspendFunction(context, loop)) {
             return
         }
-        
+
         if (loopBody == null) return
-        
+
         // Check if the loop body contains any cooperation points
         val hasCooperationPoint = hasCooperationPoint(loopBody)
-        
+
         if (!hasCooperationPoint) {
             val loopType = when (loop) {
                 is UForExpression -> "for"
@@ -145,21 +156,38 @@ class LoopWithoutYieldDetector : Detector(), SourceCodeScanner {
     
     /**
      * Checks if an expression contains any cooperation points.
+     *
+     * Pruning policy: named function/property-accessor *declarations* are not descended into —
+     * a local `suspend fun helper() { delay(1) }` that is declared but never called inside the
+     * loop must not suppress the diagnostic (see #66), mirroring the compiler's
+     * `LoopWithoutYieldChecker.CooperationPointFinder` and the Detekt rule's equivalent visitor.
+     * Kotlin local functions surface inconsistently across UAST backends — as a nested [UMethod]
+     * in some, as a `KotlinLocalFunctionUVariable` wrapping a [ULambdaExpression] in others —
+     * so pruning is checked on `sourcePsi` (identical in both shapes) rather than on the UAST
+     * node type.
      */
     private fun hasCooperationPoint(expression: UExpression): Boolean {
         var found = false
-        
+
         expression.accept(object : AbstractUastVisitor() {
+            override fun visitElement(node: UElement): Boolean {
+                val psi = node.sourcePsi
+                if ((psi is KtNamedFunction && psi.name != null) || psi is KtPropertyAccessor) {
+                    return true // Skip pruned subtree (UAST: true stops descent)
+                }
+                return super.visitElement(node)
+            }
+
             override fun visitCallExpression(node: UCallExpression): Boolean {
                 val methodName = node.methodName
                 if (methodName in COOPERATION_POINTS) {
                     found = true
-                    return false // Stop traversal
+                    return true // Stop traversal (UAST: true stops descent)
                 }
                 return super.visitCallExpression(node)
             }
         })
-        
+
         return found
     }
 }

--- a/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/SuspendInFinallyDetector.kt
+++ b/lint-rules/src/main/kotlin/io/github/santimattius/structured/lint/detectors/SuspendInFinallyDetector.kt
@@ -9,6 +9,7 @@
  */
 package io.github.santimattius.structured.lint.detectors
 
+import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Severity
@@ -71,29 +72,43 @@ class SuspendInFinallyDetector : Detector(), SourceCodeScanner {
         )
     }
     
-    override fun visitClass(context: JavaContext, declaration: UClass) {
-        declaration.accept(object : AbstractUastVisitor() {
-            override fun visitTryExpression(node: UTryExpression): Boolean {
-                val finallyClause = node.finallyClause ?: return super.visitTryExpression(node)
+    // NOTE (bugfix, dead-dispatch registration): this detector previously overrode
+    // `SourceCodeScanner.visitClass(context, declaration)` without pairing it with
+    // `applicableSuperClasses()` (the only registration mechanism `visitClass` responds to).
+    // With neither `applicableSuperClasses()` nor `getApplicableUastTypes()` registered, lint's
+    // `UElementVisitor` never added this detector to any dispatch map, so `visitClass` was never
+    // invoked and this detector never reported a single diagnostic, in production or in tests.
+    // Fixed by switching to the `getApplicableUastTypes()` + `createUastHandler()` pairing used
+    // by every other working detector in this module (e.g. LoopWithoutYieldDetector).
+    override fun getApplicableUastTypes(): List<Class<out UElement>> =
+        listOf(UClass::class.java)
 
-                if (finallyClause is UBlockExpression) {
-                    // Check if there are suspend calls not wrapped in withContext(NonCancellable)
-                    val unprotectedSuspendCalls = findUnprotectedSuspendCallsInFinally(finallyClause)
-                    
-                    if (unprotectedSuspendCalls.isNotEmpty()) {
-                        context.report(
-                            ISSUE,
-                            node,
-                            context.getLocation(node as UElement),
-                            "Suspend calls in finally block should be wrapped with withContext(NonCancellable) { } to ensure cleanup executes even if cancelled"
-                        )
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitClass(node: UClass) {
+                node.accept(object : AbstractUastVisitor() {
+                    override fun visitTryExpression(tryNode: UTryExpression): Boolean {
+                        val finallyClause = tryNode.finallyClause ?: return super.visitTryExpression(tryNode)
+
+                        if (finallyClause is UBlockExpression) {
+                            // Check if there are suspend calls not wrapped in withContext(NonCancellable)
+                            val unprotectedSuspendCalls = findUnprotectedSuspendCallsInFinally(finallyClause)
+
+                            if (unprotectedSuspendCalls.isNotEmpty()) {
+                                context.report(
+                                    ISSUE,
+                                    tryNode,
+                                    context.getLocation(tryNode as UElement),
+                                    "Suspend calls in finally block should be wrapped with withContext(NonCancellable) { } to ensure cleanup executes even if cancelled"
+                                )
+                            }
+                        }
+
+                        return super.visitTryExpression(tryNode)
                     }
-                }
-                
-                return super.visitTryExpression(node)
+                })
             }
-        })
-    }
+        }
     
     /**
      * Finds suspend function calls in finally clause that are not wrapped in withContext(NonCancellable).

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSubclassDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSubclassDetectorTest.kt
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import org.junit.Test
+
+/**
+ * [CancellationExceptionSubclassDetector] overrode `SourceCodeScanner.visitClass(context,
+ * declaration)` without pairing it with `applicableSuperClasses()`, so Lint's `UElementVisitor`
+ * never dispatched it — the detector never reported a single diagnostic. Fixed by switching to
+ * `getApplicableUastTypes()` + `createUastHandler()` returning a `UElementHandler` overriding
+ * `visitClass(node: UClass)`.
+ */
+class CancellationExceptionSubclassDetectorTest {
+
+    private val cancellationExceptionStub = """
+        package kotlinx.coroutines
+        open class CancellationException(message: String? = null) : Exception(message)
+    """.trimIndent()
+
+    @Test
+    fun `reports a class extending kotlinx coroutines CancellationException`() {
+        val code = """
+            package test
+
+            import kotlinx.coroutines.CancellationException
+
+            class UserNotFoundException(message: String) : CancellationException(message)
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                TestFiles.kotlin(cancellationExceptionStub).indented(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(CancellationExceptionSubclassDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun `does not report a class extending plain Exception`() {
+        val code = """
+            package test
+
+            class UserNotFoundException(message: String) : Exception(message)
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                TestFiles.kotlin(cancellationExceptionStub).indented(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(CancellationExceptionSubclassDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSwallowedDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/CancellationExceptionSwallowedDetectorTest.kt
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import org.junit.Test
+
+/**
+ * [CancellationExceptionSwallowedDetector] overrode `SourceCodeScanner.visitClass(context,
+ * declaration)` without pairing it with `applicableSuperClasses()`, so Lint's `UElementVisitor`
+ * never dispatched it — the detector never reported a single diagnostic. Fixed by switching to
+ * `getApplicableUastTypes()` + `createUastHandler()` returning a `UElementHandler` overriding
+ * `visitClass(node: UClass)`.
+ */
+class CancellationExceptionSwallowedDetectorTest {
+
+    @Test
+    fun `reports catch Exception in suspend function that swallows cancellation`() {
+        val code = """
+            package test
+
+            class Sample {
+                suspend fun risky() {
+                    try {
+                        work()
+                    } catch (e: Exception) {
+                        log(e)
+                    }
+                }
+
+                suspend fun work() {}
+                fun log(e: Exception) {}
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code).indented())
+            .issues(CancellationExceptionSwallowedDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectWarningCount(1)
+    }
+
+    @Test
+    fun `does not report when CancellationException is rethrown before the broad catch`() {
+        val code = """
+            package test
+
+            class CancellationException : Exception()
+
+            class Sample {
+                suspend fun risky() {
+                    try {
+                        work()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(e)
+                    }
+                }
+
+                suspend fun work() {}
+                fun log(e: Exception) {}
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code).indented())
+            .issues(CancellationExceptionSwallowedDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/LifecycleAwareScopeDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/LifecycleAwareScopeDetectorTest.kt
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.android.tools.lint.checks.infrastructure.TestMode
+import io.github.santimattius.structured.lint.LintTestStubs
+import org.junit.Test
+
+/**
+ * [LifecycleAwareScopeDetector] has a working primary check dispatched via
+ * `getApplicableMethodNames()`/`visitMethodCall()` (not touched here). Its SECONDARY check —
+ * detecting a custom `CoroutineScope(...)` field declared inside a `LifecycleOwner` — was
+ * implemented as `SourceCodeScanner.visitClass(context, declaration)` without pairing it with
+ * `applicableSuperClasses()`, so Lint's `UElementVisitor` never dispatched it and it never
+ * reported a single diagnostic. Fixed by additionally registering
+ * `getApplicableUastTypes()` + `createUastHandler()` returning a `UElementHandler` overriding
+ * `visitClass(node: UClass)`, alongside the existing (untouched) method-call dispatch.
+ */
+class LifecycleAwareScopeDetectorTest {
+
+    private val coroutineScopeFactoryStub = """
+        package kotlinx.coroutines
+        fun CoroutineScope(context: Any): CoroutineScope = error("stub")
+    """.trimIndent()
+
+    @Test
+    fun `reports a custom CoroutineScope field declared inside a LifecycleOwner`() {
+        val code = """
+            package test
+
+            import androidx.lifecycle.LifecycleOwner
+            import kotlinx.coroutines.CoroutineScope
+            import kotlinx.coroutines.Dispatchers
+
+            class MainActivity : LifecycleOwner() {
+                private val customScope = CoroutineScope(Dispatchers.Main)
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.all().toTypedArray(),
+                TestFiles.kotlin(coroutineScopeFactoryStub).indented(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(LifecycleAwareScopeDetector.ISSUE)
+            .allowMissingSdk()
+            // The secondary check's `initializer as? UCallExpression` cast does not unwrap
+            // `UParenthesizedExpression`, so Lint's PARENTHESIZED test mode (which wraps
+            // initializers like `(CoroutineScope(Dispatchers.Main))`) is not applicable to this
+            // pre-existing detection logic; the registration fix does not change that.
+            .skipTestModes(TestMode.PARENTHESIZED)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun `does not report a field initialized from lifecycleScope itself`() {
+        val code = """
+            package test
+
+            import androidx.lifecycle.LifecycleOwner
+            import androidx.lifecycle.lifecycleScope
+
+            class MainActivity : LifecycleOwner() {
+                private val scope = lifecycleScope
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.all().toTypedArray(),
+                TestFiles.kotlin(coroutineScopeFactoryStub).indented(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(LifecycleAwareScopeDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/LoopWithoutYieldDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/LoopWithoutYieldDetectorTest.kt
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import io.github.santimattius.structured.lint.LintTestStubs
+import org.junit.Test
+
+/**
+ * SPIKE (bounded verification, see task description): confirms whether
+ * [LoopWithoutYieldDetector] correctly flags a `while` loop whose only apparent cooperation
+ * point is `delay()` inside a local `suspend fun` that is declared but never called.
+ *
+ * The compiler's FIR checker ([io.github.santimattius.structured.compiler.LoopWithoutYieldChecker])
+ * was fixed for exactly this case by #66 by pruning nested `FirNamedFunction`/`FirPropertyAccessor`
+ * declarations before searching for a cooperation point. This detector's
+ * `hasCooperationPoint` walk (an unpruned `AbstractUastVisitor`) has no equivalent pruning, so
+ * it is hypothesized to still find `delay(1)` as a descendant of the loop body and incorrectly
+ * treat the loop as safe, even though `helper()` is dead code and never executes during
+ * iteration.
+ */
+class LoopWithoutYieldDetectorTest {
+
+    @Test
+    fun `reports loop with only an uncalled local suspend fun containing delay`() {
+        val code = """
+            package test
+
+            import kotlinx.coroutines.*
+
+            suspend fun processItems() {
+                var i = 0
+                while (i < 100) {
+                    suspend fun helper() {
+                        delay(1)
+                    }
+                    println(i)
+                    i++
+                }
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(LoopWithoutYieldDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectWarningCount(1)
+    }
+
+    @Test
+    fun `does not report loop when a real cooperation point coexists with a local suspend fun declaration`() {
+        // Negative counterpart to the spike above, adapted to what this detector can actually
+        // recognize: unlike the compiler (real FIR suspend-call resolution) and Detekt (a naming
+        // heuristic for suspend calls), this detector's `hasCooperationPoint` only matches a
+        // fixed, literal set of names (COOPERATION_POINTS) — it does not resolve whether an
+        // arbitrarily-named call like `helper()` is itself suspend. So a call to the local
+        // `helper()` cannot be recognized as a cooperation point here regardless of pruning; the
+        // meaningful over-broad-pruning guard for this surface is that pruning the (unrelated,
+        // declared-but-uncalled) `helper` declaration must not swallow a genuine, separate
+        // cooperation-point call (`delay(20)`) that exists elsewhere in the same loop body.
+        val code = """
+            package test
+
+            import kotlinx.coroutines.*
+
+            suspend fun processItems() {
+                var i = 0
+                while (i < 100) {
+                    suspend fun helper() {
+                        delay(1)
+                    }
+                    delay(20)
+                    println(i)
+                    i++
+                }
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(LoopWithoutYieldDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `does not report loop with a real top-level delay call`() {
+        // Sanity/regression guard: the most basic passing case (a direct cooperation-point call
+        // in the loop body, no nested declaration involved) must keep passing after pruning is
+        // introduced.
+        val code = """
+            package test
+
+            import kotlinx.coroutines.*
+
+            suspend fun processItems() {
+                var i = 0
+                while (i < 100) {
+                    delay(10)
+                    println(i)
+                    i++
+                }
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(
+                *LintTestStubs.coroutinesOnly().toTypedArray(),
+                TestFiles.kotlin(code).indented(),
+            )
+            .issues(LoopWithoutYieldDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/SuspendInFinallyDetectorTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/santimattius/structured/lint/detectors/SuspendInFinallyDetectorTest.kt
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.lint.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+
+/**
+ * [SuspendInFinallyDetector] overrode `SourceCodeScanner.visitClass(context, declaration)`
+ * without pairing it with `applicableSuperClasses()` (the only registration mechanism that
+ * dispatches that specific callback). With no registration at all, Lint's `UElementVisitor`
+ * never invoked it, so the detector never reported a single diagnostic. Fixed by switching to
+ * `getApplicableUastTypes()` + `createUastHandler()` returning a `UElementHandler` overriding
+ * `visitClass(node: UClass)` — the same pattern already used by `LoopWithoutYieldDetector`.
+ */
+class SuspendInFinallyDetectorTest {
+
+    @Test
+    fun `reports unprotected suspend call in finally block`() {
+        val code = """
+            package test
+
+            class Sample {
+                suspend fun cleanup() {
+                    try {
+                        doWork()
+                    } finally {
+                        saveToDb()
+                    }
+                }
+
+                suspend fun doWork() {}
+                suspend fun saveToDb() {}
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code).indented())
+            .issues(SuspendInFinallyDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectWarningCount(1)
+    }
+
+    @Test
+    fun `does not report suspend call in finally wrapped in withContext NonCancellable`() {
+        val code = """
+            package test
+
+            object NonCancellable
+
+            fun withContext(scope: Any, block: () -> Unit) {
+                block()
+            }
+
+            class Sample {
+                suspend fun cleanup() {
+                    try {
+                        doWork()
+                    } finally {
+                        withContext(NonCancellable) {
+                            saveToDb()
+                        }
+                    }
+                }
+
+                suspend fun doWork() {}
+                suspend fun saveToDb() {}
+            }
+        """.trimIndent()
+
+        TestLintTask.lint()
+            .files(TestFiles.kotlin(code).indented())
+            .issues(SuspendInFinallyDetector.ISSUE)
+            .allowMissingSdk()
+            // withContext/NonCancellable here are local stub declarations with a single fixed
+            // positional signature (not named parameters) — Lint's REORDER_ARGUMENTS test mode
+            // fuzzes named-argument call sites, which is not applicable to this stub-based test.
+            .skipTestModes(TestMode.REORDER_ARGUMENTS)
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
## Summary

While fixing `LoopWithoutYieldDetector`'s dead-dispatch bug in the previous PR of this chain (#82), the same broken pattern was found and independently confirmed (against Lint's actual API source) in 4 more detectors in `lint-rules`:

- **`SuspendInFinallyDetector`** — fully dead, never ran.
- **`CancellationExceptionSubclassDetector`** — fully dead, never ran.
- **`CancellationExceptionSwallowedDetector`** — fully dead, never ran.
- **`LifecycleAwareScopeDetector`** — its primary check (`getApplicableMethodNames()`/`visitMethodCall()`) works correctly and is untouched; a secondary check (custom `CoroutineScope` field inside a `LifecycleOwner` class) shared the dead `visitClass()`-only pattern and never fired.

Root cause: `SourceCodeScanner.visitClass(context, declaration)` is only invoked by Lint's `UElementVisitor` when a detector also implements `applicableSuperClasses()` — confirmed against the Lint API source (`UElementVisitor.kt`'s `superClassDetectors` registration + dispatch). None of these 4 detectors did, so the callback was silently unreachable — dead code in production with zero test coverage since creation.

Fix: switched each to the `getApplicableUastTypes()` + `createUastHandler()` pairing already used correctly by every working detector in this module (including `LoopWithoutYieldDetector`, fixed the same way in #82). Detection logic inside each `visitClass(node: UClass)` handler is unchanged — only the dispatch registration is fixed. `LifecycleAwareScopeDetector`'s fix is additive: its working primary check is untouched, the secondary check gets its own correct registration alongside it.

Added `TestLintTask`-based tests for all 4 detectors (none had any test before), each with a positive case (proving the fix makes the documented violation fire) and a negative case (guarding against over-reporting).

Relates to #79 (part 4 of the toolkit-parity-audit PR chain — targets #82, part 3). This is a follow-up finding discovered during this chain, not part of the original audit scope.

## Type of change

- [x] Bug fix

## Component(s)

- [x] Android Lint rules
- [x] Samples / tests

## Test plan

```bash
./gradlew :lint-rules:test
./gradlew testAll
```

- `lint-rules`: 70/70 passing (was 62/62 before this PR's chain; +8 new tests).
- `testAll`: BUILD SUCCESSFUL, zero cross-module regressions.
- Strict TDD followed: each new test confirmed RED (failing) against the dead code before the fix, GREEN after.

## Checklist

- [x] Tests pass locally (relevant `./gradlew` tasks)
- [x] New/changed rules updated in `docs/rule-codes.yml` and samples where applicable — N/A, dispatch-registration fix only, no rule-code/coverage change
- [x] `CHANGELOG.md` updated for user-facing changes — pending in the severity-alignment PR of this chain, will fold this in too since it's user-facing (4 rules going from never-firing to correctly firing)
- [x] Follows CONTRIBUTING.md guidelines