### PR TITLE
fix(compiler): resolve FirResolvedQualifier.classId removal on Kotlin 2.4.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **`NoSuchMethodError` on `FirResolvedQualifier.getClassId()` under Kotlin 2.4.20`** — `FirResolvedQualifier.classId` was removed as a member in Kotlin 2.4.20 (KT-84522), which broke `SuspendInFinallyChecker` (CANCEL_004), `UnstructuredLaunchChecker` (GlobalScope detection), and `DispatchersUnconfinedChecker` (DISPATCH_003) at runtime against a 2.4.20 `kotlin-compiler-embeddable`. All three checkers now resolve the `ClassId` through a shared `FirResolvedQualifier.resolvedClassId()` helper built from the stable `packageFqName`/`relativeClassFqName` members instead of the removed `.classId` member, and a structural guard test now forbids any direct `.classId` call on a `FirResolvedQualifier` under `compiler/src/main` to prevent the pattern — including the KDoc mutual-precedent citation chain between these three checkers that spread it (#71) — from reappearing. Behavior is unchanged on the pinned Kotlin 2.4.0. (#90)
+
+---
+
 ## [1.2.0] — 2026-09-08
 
 ### Fixed

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/DispatchersUnconfinedChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/DispatchersUnconfinedChecker.kt
@@ -170,16 +170,17 @@ class DispatchersUnconfinedChecker(
     /**
      * Checks whether [expression] resolves to the `kotlinx.coroutines.Dispatchers` object.
      *
-     * Mirrors the verified precedent in `SuspendInFinallyChecker.isNonCancellable`: a resolved
-     * object reference (e.g. the `Dispatchers` in `Dispatchers.Unconfined`) surfaces as a
-     * [FirResolvedQualifier], not a [FirPropertyAccessExpression] as the previous implementation
-     * assumed — which made the check always return false. The [ConeClassLikeType.lookupTag]
-     * fallback additionally covers a [FirPropertyAccessExpression] receiver whose resolved type
-     * is `Dispatchers` (e.g. referenced through a property alias).
+     * A resolved object reference (e.g. the `Dispatchers` in `Dispatchers.Unconfined`) surfaces
+     * as a [FirResolvedQualifier], not a [FirPropertyAccessExpression] as a previous
+     * implementation assumed — which made the check always return false. It is resolved via the
+     * shared [resolvedClassId] helper, not a direct `.classId` call — removed as a member in
+     * Kotlin 2.4.20 (KT-84522). The [ConeClassLikeType.lookupTag] fallback additionally covers a
+     * [FirPropertyAccessExpression] receiver whose resolved type is `Dispatchers` (e.g.
+     * referenced through a property alias).
      */
     private fun isDispatchersReceiver(expression: FirExpression): Boolean {
         if (expression is FirResolvedQualifier) {
-            return expression.classId == DISPATCHERS_CLASS_ID
+            return expression.resolvedClassId() == DISPATCHERS_CLASS_ID
         }
 
         val classId = (expression.resolvedType as? ConeClassLikeType)?.lookupTag?.classId

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/FirQualifierResolution.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/FirQualifierResolution.kt
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.fir.expressions.FirResolvedQualifier
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+
+/**
+ * Reconstructs a [ClassId] from a [FirResolvedQualifier]'s two stable parts, mirroring
+ * JetBrains' own `FirExpressionUtil.kt` extension-property logic (#90).
+ *
+ * Pure core: unit-testable without constructing a real `FirResolvedQualifier`, which this
+ * codebase's test suite has no precedent for (no FIR node is ever mocked/built in tests).
+ *
+ * @param packageFqName the qualifier's package, e.g. `kotlinx.coroutines`
+ * @param relativeClassFqName the class name(s) relative to the package, e.g. `NonCancellable`
+ *   or `Outer.Inner` for a nested class; `null` for a package-only qualifier
+ */
+internal fun classIdFromQualifierParts(packageFqName: FqName, relativeClassFqName: FqName?): ClassId? =
+    relativeClassFqName?.let { ClassId(packageFqName, it, isLocal = false) }
+
+/**
+ * Resolves the [ClassId] of a [FirResolvedQualifier] using only the stable members
+ * `packageFqName` and `relativeClassFqName` (#90).
+ *
+ * **Deliberately NOT named `classId`.** `FirResolvedQualifier.classId` still exists as a member
+ * on the pinned Kotlin 2.4.0, and Kotlin resolves a member before a same-named extension in the
+ * same scope. An extension named `classId` here would therefore be silently shadowed at every
+ * call site: the code would still compile and every 2.4.0 test would still pass, while the
+ * `NoSuchMethodError` this change fixes would remain unfixed against Kotlin 2.4.20.
+ *
+ * This is the single sanctioned way to obtain a `ClassId` from a `FirResolvedQualifier` in this
+ * module — see `NoDirectResolvedQualifierClassIdTest` for the structural guard that enforces it.
+ */
+internal fun FirResolvedQualifier.resolvedClassId(): ClassId? =
+    classIdFromQualifierParts(packageFqName, relativeClassFqName)
+
+/**
+ * Regex matching a `if (<ident> is FirResolvedQualifier)` guard, capturing `<ident>`.
+ */
+private val RESOLVED_QUALIFIER_GUARD_REGEX =
+    Regex("""if\s*\(\s*(\w+)\s+is\s+FirResolvedQualifier\s*\)""")
+
+/**
+ * Regex matching an inline `(... as FirResolvedQualifier).classId` / `as? ... )?.classId` cast.
+ */
+private val RESOLVED_QUALIFIER_INLINE_CAST_REGEX =
+    Regex("""as\??\s+FirResolvedQualifier\s*\)?\??\.classId\b""")
+
+/**
+ * Pure detector core (#90): scans Kotlin [source] text for a direct `.classId` access on a
+ * narrowed `FirResolvedQualifier` expression and returns the 1-indexed line number of each
+ * violation found.
+ *
+ * Detects two shapes (R1, R2 from design):
+ * - **R1**: `if (<ident> is FirResolvedQualifier) { ... <ident>.classId ... }` — captures
+ *   `<ident>` from the guard, then flags `\b<ident>\.classId\b` on any later line.
+ * - **R2**: an inline safe/unsafe cast immediately followed by `.classId`, e.g.
+ *   `(e as? FirResolvedQualifier)?.classId`.
+ *
+ * Deliberately does NOT match `lookupTag.classId` / `lookupTag?.classId` (a different receiver —
+ * the untouched `ConeClassLikeType` fallback chain) or `resolvedClassId()` (the sanctioned
+ * helper). No allowlist: an allowlist would let the pattern back in.
+ *
+ * Comments are blanked out before scanning (preserving line numbers) so that KDoc/line comments
+ * *documenting* these patterns — including this file's own KDoc — never register as violations.
+ */
+internal fun findDirectResolvedQualifierClassIdUsages(source: String): List<Int> {
+    val violations = mutableListOf<Int>()
+    var trackedIdentifier: String? = null
+
+    blankOutComments(source).lines().forEachIndexed { index, line ->
+        val lineNumber = index + 1
+
+        RESOLVED_QUALIFIER_GUARD_REGEX.find(line)?.let { match ->
+            trackedIdentifier = match.groupValues[1]
+        }
+
+        trackedIdentifier?.let { ident ->
+            if (Regex("""\b${Regex.escape(ident)}\.classId\b""").containsMatchIn(line)) {
+                violations += lineNumber
+            }
+        }
+
+        if (RESOLVED_QUALIFIER_INLINE_CAST_REGEX.containsMatchIn(line)) {
+            violations += lineNumber
+        }
+    }
+
+    return violations
+}
+
+/**
+ * Replaces the contents of `//` line comments, `/* ... */` block comments, and `"..."` string
+ * literals with spaces (preserving every newline and overall length), so line-based scanning
+ * never mistakes documentation text or string contents for real code.
+ */
+private fun blankOutComments(source: String): String {
+    val result = StringBuilder(source.length)
+    var index = 0
+    var inLineComment = false
+    var inBlockComment = false
+    var inString = false
+
+    while (index < source.length) {
+        val current = source[index]
+        val lookahead = source.getOrNull(index + 1)
+
+        when {
+            inLineComment -> {
+                if (current == '\n') {
+                    inLineComment = false
+                    result.append(current)
+                } else {
+                    result.append(' ')
+                }
+            }
+            inBlockComment -> {
+                if (current == '*' && lookahead == '/') {
+                    inBlockComment = false
+                    result.append("  ")
+                    index++
+                } else if (current == '\n') {
+                    result.append(current)
+                } else {
+                    result.append(' ')
+                }
+            }
+            inString -> {
+                if (current == '\\' && lookahead != null) {
+                    result.append("  ")
+                    index++
+                } else if (current == '"') {
+                    inString = false
+                    result.append(' ')
+                } else if (current == '\n') {
+                    result.append(current)
+                } else {
+                    result.append(' ')
+                }
+            }
+            current == '/' && lookahead == '/' -> {
+                inLineComment = true
+                result.append("  ")
+                index++
+            }
+            current == '/' && lookahead == '*' -> {
+                inBlockComment = true
+                result.append("  ")
+                index++
+            }
+            current == '"' -> {
+                inString = true
+                result.append(' ')
+            }
+            else -> result.append(current)
+        }
+        index++
+    }
+
+    return result.toString()
+}

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/SuspendInFinallyChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/SuspendInFinallyChecker.kt
@@ -169,14 +169,14 @@ class SuspendInFinallyChecker(
      * as a bare imported name, fully qualified, combined via `+` with another
      * `CoroutineContext`, or through a variable typed as `NonCancellable`.
      *
-     * Mirrors the verified precedent in `UnstructuredLaunchChecker.isGlobalScope`: a resolved
-     * object reference is a [FirResolvedQualifier], and [ConeClassLikeType.lookupTag] is used
-     * instead of the unstable `ConeKotlinType.toClassSymbol()` API that changed signature in
-     * Kotlin 2.3.20.
+     * A resolved object reference is a [FirResolvedQualifier], resolved via the shared
+     * [resolvedClassId] helper (not a direct `.classId` call — removed as a member in Kotlin
+     * 2.4.20, KT-84522). [ConeClassLikeType.lookupTag] is used for the fallback path instead of
+     * the unstable `ConeKotlinType.toClassSymbol()` API that changed signature in Kotlin 2.3.20.
      */
     private fun isNonCancellable(expression: FirExpression): Boolean {
         if (expression is FirResolvedQualifier) {
-            return expression.classId == NON_CANCELLABLE_CLASS_ID
+            return expression.resolvedClassId() == NON_CANCELLABLE_CLASS_ID
         }
 
         if (expression is FirFunctionCall && expression.calleeReference.name == PLUS_NAME) {

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/UnstructuredLaunchChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/UnstructuredLaunchChecker.kt
@@ -302,9 +302,11 @@ class UnstructuredLaunchChecker(
         receiver: FirExpression,
         context: CheckerContext
     ): Boolean {
-        // Check if it's a direct reference to GlobalScope object
+        // Check if it's a direct reference to GlobalScope object. Resolved via the shared
+        // resolvedClassId() helper, not a direct .classId call — removed as a member in
+        // Kotlin 2.4.20 (KT-84522).
         if (receiver is FirResolvedQualifier) {
-            return receiver.classId == GLOBAL_SCOPE_CLASS_ID
+            return receiver.resolvedClassId() == GLOBAL_SCOPE_CLASS_ID
         }
 
         // Check the resolved type via ConeClassLikeType.lookupTag to avoid the unstable

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/FirQualifierResolutionTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/FirQualifierResolutionTest.kt
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.compiler
+
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pure-core unit tests for [classIdFromQualifierParts] (#90).
+ *
+ * `FirResolvedQualifier.classId` was removed as a member in Kotlin 2.4.20 (KT-84522);
+ * [classIdFromQualifierParts] reconstructs the same [ClassId] from the stable
+ * `packageFqName`/`relativeClassFqName` parts, without needing a real `FirResolvedQualifier`
+ * instance — this codebase has no precedent for constructing FIR nodes in unit tests.
+ */
+class FirQualifierResolutionTest {
+
+    @Test
+    fun `top-level relative name resolves to NonCancellable ClassId`() {
+        val result = classIdFromQualifierParts(
+            packageFqName = FqName("kotlinx.coroutines"),
+            relativeClassFqName = FqName("NonCancellable"),
+        )
+
+        assertEquals(
+            ClassId(FqName("kotlinx.coroutines"), Name.identifier("NonCancellable")),
+            result,
+        )
+    }
+
+    @Test
+    fun `top-level relative name resolves to GlobalScope ClassId`() {
+        val result = classIdFromQualifierParts(
+            packageFqName = FqName("kotlinx.coroutines"),
+            relativeClassFqName = FqName("GlobalScope"),
+        )
+
+        assertEquals(
+            ClassId(FqName("kotlinx.coroutines"), Name.identifier("GlobalScope")),
+            result,
+        )
+    }
+
+    @Test
+    fun `top-level relative name resolves to Dispatchers ClassId`() {
+        val result = classIdFromQualifierParts(
+            packageFqName = FqName("kotlinx.coroutines"),
+            relativeClassFqName = FqName("Dispatchers"),
+        )
+
+        assertEquals(
+            ClassId(FqName("kotlinx.coroutines"), Name.identifier("Dispatchers")),
+            result,
+        )
+    }
+
+    @Test
+    fun `null relativeClassFqName returns null`() {
+        val result = classIdFromQualifierParts(
+            packageFqName = FqName("kotlinx.coroutines"),
+            relativeClassFqName = null,
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `nested class fqName resolves to a nested ClassId`() {
+        val result = classIdFromQualifierParts(
+            packageFqName = FqName("kotlinx.coroutines"),
+            relativeClassFqName = FqName("Outer.Inner"),
+        )
+
+        assertNotNull(result)
+        assertTrue(result.isNestedClass)
+        assertEquals(FqName("kotlinx.coroutines.Outer.Inner"), result.asSingleFqName())
+    }
+
+    @Test
+    fun `root package qualifier resolves without a package prefix`() {
+        val result = classIdFromQualifierParts(
+            packageFqName = FqName.ROOT,
+            relativeClassFqName = FqName("TopLevelClass"),
+        )
+
+        assertEquals(
+            ClassId(FqName.ROOT, Name.identifier("TopLevelClass")),
+            result,
+        )
+    }
+
+    @Test
+    fun `reconstructed ClassId is never local`() {
+        val result = classIdFromQualifierParts(
+            packageFqName = FqName("kotlinx.coroutines"),
+            relativeClassFqName = FqName("NonCancellable"),
+        )
+
+        assertNotNull(result)
+        assertFalse(result.isLocal)
+    }
+}

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/NoDirectResolvedQualifierClassIdTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/NoDirectResolvedQualifierClassIdTest.kt
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2026 Santiago Mattiauda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.santimattius.structured.compiler
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Structural guard (#90, precedent: [NoDeadSeverityParameterOverloadsTest]) against a direct
+ * `.classId` call on a `FirResolvedQualifier` ever reappearing under `compiler/src/main`.
+ *
+ * `FirResolvedQualifier.classId` was removed as a member in Kotlin 2.4.20 (KT-84522); every
+ * checker must resolve it through the shared `FirResolvedQualifier.resolvedClassId()` helper in
+ * `FirQualifierResolution.kt` instead. [findDirectResolvedQualifierClassIdUsages] is the pure
+ * detector core; the whole-tree scan test below is its filesystem-walk wrapper.
+ */
+class NoDirectResolvedQualifierClassIdTest {
+
+    @Test
+    fun `detects direct classId access inside an is-check guard`() {
+        val source = """
+            fun check(x: FirExpression) {
+                if (x is FirResolvedQualifier) {
+                    return x.classId == TARGET
+                }
+            }
+        """.trimIndent()
+
+        val violations = findDirectResolvedQualifierClassIdUsages(source)
+
+        assertEquals(1, violations.size)
+    }
+
+    @Test
+    fun `detects direct classId access inline through a safe cast`() {
+        val source = """
+            fun check(e: FirExpression) {
+                val id = (e as? FirResolvedQualifier)?.classId
+            }
+        """.trimIndent()
+
+        val violations = findDirectResolvedQualifierClassIdUsages(source)
+
+        assertEquals(1, violations.size)
+    }
+
+    @Test
+    fun `does not flag lookupTag classId access`() {
+        val source = """
+            fun check(type: ConeClassLikeType) {
+                val id = type.lookupTag.classId
+            }
+        """.trimIndent()
+
+        assertTrue(findDirectResolvedQualifierClassIdUsages(source).isEmpty())
+    }
+
+    @Test
+    fun `does not flag nullable lookupTag classId access`() {
+        val source = """
+            fun check(type: ConeClassLikeType?) {
+                val id = type?.lookupTag?.classId
+            }
+        """.trimIndent()
+
+        assertTrue(findDirectResolvedQualifierClassIdUsages(source).isEmpty())
+    }
+
+    @Test
+    fun `does not flag the sanctioned resolvedClassId helper`() {
+        val source = """
+            fun check(x: FirResolvedQualifier) {
+                val id = x.resolvedClassId()
+            }
+        """.trimIndent()
+
+        assertTrue(findDirectResolvedQualifierClassIdUsages(source).isEmpty())
+    }
+
+    @Test
+    fun `no file under compiler src main directly accesses FirResolvedQualifier classId`() {
+        val rootDir = System.getProperty("structuredCoroutines.rootDir")
+            ?: error("structuredCoroutines.rootDir system property not set — run via Gradle (:compiler:test)")
+        val mainSourceDir = File(rootDir, "compiler/src/main/kotlin")
+
+        val offendingSites = mainSourceDir.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { file ->
+                findDirectResolvedQualifierClassIdUsages(file.readText())
+                    .map { line -> "${file.name}:$line" }
+            }
+            .toList()
+
+        assertTrue(
+            offendingSites.isEmpty(),
+            "Found direct FirResolvedQualifier.classId access outside the shared helper: $offendingSites",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Kotlin 2.4.20 removed `FirResolvedQualifier.classId` as a member (KT-84522), crashing three checkers with `NoSuchMethodError` whenever they encounter a resolved qualifier: `SuspendInFinallyChecker` (`NonCancellable`, backs CANCEL_004), `UnstructuredLaunchChecker` (`GlobalScope`), and `DispatchersUnconfinedChecker` (`Dispatchers.Unconfined`, added by #88 three days before this was reported).

## Type of change

- [x] Bug fix
- [ ] New rule / inspection
- [ ] Enhancement to existing rule or tooling
- [ ] Documentation
- [ ] Build / CI
- [ ] Other (describe below)

## Component(s)

- [x] Compiler plugin
- [ ] Detekt rules
- [ ] Android Lint rules
- [ ] IntelliJ plugin
- [ ] Gradle plugin
- [ ] Samples / tests
- [x] Docs / skill / rule manifest

## Changes

- Add `FirQualifierResolution.kt`: a shared, version-stable `resolvedClassId()` extension that reconstructs the `ClassId` from `packageFqName`/`relativeClassFqName`, mirroring JetBrains' own replacement logic. Deliberately **not** named `classId` — Kotlin resolves a same-named member before a same-named extension, so on the still-pinned 2.4.0 toolchain a same-named shim would silently no-op.
- Route all three crash sites through the new helper, preserving the existing fallback chain (`lookupTag.classId`) untouched.
- Add a structural guard test that source-scans the compiler module for any direct `.classId` call on a `FirResolvedQualifier`-narrowed expression, so the copy-paste precedent chain that caused this (#65 → #69 → #88) can't reintroduce the same defect. Verified non-vacuous by live revert-then-test.
- Add unit tests for the pure ClassId-reconstruction logic.

Full SDD cycle (explore → research → propose → spec → design → tasks → apply → verify → archive) tracked in Engram under `nonresolved-nc-classid-90`.

## Test plan

```bash
./gradlew :compiler:test
```

Full compiler module suite: 108/108 passing, including 13 new tests and the 8 pre-existing CANCEL_004/GlobalScope/Unconfined functional tests (unmodified, unregressed). Compile gate confirms `packageFqName`/`relativeClassFqName` are stable members on the currently pinned Kotlin 2.4.0, not just 2.4.20.

## Out of scope (tracked as follow-ups)

- The `CoroutineContext`-typed-alias false positive on CANCEL_004 (separate root cause — static-type-only `resolvedType` fallback).
- Bumping the pinned Kotlin version 2.4.0 → 2.4.20 (needs its own detekt/lint/intellij-plugin compatibility audit).

## Checklist

- [x] Tests pass locally (relevant `./gradlew` tasks)
- [x] New/changed rules updated in `docs/rule-codes.yml` and samples where applicable — no rule behavior/severity changed, N/A
- [x] `CHANGELOG.md` updated for user-facing changes
- [x] Follows CONTRIBUTING.md guidelines

Closes #90