### PR TITLE
docs: fix stale severity/version references introduced by 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ pluginManagement {
 // build.gradle.kts
 plugins {
     kotlin("jvm") version "2.3.0"
-    id("io.github.santimattius.structured-coroutines") version "0.1.0"
+    id("io.github.santimattius.structured-coroutines") version "1.1.1"
 }
 
 dependencies {
-    implementation("io.github.santimattius:structured-coroutines-annotations:0.1.0")
+    implementation("io.github.santimattius:structured-coroutines-annotations:1.1.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
 }
 ```
@@ -136,7 +136,7 @@ plugins {
 }
 
 dependencies {
-    detektPlugins("io.github.santimattius:structured-coroutines-detekt-rules:0.1.0")
+    detektPlugins("io.github.santimattius:structured-coroutines-detekt-rules:1.1.1")
 }
 ```
 
@@ -145,7 +145,7 @@ dependencies {
 ```kotlin
 // build.gradle.kts (Android project)
 dependencies {
-    lintChecks("io.github.santimattius:structured-coroutines-lint-rules:0.1.0")
+    lintChecks("io.github.santimattius:structured-coroutines-lint-rules:1.1.1")
 }
 ```
 
@@ -174,7 +174,7 @@ Or install manually:
 ```kotlin
 plugins {
     kotlin("multiplatform") version "2.3.0"
-    id("io.github.santimattius.structured-coroutines") version "0.1.0"
+    id("io.github.santimattius.structured-coroutines") version "1.1.1"
 }
 
 kotlin {
@@ -186,7 +186,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("io.github.santimattius:structured-coroutines-annotations:0.1.0")
+                implementation("io.github.santimattius:structured-coroutines-annotations:1.1.1")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
             }
         }

--- a/docs/CI_INTEGRATION.md
+++ b/docs/CI_INTEGRATION.md
@@ -183,7 +183,7 @@ detekt {
 }
 ```
 
-The Detekt HTML report lists findings from all 19 Detekt rules in the toolkit — including `WithTimeoutScopeCancellation`, `ChannelNotClosed`, `FlowBlockingCall`, and others — with the rule code, description, and a link to the documentation.
+The Detekt HTML report lists findings from all 40 Detekt rules in the toolkit — including `WithTimeoutScopeCancellation`, `ChannelNotClosed`, `FlowBlockingCall`, and others — with the rule code, description, and a link to the documentation.
 
 ---
 
@@ -208,8 +208,8 @@ Detekt can export findings in SARIF format, which GitHub displays directly in th
 |-------------|--------------|
 | `compileKotlin` | Compiles with the active compiler plugin; errors/warnings appear in the log |
 | `structuredCoroutinesReport` | Generates HTML + plain-text report of the active configuration |
-| `detekt` | Runs all 19 Detekt rules with HTML / XML / SARIF output |
-| `lint` | Runs all 21 Android Lint rules with HTML / XML output |
+| `detekt` | Runs all 40 Detekt rules with HTML / XML / SARIF output |
+| `lint` | Runs all 35 Android Lint detectors with HTML / XML output |
 | `testAll` | Runs tests for all modules (excludes `:sample`, which fails by design) |
 
 ---

--- a/docs/SUPPRESSING_RULES.md
+++ b/docs/SUPPRESSING_RULES.md
@@ -135,6 +135,45 @@ That way the code compiles, passes Detekt, and the IDE does not show the inspect
 
 ---
 
+## Severity-reconfigured rules need the twin suppress name
+
+**Breaking change in 1.2.0.** Every configurable rule now has **two** diagnostic factories, one per
+severity. The factory bound to the rule's **documented default** severity keeps its original name
+(e.g. `LOOP_WITHOUT_YIELD`, `DISPATCHERS_UNCONFINED_USAGE`) — unreconfigured builds are unaffected.
+The **opposite**-severity twin is suffixed `_WARNING` (for ERROR-default rules) or `_ERROR` (for
+WARNING-default rules) — e.g. `GLOBAL_SCOPE_USAGE_WARNING`, `LOOP_WITHOUT_YIELD_ERROR`.
+
+If you reconfigure a check away from its default severity — via `structuredCoroutines { }` (including
+through `severityEnforcement = "strict"`, once a tightened check starts enforcing) — **and** suppress
+it with `@Suppress("<ORIGINAL_NAME>")`, that suppression stops matching on the reconfigured path,
+because the diagnostic is now emitted by the differently-named factory.
+
+```kotlin
+// build.gradle.kts
+structuredCoroutines {
+    loopWithoutYield.set("error")   // default is "warning" — now emits LOOP_WITHOUT_YIELD_ERROR
+}
+```
+
+```kotlin
+// ❌ Stops matching once the check above is reconfigured to "error"
+@Suppress("LOOP_WITHOUT_YIELD")
+suspend fun legacyLoop() {
+    while (true) { /* ... */ }
+}
+
+// ✅ Matches the reconfigured (twin) diagnostic
+@Suppress("LOOP_WITHOUT_YIELD_ERROR")
+suspend fun legacyLoop() {
+    while (true) { /* ... */ }
+}
+```
+
+**Remedy:** either update the `@Suppress` string to the suffixed twin name, or leave the check at its
+documented default severity.
+
+---
+
 ## References
 
 - [Rule codes and practices](BEST_PRACTICES_COROUTINES.md#rule-codes-reference) — full list and

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -34,9 +34,9 @@ This publishes artifacts to `~/.m2/repository/`:
 
 | Artifact                                                              | Purpose                                          |
 |-----------------------------------------------------------------------|--------------------------------------------------|
-| `io.github.santimattius:structured-coroutines-annotations:0.1.0`      | Annotations (`@StructuredScope`) - Multiplatform |
-| `io.github.santimattius:structured-coroutines-compiler:0.1.0`         | Kotlin Compiler Plugin                           |
-| `io.github.santimattius.structured-coroutines:...gradle.plugin:0.1.0` | Gradle Plugin                                    |
+| `io.github.santimattius:structured-coroutines-annotations:1.1.1`      | Annotations (`@StructuredScope`) - Multiplatform |
+| `io.github.santimattius:structured-coroutines-compiler:1.1.1`         | Kotlin Compiler Plugin                           |
+| `io.github.santimattius.structured-coroutines:...gradle.plugin:1.1.1` | Gradle Plugin                                    |
 
 ### 2. Configure Repositories
 
@@ -68,12 +68,12 @@ dependencyResolutionManagement {
 ```kotlin
 plugins {
     kotlin("jvm") version "2.3.0"  // Requires Kotlin 2.0+
-    id("io.github.santimattius.structured-coroutines") version "0.1.0"
+    id("io.github.santimattius.structured-coroutines") version "1.1.1"
 }
 
 dependencies {
     // Annotations for @StructuredScope
-    implementation("io.github.santimattius:structured-coroutines-annotations:0.1.0")
+    implementation("io.github.santimattius:structured-coroutines-annotations:1.1.1")
 
     // Coroutines dependency
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
@@ -118,11 +118,35 @@ structuredCoroutines {
 |--------------|----------------------------------------------------------------------|
 | `"error"`    | Reports as compilation error (blocks build)                        |
 | `"warning"`  | Reports as warning (allows build to succeed)                       |
-| `"disabled"` | Recorded and shown distinctly in `structuredCoroutinesReport`; decorative this release — the check still reports at its default severity, and a one-time build advisory names it. Real compile-time suppression is tracked in [issue #68](https://github.com/santimattius/structured-coroutines/issues/68). Only the exact string `"disabled"` is recognized (case-insensitive); `"off"` is not accepted. |
+| `"disabled"` | Recorded and shown distinctly in `structuredCoroutinesReport`; as of 1.2.0, `"disabled"` really suppresses the diagnostic at compile time — the check no longer reports at all ([issue #68](https://github.com/santimattius/structured-coroutines/issues/68)). Only the exact string `"disabled"` is recognized (case-insensitive); `"off"` is not accepted. |
 
 ```kotlin
 structuredCoroutines {
-    loopWithoutYield.set("disabled")   // still reports at default severity this release; see #68
+    loopWithoutYield.set("disabled")   // suppressed at compile time — no report, no build failure
+}
+```
+
+### Severity enforcement grace period
+
+Since 1.2.0, changing a check's severity really takes effect at compile time — but *tightening* a check gets a one-release grace period:
+
+- **Relaxing** a check (`error` → `warning`, or anything → `disabled`) applies **immediately**, since it can only make a previously-failing build pass.
+- **Tightening** a check (`warning` → `error`) is **deferred**: in 1.2.0 the check keeps reporting at its documented default severity, and the build logs a one-time advisory naming the rule, the configured value, the currently-effective severity, and the release (**1.3.0**) where enforcement starts.
+
+```kotlin
+structuredCoroutines {
+    dispatchersUnconfined.set("error")   // default is "warning" — deferred until 1.3.0; logs an advisory
+}
+```
+
+### Opting into strict enforcement now (`severityEnforcement`)
+
+Set `severityEnforcement = "strict"` in the `structuredCoroutines { }` block to opt into immediate enforcement of tightened checks now, ahead of 1.3.0:
+
+```kotlin
+structuredCoroutines {
+    severityEnforcement = "strict"
+    dispatchersUnconfined.set("error")   // enforced immediately instead of waiting for 1.3.0
 }
 ```
 
@@ -245,7 +269,7 @@ This plugin is the **recommended single entry point** for structured-coroutines:
 ```kotlin
 plugins {
     kotlin("jvm") version "2.3.0"
-    id("io.github.santimattius.structured-coroutines") version "0.1.0"
+    id("io.github.santimattius.structured-coroutines") version "1.1.1"
 }
 
 structuredCoroutines {
@@ -430,7 +454,7 @@ The plugin fully supports Kotlin Multiplatform projects.
 ```kotlin
 plugins {
     kotlin("multiplatform") version "2.3.0"
-    id("io.github.santimattius.structured-coroutines") version "0.1.0"
+    id("io.github.santimattius.structured-coroutines") version "1.1.1"
 }
 
 kotlin {
@@ -446,7 +470,7 @@ kotlin {
         commonMain {
             dependencies {
                 // Multiplatform annotations
-                implementation("io.github.santimattius:structured-coroutines-annotations:0.1.0")
+                implementation("io.github.santimattius:structured-coroutines-annotations:1.1.1")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
             }
         }
@@ -697,10 +721,10 @@ Remove or change the offending code (e.g. use `coroutineScope { launch { ... } }
 
 ```kotlin
 // For JVM projects
-implementation("io.github.santimattius:structured-coroutines-annotations:0.1.0")
+implementation("io.github.santimattius:structured-coroutines-annotations:1.1.1")
 
 // For KMP projects (in commonMain)
-implementation("io.github.santimattius:structured-coroutines-annotations:0.1.0")
+implementation("io.github.santimattius:structured-coroutines-annotations:1.1.1")
 ```
 
 ### Verify Maven Local
@@ -747,11 +771,11 @@ dependencyResolutionManagement {
 ```kotlin
 plugins {
     kotlin("jvm") version "2.3.0"
-    id("io.github.santimattius.structured-coroutines") version "0.1.0"
+    id("io.github.santimattius.structured-coroutines") version "1.1.1"
 }
 
 dependencies {
-    implementation("io.github.santimattius:structured-coroutines-annotations:0.1.0")
+    implementation("io.github.santimattius:structured-coroutines-annotations:1.1.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
 }
 
@@ -812,7 +836,7 @@ dependencyResolutionManagement {
 ```kotlin
 plugins {
     kotlin("multiplatform") version "2.3.0"
-    id("io.github.santimattius.structured-coroutines") version "0.1.0"
+    id("io.github.santimattius.structured-coroutines") version "1.1.1"
 }
 
 kotlin {
@@ -823,7 +847,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("io.github.santimattius:structured-coroutines-annotations:0.1.0")
+                implementation("io.github.santimattius:structured-coroutines-annotations:1.1.1")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
             }
         }

--- a/intellij-plugin/README.md
+++ b/intellij-plugin/README.md
@@ -79,8 +79,8 @@ The plugin provides four main feature categories:
 | MainDispatcherMisuse | WARNING | Detects blocking code on `Dispatchers.Main` |
 | ScopeReuseAfterCancel | WARNING | Detects scope cancelled then reused |
 | RunBlockingInSuspend | ERROR | Detects `runBlocking` in suspend functions |
-| UnstructuredLaunch | WARNING | Detects launch without structured scope (recognizes `@StructuredScope` on parameters and properties) |
-| AsyncWithoutAwait | WARNING | Detects `async` without `await()` |
+| UnstructuredLaunch | ERROR | Detects launch without structured scope (recognizes `@StructuredScope` on parameters and properties) |
+| AsyncWithoutAwait | ERROR | Detects `async` without `await()` |
 | InlineCoroutineScope | ERROR | Detects `CoroutineScope(...).launch` |
 | JobInBuilderContext | ERROR | Detects `Job()`/`SupervisorJob()` in builders |
 | SuspendInFinally | WARNING | Detects suspend calls in finally without NonCancellable |
@@ -159,7 +159,7 @@ suspend fun fetchData() {
 }
 ```
 
-#### AsyncWithoutAwait (WARNING)
+#### AsyncWithoutAwait (ERROR)
 
 **Problem:** `async` creates a `Deferred` that should be awaited.
 


### PR DESCRIPTION
## Summary
- `intellij-plugin/README.md`: `UnstructuredLaunch`/`AsyncWithoutAwait` severity WARNING → ERROR, matching `plugin.xml` and the 1.2.0 breaking change.
- `gradle-plugin/README.md`: `"disabled"` severity is no longer decorative (#68 resolved) — documents real compile-time suppression, the severity-enforcement grace period, and `severityEnforcement = "strict"`.
- `docs/SUPPRESSING_RULES.md`: documents the 1.2.0 breaking change where a reconfigured check's diagnostic moves to a `_WARNING`/`_ERROR`-suffixed twin, so `@Suppress("<ORIGINAL_NAME>")` can stop matching.
- `README.md` / `gradle-plugin/README.md`: stale `0.1.0` install placeholder → `1.1.1` (latest stable).
- `docs/CI_INTEGRATION.md`: stale rule counts (19 Detekt / 21 Lint) → current (40 Detekt / 35 Lint), matching README's Project Status table.

## Test plan
- [x] Read-only doc changes; no code/build impact.
- [x] Cross-checked severities against `intellij-plugin/src/main/resources/META-INF/plugin.xml`.
- [x] Cross-checked rule counts against `README.md`'s Project Status table.