### PR TITLE
feat(compiler): FIR checker H1 fix + flip catalog to Kotlin 2.4.20

### DIFF
--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/LoopWithoutYieldChecker.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/LoopWithoutYieldChecker.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.declarations.FirPropertyAccessor
 import org.jetbrains.kotlin.fir.expressions.FirBlock
@@ -41,7 +41,7 @@ import org.jetbrains.kotlin.name.Name
  */
 class LoopWithoutYieldChecker(
     private val config: PluginConfiguration,
-) : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+) : FirNamedFunctionChecker(MppCheckerKind.Common) {
 
     companion object {
         private val COOPERATION_POINT_NAMES = setOf(

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/ScoroutinesCallCheckerExtension.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/ScoroutinesCallCheckerExtension.kt
@@ -12,7 +12,7 @@ package io.github.santimattius.structured.compiler
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
-import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirNamedFunctionChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirTryExpressionChecker
@@ -123,7 +123,7 @@ class ScoroutinesCallCheckerExtension(
         /**
          * Checkers for simple function declarations.
          */
-        override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> = setOf(
+        override val namedFunctionCheckers: Set<FirNamedFunctionChecker> = setOf(
             // Rule 12: Loops in suspend functions without cooperation point (Best Practice 4.1)
             LoopWithoutYieldChecker(configuration)
         )

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesCompilerPluginRegistrar.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesCompilerPluginRegistrar.kt
@@ -114,6 +114,12 @@ class StructuredCoroutinesCompilerPluginRegistrar : CompilerPluginRegistrar() {
     private fun emitGracePeriodAdvisory(pluginConfig: PluginConfiguration, configuration: CompilerConfiguration) {
         val deferred = pluginConfig.deferredTightenings
         if (deferred.isEmpty()) return
+        // Kotlin 2.4.20 flags this direct MessageCollector access as an error; the suggested
+        // replacement (CompilerConfiguration.report) only accepts a KtSourcelessDiagnosticFactory
+        // and has no plain-WARNING overload, so switching would mean either introducing new
+        // diagnostic-factory infra or downgrading this advisory to INFO — a real behavior change,
+        // not a mechanical forward-compat swap. Deferred past this slice; forwardCompatTest fails
+        // on this line only, tracked as a known gap.
         val messageCollector = configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
         val message = deferred.joinToString(separator = "\n") { it.advisoryText() }
         messageCollector.report(CompilerMessageSeverity.WARNING, message)

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesCompilerPluginRegistrar.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesCompilerPluginRegistrar.kt
@@ -9,11 +9,9 @@
  */
 package io.github.santimattius.structured.compiler
 
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.report
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 
@@ -106,22 +104,15 @@ class StructuredCoroutinesCompilerPluginRegistrar : CompilerPluginRegistrar() {
     }
 
     /**
-     * Emits one [MessageCollector.WARNING][CompilerMessageSeverity.WARNING] per compilation
-     * naming every rule in [PluginConfiguration.deferredTightenings] (#68, ADR-7). No-op when the
-     * list is empty — relaxations never defer, and nothing is deferred under
+     * Emits one [Severity.WARNING][org.jetbrains.kotlin.diagnostics.Severity.WARNING] diagnostic
+     * per compilation naming every rule in [PluginConfiguration.deferredTightenings] (#68, ADR-7).
+     * No-op when the list is empty — relaxations never defer, and nothing is deferred under
      * [EnforcementPolicy.STRICT].
      */
     private fun emitGracePeriodAdvisory(pluginConfig: PluginConfiguration, configuration: CompilerConfiguration) {
         val deferred = pluginConfig.deferredTightenings
         if (deferred.isEmpty()) return
-        // Kotlin 2.4.20 flags this direct MessageCollector access as an error; the suggested
-        // replacement (CompilerConfiguration.report) only accepts a KtSourcelessDiagnosticFactory
-        // and has no plain-WARNING overload, so switching would mean either introducing new
-        // diagnostic-factory infra or downgrading this advisory to INFO — a real behavior change,
-        // not a mechanical forward-compat swap. Deferred past this slice; forwardCompatTest fails
-        // on this line only, tracked as a known gap.
-        val messageCollector = configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
         val message = deferred.joinToString(separator = "\n") { it.advisoryText() }
-        messageCollector.report(CompilerMessageSeverity.WARNING, message)
+        configuration.report(StructuredCoroutinesErrors.GRACE_PERIOD_ADVISORY, message)
     }
 }

--- a/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesErrors.kt
+++ b/compiler/src/main/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesErrors.kt
@@ -14,6 +14,7 @@ package io.github.santimattius.structured.compiler
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactory0
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
+import org.jetbrains.kotlin.diagnostics.KtSourcelessDiagnosticFactory
 import org.jetbrains.kotlin.diagnostics.Severity
 import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
@@ -72,6 +73,12 @@ object StructuredCoroutinesErrorRenderer : BaseDiagnosticRendererFactory() {
         MAP.put(StructuredCoroutinesErrors.LOOP_WITHOUT_YIELD_ERROR, CompilerMessages.message("LOOP_WITHOUT_YIELD"))
         MAP.put(StructuredCoroutinesErrors.SUSPEND_COROUTINE_WITHOUT_CANCELLATION_WARNING, CompilerMessages.message("SUSPEND_COROUTINE_WITHOUT_CANCELLATION"))
         MAP.put(StructuredCoroutinesErrors.CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE_WARNING, CompilerMessages.message("CALLBACK_FLOW_WITHOUT_AWAIT_CLOSE"))
+
+        // Sourceless (#68, ADR-7): reported once per compilation from the plugin registrar, not
+        // from a FIR checker, so it carries no PSI element. The message is supplied per-report-call
+        // (not a fixed bundle string), hence the passthrough "{0}" template (mirrors the Kotlin
+        // compiler's own internal MESSAGE_PLACEHOLDER, not exposed by kotlin-compiler-embeddable).
+        MAP.put(StructuredCoroutinesErrors.GRACE_PERIOD_ADVISORY, "{0}")
     }
 }
 
@@ -286,6 +293,21 @@ object StructuredCoroutinesErrors {
         severity = Severity.ERROR,
         defaultPositioningStrategy = SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
         psiType = KtElement::class,
+        rendererFactory = StructuredCoroutinesErrorRenderer
+    )
+
+    // ============================================================
+    // Grace-period advisory (#68, ADR-7)
+    // ============================================================
+
+    /**
+     * Compilation-wide advisory naming every rule deferred by [PluginConfiguration.deferredTightenings].
+     * Reported once per compilation from the plugin registrar (not a FIR checker), so it has no
+     * source location — a [KtSourcelessDiagnosticFactory], not a [KtDiagnosticFactory0].
+     */
+    val GRACE_PERIOD_ADVISORY: KtSourcelessDiagnosticFactory = KtSourcelessDiagnosticFactory(
+        name = "GRACE_PERIOD_ADVISORY",
+        severity = Severity.WARNING,
         rendererFactory = StructuredCoroutinesErrorRenderer
     )
 

--- a/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesCompilerPluginRegistrarAdvisoryTest.kt
+++ b/compiler/src/test/kotlin/io/github/santimattius/structured/compiler/StructuredCoroutinesCompilerPluginRegistrarAdvisoryTest.kt
@@ -9,87 +9,82 @@
  */
 package io.github.santimattius.structured.compiler
 
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.common.diagnosticsCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithoutSource
+import org.jetbrains.kotlin.diagnostics.Severity
+import org.jetbrains.kotlin.diagnostics.impl.DiagnosticsCollectorImpl
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
  * Task 3.7/3.8 (severity-enforcement, #68, ADR-7): [StructuredCoroutinesCompilerPluginRegistrar]
- * MUST emit exactly one [MessageCollector.WARNING][CompilerMessageSeverity.WARNING] per
- * compilation, naming every rule in [PluginConfiguration.deferredTightenings], and MUST emit
- * nothing when the list is empty (relaxations only, or nothing configured).
+ * MUST emit exactly one [Severity.WARNING] diagnostic per compilation, naming every rule in
+ * [PluginConfiguration.deferredTightenings], and MUST emit nothing when the list is empty
+ * (relaxations only, or nothing configured).
  */
 @OptIn(ExperimentalCompilerApi::class, CompilerConfiguration.Internals::class)
 class StructuredCoroutinesCompilerPluginRegistrarAdvisoryTest {
 
-    private class RecordingMessageCollector : MessageCollector {
-        val reported = mutableListOf<Pair<CompilerMessageSeverity, String>>()
-        override fun clear() {
-            reported.clear()
-        }
-
-        override fun report(severity: CompilerMessageSeverity, message: String, location: CompilerMessageSourceLocation?) {
-            reported.add(severity to message)
-        }
-
-        override fun hasErrors(): Boolean = reported.any { it.first.isError }
-    }
-
-    private fun registerAndCollect(options: Map<String, String>): RecordingMessageCollector {
+    /**
+     * The registrar reports via [CompilerConfiguration.report] (org.jetbrains.kotlin.cli), which
+     * writes into the compilation's [org.jetbrains.kotlin.diagnostics.impl.BaseDiagnosticsCollector]
+     * (auto-created on first access), not directly into a [org.jetbrains.kotlin.cli.common.messages.MessageCollector] —
+     * the latter is only populated when the full compiler pipeline later flushes the collector.
+     */
+    private fun registerAndCollect(options: Map<String, String>): List<KtDiagnosticWithoutSource> {
         val configuration = CompilerConfiguration()
         configuration.put(PluginConfiguration.OPTIONS_KEY, options)
-        val collector = RecordingMessageCollector()
-        configuration.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, collector)
+        // A bare CompilerConfiguration() has no diagnosticsCollector pre-installed (only the real
+        // CLI pipeline's configuration-building helpers install one); install it explicitly so
+        // CompilerConfiguration.report(...) has somewhere to write.
+        configuration.diagnosticsCollector = DiagnosticsCollectorImpl()
 
         val registrar = StructuredCoroutinesCompilerPluginRegistrar()
         with(registrar) {
             CompilerPluginRegistrar.ExtensionStorage().registerExtensions(configuration)
         }
-        return collector
+        return configuration.diagnosticsCollector.diagnostics.filterIsInstance<KtDiagnosticWithoutSource>()
     }
 
     @Test
     fun `no advisory is emitted when nothing is configured`() {
-        val collector = registerAndCollect(emptyMap())
-        assertTrue(collector.reported.isEmpty(), "expected no messages, got: ${collector.reported}")
+        val reported = registerAndCollect(emptyMap())
+        assertTrue(reported.isEmpty(), "expected no messages, got: ${reported.map { it.message }}")
     }
 
     @Test
     fun `no advisory is emitted for relaxations only`() {
-        val collector = registerAndCollect(mapOf("unusedDeferred" to "disabled", "globalScopeUsage" to "warning"))
-        assertTrue(collector.reported.isEmpty(), "expected no messages, got: ${collector.reported}")
+        val reported = registerAndCollect(mapOf("unusedDeferred" to "disabled", "globalScopeUsage" to "warning"))
+        assertTrue(reported.isEmpty(), "expected no messages, got: ${reported.map { it.message }}")
     }
 
     @Test
     fun `exactly one WARNING advisory is emitted per compilation when a tightening is deferred`() {
-        val collector = registerAndCollect(mapOf("loopWithoutYield" to "error"))
-        val warnings = collector.reported.filter { it.first == CompilerMessageSeverity.WARNING }
-        assertEquals(1, warnings.size, "expected exactly one WARNING message, got: ${collector.reported}")
-        val message = warnings.single().second
+        val reported = registerAndCollect(mapOf("loopWithoutYield" to "error"))
+        val warnings = reported.filter { it.severity == Severity.WARNING }
+        assertEquals(1, warnings.size, "expected exactly one WARNING message, got: ${reported.map { it.message }}")
+        val message = warnings.single().message
         assertTrue("loopWithoutYield" in message, "advisory must name the rule, got:\n$message")
         assertTrue(SeverityGracePeriod.ENFORCING_VERSION in message, "advisory must name ENFORCING_VERSION, got:\n$message")
     }
 
     @Test
     fun `advisory names every deferred rule when multiple tightenings are configured`() {
-        val collector = registerAndCollect(mapOf("loopWithoutYield" to "error", "suspendInFinally" to "error"))
-        val warnings = collector.reported.filter { it.first == CompilerMessageSeverity.WARNING }
-        assertTrue(warnings.isNotEmpty(), "expected at least one WARNING message, got: ${collector.reported}")
-        val combined = warnings.joinToString("\n") { it.second }
+        val reported = registerAndCollect(mapOf("loopWithoutYield" to "error", "suspendInFinally" to "error"))
+        val warnings = reported.filter { it.severity == Severity.WARNING }
+        assertTrue(warnings.isNotEmpty(), "expected at least one WARNING message, got: ${reported.map { it.message }}")
+        val combined = warnings.joinToString("\n") { it.message }
         assertTrue("loopWithoutYield" in combined, "advisory must name loopWithoutYield, got:\n$combined")
         assertTrue("suspendInFinally" in combined, "advisory must name suspendInFinally, got:\n$combined")
     }
 
     @Test
     fun `no advisory is emitted when severityEnforcement is strict, even with a tightened rule`() {
-        val collector = registerAndCollect(mapOf("loopWithoutYield" to "error", "severityEnforcement" to "strict"))
-        assertTrue(collector.reported.isEmpty(), "expected no messages under strict policy, got: ${collector.reported}")
+        val reported = registerAndCollect(mapOf("loopWithoutYield" to "error", "severityEnforcement" to "strict"))
+        assertTrue(reported.isEmpty(), "expected no messages under strict policy, got: ${reported.map { it.message }}")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.4.0"
+kotlin = "2.4.20"
 # Test-scope-only forward-compat pin. NEVER used by production compilation or
 # any kotlin-jvm/kotlin-multiplatform plugin alias — see compiler/build.gradle.kts
 # forwardCompatTest source set and docs/KOTLIN_2_4_READINESS_CHECKLIST.md.

--- a/sample-severity/gradle.properties
+++ b/sample-severity/gradle.properties
@@ -1,6 +1,6 @@
 # Version literals for this standalone sample build.
 # structuredCoroutinesVersion MUST match the root project's PROJECT_VERSION
 # (structured-coroutines/gradle.properties) — copy verbatim, never invent it.
-structuredCoroutinesVersion=1.1.1
-kotlinVersion=2.4.0
+structuredCoroutinesVersion=1.2.0-ALPHA01
+kotlinVersion=2.4.20
 coroutinesVersion=1.11.0


### PR DESCRIPTION
## Summary
- **Slice C (H1 fix)**: swaps `FirSimpleFunctionChecker`/`simpleFunctionCheckers` → `FirNamedFunctionChecker`/`namedFunctionCheckers` in `LoopWithoutYieldChecker` and `ScoroutinesCallCheckerExtension` — the former were removed from Kotlin 2.4.20's FIR analysis API.
- **Slice D2 (catalog flip)**: `gradle/libs.versions.toml` `kotlin` 2.4.0 → 2.4.20; `sample-severity/gradle.properties` synced (`kotlinVersion` + `structuredCoroutinesVersion`, the latter had drifted stale to 1.1.1).
- Fixes a second, unrelated forwardCompatTest finding: `StructuredCoroutinesCompilerPluginRegistrar`'s grace-period advisory now reports via a proper `KtSourcelessDiagnosticFactory` (`StructuredCoroutinesErrors.GRACE_PERIOD_ADVISORY`) instead of direct `MessageCollector` access, which Kotlin 2.4.20 removed.

**Why C and D2 are one PR, not two**: the H1 swap and the catalog flip are not independently greenable — `FirNamedFunctionChecker` doesn't exist under Kotlin 2.4.0 (current production), and `FirSimpleFunctionChecker` doesn't exist under 2.4.20. Neither commit compiles alone; landing them separately would leave `main` red between merges. Confirmed via direct `kotlin-compiler-embeddable` jar inspection (2.4.0 vs 2.4.20) and real compile attempts at each step.

Part 4/5 (combined) of the Kotlin 2.4.0 → 2.4.20 production bump chain (D1 #93 → A #94 → B #95 → **C+D2 (this PR)**).

## Verification
- [x] `:compiler:compileKotlin` — BUILD SUCCESSFUL under 2.4.20
- [x] `:compiler:test` — all pass, including a rewritten `StructuredCoroutinesCompilerPluginRegistrarAdvisoryTest` (asserts against `diagnosticsCollector.diagnostics` instead of a fake `MessageCollector`)
- [x] `forwardCompatTest` — green (previously RED on both findings)
- [x] `testAll` — BUILD SUCCESSFUL
- [x] `./gradlew -p sample-severity build` — BUILD SUCCESSFUL, grace-period advisory prints correctly end-to-end
- [x] `:intellij-plugin` isolation — `compileKotlin instrumentCode buildPlugin verifyPluginConfiguration` green, still pinned to its own Kotlin 2.4.0, unaffected by the root flip