### PR TITLE
refactor(build): isolate :intellij-plugin as an included build (D1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,4 +91,4 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Compile IntelliJ plugin
-        run: ./gradlew :intellij-plugin:compileKotlin :intellij-plugin:instrumentCode --no-daemon
+        run: ./gradlew -p intellij-plugin compileKotlin instrumentCode --no-daemon

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,9 @@ cd structured-coroutines
 # Core modules only (matches CI)
 ./gradlew :compiler:test :detekt-rules:test :lint-rules:test
 
-# IntelliJ plugin compilation (matches CI)
-./gradlew :intellij-plugin:compileKotlin :intellij-plugin:instrumentCode
+# IntelliJ plugin compilation (matches CI) — :intellij-plugin is an included build,
+# so its tasks are addressed with -p, not a root project path
+./gradlew -p intellij-plugin compileKotlin instrumentCode
 
 # Detekt sample validation
 ./gradlew :sample-detekt:detekt

--- a/README.md
+++ b/README.md
@@ -157,11 +157,12 @@ use the Compiler Plugin or Detekt Rules.
 Install from JetBrains Marketplace or build from source:
 
 ```bash
-# Build the plugin
-./gradlew :intellij-plugin:build
+# Build the plugin — :intellij-plugin is an included build, so its tasks
+# are addressed with -p, not a root project path
+./gradlew -p intellij-plugin build
 
 # Run IDE sandbox for testing
-./gradlew :intellij-plugin:runIde
+./gradlew -p intellij-plugin runIde
 ```
 
 Or install manually:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,8 +53,10 @@ tasks.register("testAll") {
         ":detekt-rules:test",
         ":gradle-plugin:test",
         ":lint-rules:test",
-        ":intellij-plugin:test",
     )
+    // :intellij-plugin is a separate included build (see settings.gradle.kts) so its
+    // test task is referenced via the included-build task path, not a root project path.
+    dependsOn(gradle.includedBuild("intellij-plugin").task(":test"))
 }
 
 // Validate that the sample project fails compilation with expected compiler rule codes (run as part of :compiler:test)

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/CatalogVersionConsistencyTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/CatalogVersionConsistencyTest.kt
@@ -24,6 +24,12 @@ class CatalogVersionConsistencyTest {
         File(rootDir, "sample-severity/gradle.properties")
     }
 
+    private val intellijPluginPropertiesFile: File by lazy {
+        val rootDir = System.getProperty("structuredCoroutines.rootDir")
+            ?: error("structuredCoroutines.rootDir system property not set — run via Gradle (:compiler:test)")
+        File(rootDir, "intellij-plugin/gradle.properties")
+    }
+
     private fun parseCatalogVersion(key: String): String {
         val pattern = Regex("""^\s*$key\s*=\s*"([^"]+)"""", RegexOption.MULTILINE)
         val content = catalogFile.readText()
@@ -31,12 +37,14 @@ class CatalogVersionConsistencyTest {
             ?: error("Key '$key' not found in ${catalogFile.absolutePath}")
     }
 
-    private fun parseSampleSeverityProperty(key: String): String {
+    private fun parseProperty(file: File, key: String): String {
         val pattern = Regex("""^\s*$key\s*=\s*(\S+)\s*$""", RegexOption.MULTILINE)
-        val content = sampleSeverityPropertiesFile.readText()
+        val content = file.readText()
         return pattern.find(content)?.groupValues?.get(1)
-            ?: error("Key '$key' not found in ${sampleSeverityPropertiesFile.absolutePath}")
+            ?: error("Key '$key' not found in ${file.absolutePath}")
     }
+
+    private fun parseSampleSeverityProperty(key: String): String = parseProperty(sampleSeverityPropertiesFile, key)
 
     @Test
     fun `catalog kotlin version matches kotlinVersion system property`() {
@@ -78,6 +86,27 @@ class CatalogVersionConsistencyTest {
                 "kotlinVersion=$sampleSeverityKotlin; sample-severity is a standalone build and does " +
                 "not read the root catalog, so it can silently diverge from the production Kotlin " +
                 "version unless kept in sync manually."
+        )
+    }
+
+    @Test
+    fun `intellij-plugin kotlinVersion is pinned independently at the documented value`() {
+        // :intellij-plugin is an included build (see settings.gradle.kts / intellij-plugin/settings.gradle.kts)
+        // with its own Kotlin Gradle Plugin pin, deliberately NOT tracking the root catalog's `kotlin` version.
+        // It stays frozen at 2.4.0 — the documented IDE-supported version — until a released
+        // intellij-platform-gradle-plugin maps the target IDE build to a newer Kotlin version.
+        // See intellij-plugin/gradle.properties and docs/KOTLIN_2_4_READINESS_CHECKLIST.md.
+        val documentedIntellijPluginKotlinVersion = "2.4.0"
+        val intellijPluginKotlin = parseProperty(intellijPluginPropertiesFile, "kotlinVersion")
+
+        assertEquals(
+            documentedIntellijPluginKotlinVersion,
+            intellijPluginKotlin,
+            "intellij-plugin/gradle.properties kotlinVersion=$intellijPluginKotlin but the documented " +
+                "IDE-supported pin is $documentedIntellijPluginKotlinVersion; :intellij-plugin is an " +
+                "isolated included build and must stay pinned independently of the root catalog's " +
+                "`kotlin` version until the unblock criteria in " +
+                "docs/KOTLIN_2_4_READINESS_CHECKLIST.md are met."
         )
     }
 }

--- a/docs/KOTLIN_2_4_READINESS_CHECKLIST.md
+++ b/docs/KOTLIN_2_4_READINESS_CHECKLIST.md
@@ -40,6 +40,33 @@ rediscovered from scratch at bump time:
   `fix/firresolvedqualifier-classid-crash-90` branch (issue #90) merged before
   or as part of the bump.
 
+## `:intellij-plugin` isolated-build exception (D1)
+
+`:intellij-plugin` is extracted into its own Gradle included build
+(`intellij-plugin/settings.gradle.kts`, `intellij-plugin/gradle.properties`),
+independent of the root buildscript classpath. This is required, not
+optional: the root build declares `alias(libs.plugins.kotlin.jvm) apply false`,
+which resolves the Kotlin Gradle Plugin once onto the root classpath, and
+Gradle rejects a subproject that requests a differing KGP version from an
+ancestor classpath. A separate build is the only mechanism that yields a
+genuinely independent KGP classpath.
+
+`:intellij-plugin` is pinned at Kotlin **2.4.0** — the version it already
+compiled with before this change — so the extraction itself is purely
+structural and behaviour-preserving. It does **not** track the root
+catalog's `kotlin` version, and after the production bump to 2.4.20
+(tracked separately) it will remain on 2.4.0 by design. This drift is
+guarded by `CatalogVersionConsistencyTest` in `compiler/src/test/kotlin/...`
+(`intellij-plugin kotlinVersion is pinned independently at the documented
+value`).
+
+**Unblock criterion** to raise `:intellij-plugin`'s pin beyond 2.4.0 (e.g.
+toward the IDE-mapped Kotlin version, or to rejoin the root catalog): a
+released `intellij-platform-gradle-plugin` version whose
+`PlatformKotlinVersions` table maps this module's target IDE build
+(`intellij-ide` in `gradle/libs.versions.toml`) to the desired Kotlin
+version — the same blocking threshold tracked in the table above.
+
 ## Non-goals
 
 This checklist does not upgrade detekt, Android Lint/AGP, or

--- a/intellij-plugin/.gitignore
+++ b/intellij-plugin/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+.intellijPlatform/
+build/

--- a/intellij-plugin/README.md
+++ b/intellij-plugin/README.md
@@ -43,8 +43,9 @@ This document provides detailed information about the Structured Coroutines Inte
 git clone https://github.com/santimattius/structured-coroutines.git
 cd structured-coroutines
 
-# Build the plugin ZIP (IntelliJ Platform Gradle Plugin 2.x)
-./gradlew :intellij-plugin:buildPlugin
+# Build the plugin ZIP (IntelliJ Platform Gradle Plugin 2.x) — :intellij-plugin
+# is an included build, so its tasks are addressed with -p, not a root project path
+./gradlew -p intellij-plugin buildPlugin
 
 # The plugin ZIP will be at:
 # intellij-plugin/build/distributions/intellij-plugin-<version>.zip
@@ -466,20 +467,23 @@ suspend fun legacy() {
 ### Commands
 
 ```bash
+# :intellij-plugin is an included build, so its tasks are addressed with -p,
+# not a root project path
+
 # Build the plugin ZIP for local install or distribution
-./gradlew :intellij-plugin:buildPlugin
+./gradlew -p intellij-plugin buildPlugin
 
 # Build and run tests
-./gradlew :intellij-plugin:build
+./gradlew -p intellij-plugin build
 
 # Run tests
-./gradlew :intellij-plugin:test
+./gradlew -p intellij-plugin test
 
 # Verify plugin compatibility
-./gradlew :intellij-plugin:verifyPlugin
+./gradlew -p intellij-plugin verifyPlugin
 
 # Run IDE sandbox for testing
-./gradlew :intellij-plugin:runIde
+./gradlew -p intellij-plugin runIde
 ```
 
 ### Project Structure

--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
 
 plugins {
-    alias(libs.plugins.kotlin.jvm)
+    kotlin("jvm")
     id("org.jetbrains.intellij.platform") version libs.versions.intellij.platform.get()
 }
 

--- a/intellij-plugin/gradle.properties
+++ b/intellij-plugin/gradle.properties
@@ -1,0 +1,14 @@
+# Kotlin version for this isolated included build. :intellij-plugin cannot
+# share the root project's Kotlin Gradle Plugin classpath (Gradle rejects a
+# differing plugin version on an ancestor classloader), so it is extracted
+# into its own build with its own pin.
+#
+# Frozen at 2.4.0 — the version this module compiles with today — so the
+# extraction in this change is purely structural and behaviour-preserving.
+# Unblock criterion to raise this pin (e.g. toward the IDE-mapped 2.3.10, or
+# to track the root catalog's `kotlin` version again): a released
+# `intellij-platform-gradle-plugin` version whose `PlatformKotlinVersions`
+# table maps this module's target IDE build (`intellij-ide` in
+# gradle/libs.versions.toml) to the desired Kotlin version. See
+# docs/KOTLIN_2_4_READINESS_CHECKLIST.md.
+kotlinVersion=2.4.0

--- a/intellij-plugin/settings.gradle.kts
+++ b/intellij-plugin/settings.gradle.kts
@@ -1,0 +1,20 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    val kotlinVersion: String by settings
+    plugins {
+        kotlin("jvm") version kotlinVersion
+    }
+}
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "intellij-plugin"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,13 @@ include(
     ":gradle-plugin",
     ":detekt-rules",
     ":lint-rules",
-    ":intellij-plugin",
     ":sample",
     ":sample-detekt"
 )
+
+// :intellij-plugin is isolated as a separate included build so it can pin its
+// own Kotlin Gradle Plugin version independently of the root buildscript
+// classpath. See intellij-plugin/settings.gradle.kts and
+// docs/KOTLIN_2_4_READINESS_CHECKLIST.md for the unblock criteria that will
+// let it rejoin the root catalog's Kotlin version.
+includeBuild("intellij-plugin")


### PR DESCRIPTION
## Summary
First slice (D1) of the Kotlin 2.4.0 → 2.4.20 production bump (tracked in #feat/kotlin-2420). Extracts `:intellij-plugin` from the root Gradle project into a separate included build so it can pin its own Kotlin Gradle Plugin version independently of the root buildscript classpath — Gradle rejects a differing KGP version resolved on an ancestor classloader, so this isolation is a prerequisite for bumping the root `kotlin` catalog ref later in this chain (slice D2) without breaking `:intellij-plugin`.

- `settings.gradle.kts`: drop `:intellij-plugin` from `include(...)`, add `includeBuild("intellij-plugin")`
- `intellij-plugin/settings.gradle.kts` (new): pins KGP via `kotlinVersion`, imports root version catalog
- `intellij-plugin/gradle.properties` (new): `kotlinVersion=2.4.0`, frozen to current pin — purely structural, no behavior change
- `intellij-plugin/build.gradle.kts`: `alias(libs.plugins.kotlin.jvm)` → `kotlin("jvm")`
- root `build.gradle.kts`: `testAll` now depends on `gradle.includedBuild("intellij-plugin").task(":test")`
- `.github/workflows/ci.yml`: `build-intellij` job uses `-p intellij-plugin` task addressing
- `CatalogVersionConsistencyTest` extended to assert `:intellij-plugin`'s Kotlin pin independently
- Docs (`README.md`, `CONTRIBUTING.md`, `intellij-plugin/README.md`) updated for the new `-p intellij-plugin <task>` command syntax

## Test plan
- [x] `./gradlew -p intellij-plugin compileKotlin instrumentCode buildPlugin verifyPluginConfiguration` passes
- [x] Post-extraction plugin distribution zip entry listing is byte-identical to the pre-extraction baseline (structural-only change confirmed)
- [x] `./gradlew testAll` green (213 tasks, rewired included-build test wiring confirmed working)
- [x] `CatalogVersionConsistencyTest` extended and passing

Part of the Kotlin 2.4.20 production bump chain: D1 (this PR) → A (detekt 2.0.0-alpha.6) → B (lint-api/AGP) → C (FIR checker fix) → D2 (catalog flip), each as its own PR against `feat/kotlin-2420`.