### PR TITLE
chore(compiler): add Kotlin 2.4.20 forward-compat readiness harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,35 @@ jobs:
         run: ./gradlew :compiler:test :detekt-rules:test :lint-rules:test --no-daemon
 
   # ──────────────────────────────────────────────
+  # Kotlin forward-compat smoke signal (readiness only)
+  # Recompiles the compiler checker sources against the test-scope-only
+  # `forward-compat-kotlin` coordinate (Kotlin 2.4.20). Advisory only: a
+  # failure here means a future Kotlin bump will need work, but it must
+  # never block this pipeline. See docs/KOTLIN_2_4_READINESS_CHECKLIST.md.
+  # ──────────────────────────────────────────────
+  forward-compat:
+    name: Kotlin forward-compat smoke test (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Smoke-compile against Kotlin 2.4.20 (forward-compat-kotlin)
+        run: ./gradlew :compiler:forwardCompatTest --no-daemon
+
+  # ──────────────────────────────────────────────
   # IntelliJ plugin: compile + instrument
   # (no test sources; compilation against IJ 2026.1 is the verification)
   # ──────────────────────────────────────────────

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -3,6 +3,23 @@ plugins {
     alias(libs.plugins.maven.publish.vanniktech)
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Forward-compat smoke source set — Kotlin readiness only, NOT production.
+//
+// Recompiles the checker sources (compiler/src/main/kotlin) against the
+// test-scope-only `forward-compat-kotlin` coordinate (Kotlin 2.4.20) while KGP
+// itself, the production `kotlin` catalog ref, and `compileKotlin`/`test` stay
+// pinned at 2.4.0. Isolated classpath — does not affect any other source set or task.
+// See docs/KOTLIN_2_4_READINESS_CHECKLIST.md for the bump criteria.
+// ──────────────────────────────────────────────────────────────────────────
+sourceSets {
+    create("forwardCompatTest") {
+        kotlin.srcDir("src/main/kotlin")
+    }
+}
+
+val forwardCompatTestCompileOnly: Configuration by configurations.getting
+
 dependencies {
     // Kotlin Compiler - compileOnly because it's provided at compile time
     compileOnly(libs.kotlin.compiler.embeddable)
@@ -11,6 +28,10 @@ dependencies {
     testImplementation(libs.kotlin.compiler.embeddable)
     testImplementation(libs.kotlin.test)
     testImplementation(gradleTestKit())
+
+    // Forward-compat smoke source set - resolves the checker sources against
+    // Kotlin 2.4.20 only; never touches the production compileOnly/testImplementation above.
+    forwardCompatTestCompileOnly(libs.forward.compat.kotlin.compiler.embeddable)
 }
 
 kotlin {
@@ -20,6 +41,23 @@ kotlin {
         // Enable context parameters for FIR checker API
         freeCompilerArgs.add("-Xcontext-parameters")
     }
+}
+
+tasks.named<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>("compileForwardCompatTestKotlin") {
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-parameters")
+        // Documented fallback (per proposal Risks table) if KGP 2.4.0 rejects
+        // forward-compat-kotlin 2.4.20 metadata on this classpath. Scoped to
+        // this task only — never applied to production compileKotlin.
+        // freeCompilerArgs.add("-Xskip-metadata-version-check")
+    }
+}
+
+val forwardCompatTest by tasks.registering {
+    group = "verification"
+    description = "Smoke-compiles compiler checker sources against the forward-compat-kotlin " +
+        "(Kotlin 2.4.20) forward-compat coordinate. Non-blocking readiness signal only."
+    dependsOn(tasks.named("compileForwardCompatTestKotlin"))
 }
 
 tasks.test {

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/CatalogVersionConsistencyTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/CatalogVersionConsistencyTest.kt
@@ -18,11 +18,24 @@ class CatalogVersionConsistencyTest {
         File(rootDir, "gradle/libs.versions.toml")
     }
 
+    private val sampleSeverityPropertiesFile: File by lazy {
+        val rootDir = System.getProperty("structuredCoroutines.rootDir")
+            ?: error("structuredCoroutines.rootDir system property not set — run via Gradle (:compiler:test)")
+        File(rootDir, "sample-severity/gradle.properties")
+    }
+
     private fun parseCatalogVersion(key: String): String {
         val pattern = Regex("""^\s*$key\s*=\s*"([^"]+)"""", RegexOption.MULTILINE)
         val content = catalogFile.readText()
         return pattern.find(content)?.groupValues?.get(1)
             ?: error("Key '$key' not found in ${catalogFile.absolutePath}")
+    }
+
+    private fun parseSampleSeverityProperty(key: String): String {
+        val pattern = Regex("""^\s*$key\s*=\s*(\S+)\s*$""", RegexOption.MULTILINE)
+        val content = sampleSeverityPropertiesFile.readText()
+        return pattern.find(content)?.groupValues?.get(1)
+            ?: error("Key '$key' not found in ${sampleSeverityPropertiesFile.absolutePath}")
     }
 
     @Test
@@ -50,6 +63,21 @@ class CatalogVersionConsistencyTest {
             propertyCoroutines,
             "Catalog kotlinx-coroutines=$catalogCoroutines but test system property coroutinesVersion=$propertyCoroutines; " +
                 "functional-test template will drift from the catalog and can reintroduce the KT-83341 ABI crash."
+        )
+    }
+
+    @Test
+    fun `sample-severity kotlinVersion matches root catalog kotlin version`() {
+        val catalogKotlin = parseCatalogVersion("kotlin")
+        val sampleSeverityKotlin = parseSampleSeverityProperty("kotlinVersion")
+
+        assertEquals(
+            catalogKotlin,
+            sampleSeverityKotlin,
+            "Root catalog kotlin=$catalogKotlin but sample-severity/gradle.properties " +
+                "kotlinVersion=$sampleSeverityKotlin; sample-severity is a standalone build and does " +
+                "not read the root catalog, so it can silently diverge from the production Kotlin " +
+                "version unless kept in sync manually."
         )
     }
 }

--- a/docs/KOTLIN_2_4_FIR_API_AUDIT.md
+++ b/docs/KOTLIN_2_4_FIR_API_AUDIT.md
@@ -1,0 +1,89 @@
+# Kotlin 2.4.x FIR API Audit
+
+This document is the defensive audit deliverable for the Kotlin forward-compat
+readiness change (deferred bump to toolkit v2.0.0). It does not upgrade or
+fix production code — see
+[KOTLIN_2_4_READINESS_CHECKLIST.md](KOTLIN_2_4_READINESS_CHECKLIST.md) for the
+thresholds that gate the eventual bump itself, and the Engram decision
+`decision/project-decision-kotlin-2-4-20-bump-targeted-for` (obs #1244) for
+why the bump is deferred rather than applied now.
+
+## Scope and method
+
+Every checker file under `compiler/src/main/kotlin/io/github/santimattius/structured/compiler/`
+was reviewed for unstable or internal Kotlin compiler (FIR) API usage. 13
+files are in scope — the 12 files whose name matches `*Checker.kt`, plus
+`ScoroutinesCallCheckerExtension.kt`, which registers the `DeclarationCheckers`
+and `ExpressionCheckers` used by every other checker and shares their exact
+FIR-API surface even though its filename does not end in `Checker.kt`. Five
+plumbing files in the same directory (`PluginConfiguration.kt`,
+`ScoroutinesFirExtensionRegistrar.kt`,
+`StructuredCoroutinesCompilerPluginRegistrar.kt`,
+`StructuredCoroutinesErrors.kt`, `StructuredScopeAnnotation.kt`) are out of
+scope: they are plugin registration/config plumbing, not diagnostic logic
+built on internal FIR node internals.
+
+Findings below are not speculative: each unstable-API row was corroborated by
+actually compiling `compiler/src/main/kotlin` against Kotlin 2.4.20 with the
+`:compiler:forwardCompatTest` task added by this change (see
+`compiler/build.gradle.kts` and the `forward-compat-kotlin` catalog
+coordinate). The production build stays pinned to Kotlin 2.4.0
+(`:compiler:compileKotlin`), which still compiles cleanly against every
+pattern documented here — nothing here is broken **today**.
+
+## Findings
+
+| # | File | Unstable/internal API(s) | Stability classification | Alternative / accepted-risk note |
+|---|------|---------------------------|---------------------------|-----------------------------------|
+| 1 | `CallbackFlowWithoutAwaitCloseChecker.kt` | `FirFunctionCallChecker`, `MppCheckerKind` (stable checker-SPI surface only) | Stable | Compiles clean against `forward-compat-kotlin` (2.4.20). No unstable internal accessors used. |
+| 2 | `CancellationExceptionSubclassChecker.kt` | `FirClassChecker`, `@OptIn(SymbolInternals::class)` via `fir.symbols.SymbolInternals` | Internal (opt-in), stable across 2.4.0 → 2.4.20 in this audit | `SymbolInternals` is JetBrains' own explicit-opt-in marker for direct symbol access; compiled clean against 2.4.20. Accepted risk — no stable non-internal replacement exists in the FIR checker API today. |
+| 3 | `CancellationExceptionSwallowedChecker.kt` | `FirTryExpressionChecker`, `@OptIn(SymbolInternals::class)` | Internal (opt-in), stable across 2.4.0 → 2.4.20 in this audit | Same as #2. Compiled clean against `forward-compat-kotlin`. |
+| 4 | `DispatchersUnconfinedChecker.kt` | `FirExpression.classId` (member) accessed directly on a `FirResolvedQualifier`-narrowed expression (`isDispatchersReceiver`, line 182); `FirFunctionCallChecker` | **Broken under Kotlin 2.4.20** (KT-84522 — `FirResolvedQualifier.classId` removed as a member). Confirmed via `forwardCompatTest`: `Unresolved reference 'classId'`. Still compiles and behaves correctly against the pinned production Kotlin 2.4.0. | A fix already exists and is tracked separately: local/remote branch `fix/firresolvedqualifier-classid-crash-90` (issue #90) adds a shared, version-stable `FirResolvedQualifier.resolvedClassId()` extension plus a structural guard test (`NoDirectResolvedQualifierClassIdTest`) and is **not yet merged to `main`** as of this audit. This change deliberately does not duplicate that fix — see Deviations in the apply-progress record. Merge #90 before (or as part of) the eventual 2.4.20 bump. |
+| 5 | `JobInBuilderContextChecker.kt` | `FirFunctionCallChecker` (stable checker-SPI surface only) | Stable | Compiles clean against `forward-compat-kotlin`. |
+| 6 | `LoopWithoutYieldChecker.kt` | `org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker` (base class) | **Broken under Kotlin 2.4.20.** Confirmed via `forwardCompatTest`: `Unresolved reference 'FirSimpleFunctionChecker'` — the type is not resolvable at that package path against the 2.4.20 compiler-embeddable. Compiles fine against the pinned 2.4.0. | New finding, not covered by issue #90. Likely renamed, relocated, or replaced by a differently-shaped function-declaration checker base class in 2.4.20; needs live investigation against an actual 2.4.20 FIR checker API at bump time (this audit does not speculate on the replacement without verifying it compiles). Track under the unblock checklist as an additional pre-bump task, not a blocker for this readiness change. |
+| 7 | `RedundantLaunchInCoroutineScopeChecker.kt` | `FirFunctionCallChecker` (stable checker-SPI surface only) | Stable | Compiles clean against `forward-compat-kotlin`. |
+| 8 | `RunBlockingInSuspendChecker.kt` | `FirFunctionCallChecker`, `@OptIn(SymbolInternals::class)` | Internal (opt-in), stable across 2.4.0 → 2.4.20 in this audit | Same as #2. Compiled clean against `forward-compat-kotlin`. |
+| 9 | `ScoroutinesCallCheckerExtension.kt` | `FirAdditionalCheckersExtension`, `DeclarationCheckers`, `ExpressionCheckers`, `FirSimpleFunctionChecker` (via `simpleFunctionCheckers: Set<FirSimpleFunctionChecker>`) | **Broken under Kotlin 2.4.20** — same root cause as #6 (`FirSimpleFunctionChecker` unresolved), which also makes the `simpleFunctionCheckers` override fail to resolve its supertype member. Compiles fine against the pinned 2.4.0. | Same alternative as #6 — resolve `FirSimpleFunctionChecker`'s 2.4.20 replacement once, then update both this file and `LoopWithoutYieldChecker.kt` together (they share the same registration contract). |
+| 10 | `SuspendCoroutineWithoutCancellationChecker.kt` | `FirFunctionCallChecker`, `@OptIn(SymbolInternals::class)` | Internal (opt-in), stable across 2.4.0 → 2.4.20 in this audit | Same as #2. Compiled clean against `forward-compat-kotlin`. |
+| 11 | `SuspendInFinallyChecker.kt` | `FirExpression.classId` (member) accessed directly on a `FirResolvedQualifier`-narrowed expression (`isNonCancellable`, line 179); `FirTryExpressionChecker` | **Broken under Kotlin 2.4.20** — same root cause as #4 (KT-84522). Confirmed via `forwardCompatTest`. Compiles fine against the pinned production Kotlin 2.4.0. | Same alternative as #4 — covered by the unmerged `fix/firresolvedqualifier-classid-crash-90` branch (issue #90). |
+| 12 | `UnstructuredLaunchChecker.kt` | `FirExpression.classId` (member) accessed directly on a `FirResolvedQualifier`-narrowed expression (`isGlobalScopeReceiver`, line 307); `FirFunctionCallChecker`, `@OptIn(SymbolInternals::class)` | **Broken under Kotlin 2.4.20** — same root cause as #4 (KT-84522). Confirmed via `forwardCompatTest`. Compiles fine against the pinned production Kotlin 2.4.0. The `SymbolInternals` usage elsewhere in this file (line 351) is unaffected — same status as #2. | Same alternative as #4 — covered by the unmerged `fix/firresolvedqualifier-classid-crash-90` branch (issue #90). |
+| 13 | `UnusedDeferredChecker.kt` | `FirFunctionCallChecker`, `@OptIn(SymbolInternals::class)` | Internal (opt-in), stable across 2.4.0 → 2.4.20 in this audit | Same as #2. Compiled clean against `forward-compat-kotlin`. |
+
+## Summary
+
+- **9 of 13** checker files compile clean against Kotlin 2.4.20 with no
+  changes: #1, #2, #3, #5, #7, #8, #10, #12 (partially — see below), #13.
+- **4 of 13** files exercise APIs that break under Kotlin 2.4.20 today:
+  - `DispatchersUnconfinedChecker.kt`, `SuspendInFinallyChecker.kt`,
+    `UnstructuredLaunchChecker.kt` — `FirResolvedQualifier.classId` removal
+    (KT-84522, issue #90). **A fix already exists** on the unmerged
+    `fix/firresolvedqualifier-classid-crash-90` branch; this change does not
+    duplicate it.
+  - `LoopWithoutYieldChecker.kt` and `ScoroutinesCallCheckerExtension.kt` —
+    `FirSimpleFunctionChecker` unresolved. **New finding**, no fix exists yet;
+    add to future bump prep work.
+- No source file was modified by this audit — all findings above were
+  reproduced read-only via the `forwardCompatTest` smoke-compile task and are
+  non-blocking in CI (see `.github/workflows/ci.yml`'s `forward-compat` job).
+- None of the above affects the current production build: `:compiler:compileKotlin`
+  and `:compiler:test` both pass unchanged against the pinned Kotlin 2.4.0.
+
+## Additional observation (outside audit scope)
+
+`StructuredCoroutinesCompilerPluginRegistrar.kt` (a plumbing file, out of the
+13-file checker scope above) surfaces a compiler diagnostic against
+`forward-compat-kotlin` (2.4.20) at its direct `CompilerConfiguration.get(...)`
+message-collector access: *"Direct access to the message collector is
+discouraged. Consider using `CompilerConfiguration.report`."* It does not
+reproduce against the pinned production Kotlin 2.4.0 and is advisory
+(discouraged, not yet a hard error) rather than broken. Recorded here for
+completeness; not fixed, since it is both out of this audit's declared scope
+and not currently broken.
+
+## Cross-references
+
+- Unblock thresholds for the eventual bump:
+  [KOTLIN_2_4_READINESS_CHECKLIST.md](KOTLIN_2_4_READINESS_CHECKLIST.md)
+- Deferral decision: Engram `decision/project-decision-kotlin-2-4-20-bump-targeted-for` (obs #1244)
+- Issue #90 fix (unmerged, tracked separately from this readiness change):
+  branch `fix/firresolvedqualifier-classid-crash-90`

--- a/docs/KOTLIN_2_4_READINESS_CHECKLIST.md
+++ b/docs/KOTLIN_2_4_READINESS_CHECKLIST.md
@@ -1,0 +1,48 @@
+# Kotlin 2.4.20 Bump — Unblock Checklist
+
+Tracked thresholds that must all be met before the production `kotlin` catalog
+ref in `gradle/libs.versions.toml` can move to Kotlin 2.4.20+ (targeted for
+toolkit v2.0.0). See the Engram decision
+`decision/project-decision-kotlin-2-4-20-bump-targeted-for` (obs #1244) for
+why the bump is deferred rather than applied now, and
+[KOTLIN_2_4_FIR_API_AUDIT.md](KOTLIN_2_4_FIR_API_AUDIT.md) for the checker-level
+readiness findings this change also produced.
+
+A future bump proposal should be able to answer "is the bump viable yet?"
+directly from this table, without re-research.
+
+| Tool | Current version (this repo) | Required version | Source / evidence | Status |
+|------|------------------------------|-------------------|--------------------|--------|
+| detekt | `1.23.7` (`gradle/libs.versions.toml` → `detekt`); latest 2.x line is alpha-only (`2.0.0-alpha.6`) | `2.0.0` GA (first stable release with Kotlin 2.4.x compiler support) | [detekt.dev compatibility table](https://detekt.dev/docs/introduction/compatibility) and [detekt/detekt#8865](https://github.com/detekt/detekt/issues/8865) | Blocked — no stable detekt release supports Kotlin 2.4.x yet |
+| Android Lint / AGP | `lint-api` `31.4.0` (`gradle/libs.versions.toml` → `lint`; this repo has no direct AGP dependency — `lint-api` 31.4.0's own POM pairs it with AGP `8.4.0`, per its published `builder-model` dependency) | AGP `>= 8.5.2`, `lint-api` `>= ~31.5.2` | Android's official [AGP ↔ Lint API / Kotlin support table](https://developer.android.com/studio/releases/gradle-plugin) and `lint-api` `31.4.0`'s Maven POM | Blocked — installed `lint-api` major predates the required Kotlin-support line |
+| intellij-platform-gradle-plugin | `2.11.0` (`gradle/libs.versions.toml` → `intellij-platform`); plugin `2.12.0`'s `PlatformKotlinVersions` table still pins IDE build `2026.1` to Kotlin `2.3.10` | A `intellij-platform-gradle-plugin` release whose `PlatformKotlinVersions` table maps the project's target IDE build (`intellij-ide = 2026.1`) to Kotlin `>= 2.4.20` | `PlatformKotlinVersions` table shipped with the `intellij-platform-gradle-plugin` artifact (IntelliJ Platform Gradle Plugin docs) | Blocked — target IDE build `2026.1` is not yet mapped to Kotlin 2.4.x by any released plugin version |
+
+## How to read an entry
+
+Each row is self-sufficient: current version installed in this repo, the
+version threshold that must be reached upstream, where that threshold is
+verified, and whether it is currently blocking the bump. When a threshold is
+met, update that row's **Status** to `Unblocked` with a refreshed evidence
+link and date, rather than deleting the row — the table's value is in
+tracking the full three-way gate over time.
+
+## Additional pre-bump work surfaced by this readiness change
+
+Not a blocking threshold on its own, but tracked here so it is not
+rediscovered from scratch at bump time:
+
+- `LoopWithoutYieldChecker.kt` and `ScoroutinesCallCheckerExtension.kt` use
+  `FirSimpleFunctionChecker`, which is unresolved against Kotlin 2.4.20 in the
+  `forwardCompatTest` smoke-compile task. See
+  [KOTLIN_2_4_FIR_API_AUDIT.md](KOTLIN_2_4_FIR_API_AUDIT.md) finding #6/#9.
+- `DispatchersUnconfinedChecker.kt`, `SuspendInFinallyChecker.kt`, and
+  `UnstructuredLaunchChecker.kt` need the fix from the unmerged
+  `fix/firresolvedqualifier-classid-crash-90` branch (issue #90) merged before
+  or as part of the bump.
+
+## Non-goals
+
+This checklist does not upgrade detekt, Android Lint/AGP, or
+intellij-platform-gradle-plugin, and does not bump the production `kotlin`
+catalog ref. It exists purely to make the eventual bump decision fast and
+evidence-based.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,13 @@
 [versions]
 kotlin = "2.4.0"
+# Test-scope-only forward-compat pin. NEVER used by production compilation or
+# any kotlin-jvm/kotlin-multiplatform plugin alias — see compiler/build.gradle.kts
+# forwardCompatTest source set and docs/KOTLIN_2_4_READINESS_CHECKLIST.md.
+# Named without a "kotlin-" prefix on purpose: Gradle's type-safe catalog
+# accessors nest dash-separated segments, and "kotlin-next" would turn the
+# existing bare "kotlin" version accessor into a group (breaking every
+# `libs.versions.kotlin.get()` call site).
+forward-compat-kotlin = "2.4.20"
 detekt = "1.23.7"
 maven-publish-plugin = "0.36.0"
 lint = "31.4.0"
@@ -16,6 +24,11 @@ intellij-ide = "2026.1"
 kotlin-compiler-embeddable = { group = "org.jetbrains.kotlin", name = "kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 kotlin-gradle-plugin-api = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin-api", version.ref = "kotlin" }
+# Test-scope-only forward-compat coordinate — see forward-compat-kotlin above.
+# Named without a "kotlin-compiler-embeddable" prefix on purpose: that exact
+# prefix is already a leaf library accessor (libs.kotlin.compiler.embeddable);
+# extending it would force every existing call site to add .asProvider().
+forward-compat-kotlin-compiler-embeddable = { group = "org.jetbrains.kotlin", name = "kotlin-compiler-embeddable", version.ref = "forward-compat-kotlin" }
 
 # Detekt
 detekt-api = { group = "io.gitlab.arturbosch.detekt", name = "detekt-api", version.ref = "detekt" }


### PR DESCRIPTION
## Summary

Relates to #90 / #91. Prepares the toolkit for a future Kotlin 2.4.0 → 2.4.20+ bump (targeted for toolkit **v2.0.0**) without bumping the production Kotlin pin now — detekt, Android Lint/AGP, and the IntelliJ Platform Gradle Plugin currently have no stable release that supports Kotlin 2.4.x (details in the checklist doc below). This is readiness/forward-compat work, not the bump itself.

## Type of change

- [ ] Bug fix
- [ ] New rule / inspection
- [ ] Enhancement to existing rule or tooling
- [ ] Documentation
- [x] Build / CI
- [ ] Other (describe below)

## Component(s)

- [x] Compiler plugin
- [ ] Detekt rules
- [ ] Android Lint rules
- [ ] IntelliJ plugin
- [ ] Gradle plugin
- [ ] Samples / tests
- [x] Docs / skill / rule manifest

## Changes

| File | Change |
|------|--------|
| `gradle/libs.versions.toml` | Add test-scope-only `forward-compat-kotlin` (2.4.20) coordinate, alongside the untouched production `kotlin` (2.4.0) ref |
| `compiler/build.gradle.kts` | Add isolated `forwardCompatTest` source set/task compiling checker sources against the new coordinate |
| `.github/workflows/ci.yml` | Add non-blocking `forward-compat` job (`continue-on-error: true`), separate from `test-core` |
| `compiler/src/test/.../CatalogVersionConsistencyTest.kt` | Add drift-guard assertion: `sample-severity`'s independently-pinned Kotlin version vs. root catalog |
| `docs/KOTLIN_2_4_FIR_API_AUDIT.md` | New — audit of all 13 FIR checker files for version-unstable API usage |
| `docs/KOTLIN_2_4_READINESS_CHECKLIST.md` | New — tracked checklist of the 3 real blockers (detekt, Lint/AGP, intellij-platform-gradle-plugin) gating the future bump |

## Findings surfaced (tracked, not fixed here)

The `forwardCompatTest` smoke task already found two things a future v2.0.0 bump needs to handle:
- The 3 `FirResolvedQualifier.classId` sites are fixed, but only on the still-unmerged `fix/firresolvedqualifier-classid-crash-90` branch (#91) — needs merging first.
- A previously unknown break: `FirSimpleFunctionChecker` is unresolved against Kotlin 2.4.20 in `LoopWithoutYieldChecker.kt` / `ScoroutinesCallCheckerExtension.kt`. No fix yet.

Both are logged in `docs/KOTLIN_2_4_READINESS_CHECKLIST.md`'s "Additional pre-bump work" section.

## Test plan

```bash
./gradlew :compiler:test                         # 96 tests, 0 failures — production suite unaffected
./gradlew :compiler:compileKotlin                 # production compile unaffected
./gradlew :compiler:forwardCompatTest --no-daemon # BUILD FAILED (expected) — surfaces the 2 findings above, non-blocking in CI
```

Full SDD cycle (explore → research → propose → spec → design-skipped → tasks → apply → verify → archive) tracked in Engram under `kotlin-2420-bump`.

## Checklist

- [x] Tests pass locally (relevant `./gradlew` tasks)
- [x] New/changed rules updated in `docs/rule-codes.yml` and samples where applicable — no rule behavior/severity changed, N/A
- [x] `CHANGELOG.md` updated for user-facing changes — N/A, no user-facing behavior change (dev-tooling/CI only)
- [x] Follows CONTRIBUTING.md guidelines